### PR TITLE
Fix keyboard movement: frame-rate dependent speed, stuck run animation, missing acceleration

### DIFF
--- a/client/src/lib/components/PlayerControl.svelte
+++ b/client/src/lib/components/PlayerControl.svelte
@@ -729,7 +729,7 @@
     })
   }
 
-  function updateKeyboardMovement() {
+  function updateKeyboardMovement(deltaTime: number) {
     runKeyboardFrame({
       currentPlayer,
       hasKeysPressed: inputHandler.hasKeysPressed,
@@ -738,6 +738,7 @@
       isInCombat: combatController.isInCombat,
       direction: inputHandler.getMovementDirection(),
       config: MOVEMENT_CONFIG,
+      deltaTimeSeconds: deltaTime / 1000,
       sampleHeight,
       isMovementBlocked,
       isUphillTooSteep,

--- a/client/src/lib/components/PlayerControl.svelte
+++ b/client/src/lib/components/PlayerControl.svelte
@@ -61,6 +61,7 @@
   } from './player-control/fsm/move-request'
   import {
     createKeyboardMoveSender,
+    createKeyboardSpeedRamp,
     createKeyboardTapTracker,
     runKeyboardFrame,
   } from './player-control/fsm/keyboard'
@@ -381,6 +382,7 @@
 
   const keyboardMoveSender = createKeyboardMoveSender(sendPlayerMove)
   const keyboardTapTracker = createKeyboardTapTracker()
+  const keyboardSpeedRamp = createKeyboardSpeedRamp()
 
   function writePlayerPosition(position: Position, rotation: number) {
     const wrappedX = wrapWorldX(position.x)
@@ -746,6 +748,7 @@
       writePlayerPosition,
       moveSender: keyboardMoveSender,
       tapTracker: keyboardTapTracker,
+      speedRamp: keyboardSpeedRamp,
       actions: keyboardFrameActions,
     })
   }

--- a/client/src/lib/components/PlayerControl.svelte
+++ b/client/src/lib/components/PlayerControl.svelte
@@ -733,6 +733,7 @@
     runKeyboardFrame({
       currentPlayer,
       hasKeysPressed: inputHandler.hasKeysPressed,
+      isKeyboardMoving: playerControlMachine.stateName === 'keyboard_moving',
       interactionExit: getInteractionExitKind(playerState),
       hasMovementTarget: movingState() !== null,
       isInCombat: combatController.isInCombat,

--- a/client/src/lib/components/player-control/fsm/keyboard.test.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.test.ts
@@ -16,6 +16,7 @@ function makeInput() {
     currentPos: { x: 0, y: 1, z: 0 },
     direction: { x: 1, z: 0 },
     config: DEFAULT_MOVEMENT_CONFIG,
+    deltaTimeSeconds: 1 / 64,
     sampleHeight: vi.fn((x: number, z: number) => x + z),
     isMovementBlocked: vi.fn(() => false),
     isUphillTooSteep: vi.fn(() => false),
@@ -63,6 +64,7 @@ const movementDeps = {
     deceleration: 6,
     arrivalThreshold: 0.05,
   },
+  deltaTimeSeconds: 1 / 64,
   sampleHeight: () => 0,
   isMovementBlocked: () => false,
   isUphillTooSteep: () => false,
@@ -71,18 +73,31 @@ const movementDeps = {
 }
 
 describe('applyKeyboardMovement', () => {
-  it('moves at fixed keyboard step and sends the new position', () => {
+  it('moves by maxSpeed × frame delta and sends the new position', () => {
     const input = makeInput()
 
     const outcome = applyKeyboardMovement(input)
 
     expect(outcome.kind).toBe('moved')
     expect(input.writePlayerPosition).toHaveBeenCalledWith(
-      { x: 0.025, y: 0.025, z: 0 },
+      { x: 0.046875, y: 0.046875, z: 0 },
       Math.PI / 2
     )
     expect(input.sendPlayerMove).toHaveBeenCalledWith(
-      { x: 0.025, y: 0.025, z: 0 },
+      { x: 0.046875, y: 0.046875, z: 0 },
+      Math.PI / 2
+    )
+  })
+
+  it('clamps oversized frame deltas to a 100ms step', () => {
+    const input = makeInput()
+    input.deltaTimeSeconds = 1
+
+    const outcome = applyKeyboardMovement(input)
+
+    expect(outcome.kind).toBe('moved')
+    expect(input.writePlayerPosition).toHaveBeenCalledWith(
+      { x: 3 * 0.1, y: 3 * 0.1, z: 0 },
       Math.PI / 2
     )
   })

--- a/client/src/lib/components/player-control/fsm/keyboard.test.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.test.ts
@@ -65,6 +65,7 @@ const movementDeps = {
     arrivalThreshold: 0.05,
   },
   deltaTimeSeconds: 1 / 64,
+  isKeyboardMoving: false,
   sampleHeight: () => 0,
   isMovementBlocked: () => false,
   isUphillTooSteep: () => false,
@@ -269,6 +270,48 @@ describe('runKeyboardFrame', () => {
 
     expect(moveSender.flush).toHaveBeenCalledExactlyOnceWith(position)
     expect(moveSender.reset).not.toHaveBeenCalled()
+  })
+
+  it('settles keyboard_moving to idle on release without a tap target', () => {
+    const a = frameActions()
+    const moveSender = makeMoveSender()
+    const position = { x: 3, y: 0, z: 4 }
+
+    runKeyboardFrame({
+      currentPlayer: { position },
+      hasKeysPressed: false,
+      interactionExit: 'none',
+      hasMovementTarget: false,
+      isInCombat: false,
+      direction: null,
+      actions: a,
+      ...movementDeps,
+      isKeyboardMoving: true,
+      moveSender,
+    })
+
+    expect(a.setKeyboardIdleRuntime).toHaveBeenCalledOnce()
+    expect(a.emitKeyboardPlayerState).toHaveBeenCalledOnce()
+    expect(moveSender.flush).toHaveBeenCalledExactlyOnceWith(position)
+  })
+
+  it('does not force idle from other states on idle frames', () => {
+    const a = frameActions()
+
+    runKeyboardFrame({
+      currentPlayer: { position: { x: 3, y: 0, z: 4 } },
+      hasKeysPressed: false,
+      interactionExit: 'none',
+      hasMovementTarget: false,
+      isInCombat: false,
+      direction: null,
+      actions: a,
+      ...movementDeps,
+      moveSender: makeMoveSender(),
+    })
+
+    expect(a.setKeyboardIdleRuntime).not.toHaveBeenCalled()
+    expect(a.emitKeyboardPlayerState).not.toHaveBeenCalled()
   })
 
   it('resets without sending when a click path owns the movement queue', () => {

--- a/client/src/lib/components/player-control/fsm/keyboard.test.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.test.ts
@@ -4,6 +4,7 @@ import {
   applyKeyboardMovement,
   applyKeyboardMovementOutcome,
   createKeyboardMoveSender,
+  createKeyboardSpeedRamp,
   createKeyboardTapTracker,
   runKeyboardFrame,
   KEYBOARD_TAP_STEP,
@@ -17,6 +18,7 @@ function makeInput() {
     direction: { x: 1, z: 0 },
     config: DEFAULT_MOVEMENT_CONFIG,
     deltaTimeSeconds: 1 / 64,
+    speedRamp: makeSpeedRamp(),
     sampleHeight: vi.fn((x: number, z: number) => x + z),
     isMovementBlocked: vi.fn(() => false),
     isUphillTooSteep: vi.fn(() => false),
@@ -57,6 +59,10 @@ function makeMoveSender() {
   return { step: vi.fn(), flush: vi.fn(), reset: vi.fn() }
 }
 
+function makeSpeedRamp(speed = 3) {
+  return { advance: vi.fn(() => speed), reset: vi.fn() }
+}
+
 const movementDeps = {
   config: {
     maxSpeed: 3,
@@ -71,6 +77,7 @@ const movementDeps = {
   isUphillTooSteep: () => false,
   writePlayerPosition: vi.fn(),
   tapTracker: makeTapTracker(),
+  speedRamp: makeSpeedRamp(),
 }
 
 describe('applyKeyboardMovement', () => {
@@ -103,6 +110,18 @@ describe('applyKeyboardMovement', () => {
     )
   })
 
+  it('advances the speed ramp with the clamped frame delta', () => {
+    const input = makeInput()
+    input.deltaTimeSeconds = 1
+
+    applyKeyboardMovement(input)
+
+    expect(input.speedRamp.advance).toHaveBeenCalledExactlyOnceWith(
+      DEFAULT_MOVEMENT_CONFIG,
+      0.1
+    )
+  })
+
   it('blocks movement before writing or sending', () => {
     const input = makeInput()
     input.isMovementBlocked.mockReturnValue(true)
@@ -123,6 +142,25 @@ describe('applyKeyboardMovement', () => {
     expect(outcome.kind).toBe('slope_blocked')
     expect(input.writePlayerPosition).not.toHaveBeenCalled()
     expect(input.sendPlayerMove).not.toHaveBeenCalled()
+  })
+})
+
+describe('createKeyboardSpeedRamp', () => {
+  it('accelerates to maxSpeed and restarts after reset', () => {
+    const ramp = createKeyboardSpeedRamp()
+    const config = {
+      maxSpeed: 3,
+      acceleration: 6,
+      deceleration: 6,
+      arrivalThreshold: 0.05,
+    }
+
+    expect(ramp.advance(config, 0.25)).toBeCloseTo(1.5)
+    expect(ramp.advance(config, 0.25)).toBeCloseTo(3)
+    expect(ramp.advance(config, 0.25)).toBeCloseTo(3)
+
+    ramp.reset()
+    expect(ramp.advance(config, 0.25)).toBeCloseTo(1.5)
   })
 })
 

--- a/client/src/lib/components/player-control/fsm/keyboard.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.ts
@@ -106,7 +106,7 @@ export function createKeyboardTapTracker(): KeyboardTapTracker {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Keyboard movement integrator (fixed-step, no accel/decel/waypoints)
+// Keyboard movement integrator (delta-time step, no accel/decel/waypoints)
 // ───────────────────────────────────────────────────────────────────────────
 
 export interface KeyboardDirection {
@@ -118,6 +118,7 @@ interface KeyboardMovementInput {
   currentPos: Position
   direction: KeyboardDirection
   config: MovementConfig
+  deltaTimeSeconds: number
   sampleHeight: (x: number, z: number) => number
   isMovementBlocked: (
     fromX: number,
@@ -150,6 +151,7 @@ export function applyKeyboardMovement({
   currentPos,
   direction,
   config,
+  deltaTimeSeconds,
   sampleHeight,
   isMovementBlocked,
   isUphillTooSteep,
@@ -157,7 +159,8 @@ export function applyKeyboardMovement({
   sendPlayerMove,
 }: KeyboardMovementInput): KeyboardMovementOutcome {
   const currentSpeed = config.maxSpeed
-  const speed = config.maxSpeed * (1000 / 120 / 1000)
+  // Clamp tab-switch delta spikes so one frame can't teleport the player.
+  const speed = config.maxSpeed * Math.min(deltaTimeSeconds, 0.1)
   const newX = currentPos.x + direction.x * speed
   const newZ = currentPos.z + direction.z * speed
 
@@ -258,6 +261,7 @@ interface RunKeyboardFrameInput {
   isInCombat: boolean
   direction: KeyboardDirection | null
   config: MovementConfig
+  deltaTimeSeconds: number
   sampleHeight: (x: number, z: number) => number
   isMovementBlocked: (
     fromX: number,
@@ -287,6 +291,7 @@ export function runKeyboardFrame({
   isInCombat,
   direction,
   config,
+  deltaTimeSeconds,
   sampleHeight,
   isMovementBlocked,
   isUphillTooSteep,
@@ -342,6 +347,7 @@ export function runKeyboardFrame({
       },
       direction,
       config,
+      deltaTimeSeconds,
       sampleHeight,
       isMovementBlocked,
       isUphillTooSteep,

--- a/client/src/lib/components/player-control/fsm/keyboard.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.ts
@@ -258,6 +258,7 @@ interface RunKeyboardFrameInput {
   hasKeysPressed: boolean
   interactionExit: InteractionExitKind
   hasMovementTarget: boolean
+  isKeyboardMoving: boolean
   isInCombat: boolean
   direction: KeyboardDirection | null
   config: MovementConfig
@@ -288,6 +289,7 @@ export function runKeyboardFrame({
   hasKeysPressed,
   interactionExit,
   hasMovementTarget,
+  isKeyboardMoving,
   isInCombat,
   direction,
   config,
@@ -315,6 +317,12 @@ export function runKeyboardFrame({
       actions.requestMove(tapTarget)
     } else {
       moveSender.flush(currentPlayer.position)
+      // Long-hold release has no glide arrival to settle the machine, so it
+      // must leave keyboard_moving itself or the run animation loops forever.
+      if (isKeyboardMoving) {
+        actions.setKeyboardIdleRuntime()
+        actions.emitKeyboardPlayerState()
+      }
     }
     return
   }

--- a/client/src/lib/components/player-control/fsm/keyboard.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.ts
@@ -106,7 +106,7 @@ export function createKeyboardTapTracker(): KeyboardTapTracker {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Keyboard movement integrator (delta-time step, no accel/decel/waypoints)
+// Keyboard movement integrator (delta-time step with accel ramp, no waypoints)
 // ───────────────────────────────────────────────────────────────────────────
 
 export interface KeyboardDirection {
@@ -114,11 +114,35 @@ export interface KeyboardDirection {
   z: number
 }
 
+// Session-scoped speed ramp so keyboard starts match the click-move
+// acceleration curve instead of snapping to full speed.
+export interface KeyboardSpeedRamp {
+  advance(config: MovementConfig, deltaTimeSeconds: number): number
+  reset(): void
+}
+
+export function createKeyboardSpeedRamp(): KeyboardSpeedRamp {
+  let speed = 0
+  return {
+    advance(config, deltaTimeSeconds) {
+      speed = Math.min(
+        speed + config.acceleration * deltaTimeSeconds,
+        config.maxSpeed
+      )
+      return speed
+    },
+    reset() {
+      speed = 0
+    },
+  }
+}
+
 interface KeyboardMovementInput {
   currentPos: Position
   direction: KeyboardDirection
   config: MovementConfig
   deltaTimeSeconds: number
+  speedRamp: KeyboardSpeedRamp
   sampleHeight: (x: number, z: number) => number
   isMovementBlocked: (
     fromX: number,
@@ -152,15 +176,17 @@ export function applyKeyboardMovement({
   direction,
   config,
   deltaTimeSeconds,
+  speedRamp,
   sampleHeight,
   isMovementBlocked,
   isUphillTooSteep,
   writePlayerPosition,
   sendPlayerMove,
 }: KeyboardMovementInput): KeyboardMovementOutcome {
-  const currentSpeed = config.maxSpeed
   // Clamp tab-switch delta spikes so one frame can't teleport the player.
-  const speed = config.maxSpeed * Math.min(deltaTimeSeconds, 0.1)
+  const dt = Math.min(deltaTimeSeconds, 0.1)
+  const currentSpeed = speedRamp.advance(config, dt)
+  const speed = currentSpeed * dt
   const newX = currentPos.x + direction.x * speed
   const newZ = currentPos.z + direction.z * speed
 
@@ -256,9 +282,9 @@ export interface KeyboardFrameActions extends KeyboardMovementOutcomeActions {
 interface RunKeyboardFrameInput {
   currentPlayer: KeyboardFramePlayer | null
   hasKeysPressed: boolean
+  isKeyboardMoving: boolean
   interactionExit: InteractionExitKind
   hasMovementTarget: boolean
-  isKeyboardMoving: boolean
   isInCombat: boolean
   direction: KeyboardDirection | null
   config: MovementConfig
@@ -281,15 +307,16 @@ interface RunKeyboardFrameInput {
   writePlayerPosition: (position: Position, rotation: number) => void
   moveSender: KeyboardMoveSender
   tapTracker: KeyboardTapTracker
+  speedRamp: KeyboardSpeedRamp
   actions: KeyboardFrameActions
 }
 
 export function runKeyboardFrame({
   currentPlayer,
   hasKeysPressed,
+  isKeyboardMoving,
   interactionExit,
   hasMovementTarget,
-  isKeyboardMoving,
   isInCombat,
   direction,
   config,
@@ -300,10 +327,12 @@ export function runKeyboardFrame({
   writePlayerPosition,
   moveSender,
   tapTracker,
+  speedRamp,
   actions,
 }: RunKeyboardFrameInput) {
   if (!currentPlayer || !hasKeysPressed) {
     const tapTarget = tapTracker.release(currentPlayer?.position ?? null)
+    speedRamp.reset()
     // Session over: a click-path or combat chase owns the movement queue now
     // (their replace supersedes us), so hand off without sending.
     if (!currentPlayer || hasMovementTarget || isInCombat) {
@@ -356,6 +385,7 @@ export function runKeyboardFrame({
       direction,
       config,
       deltaTimeSeconds,
+      speedRamp,
       sampleHeight,
       isMovementBlocked,
       isUphillTooSteep,
@@ -374,6 +404,7 @@ export function runKeyboardFrame({
       return
     }
   } else {
+    speedRamp.reset()
     actions.setKeyboardIdleRuntime()
   }
 

--- a/client/src/lib/components/player-control/fsm/machine.test.ts
+++ b/client/src/lib/components/player-control/fsm/machine.test.ts
@@ -47,6 +47,22 @@ describe('PlayerControlMachine', () => {
     ])
   })
 
+  it('passes the frame delta to the keyboard phase', () => {
+    const handleKeyboard = vi.fn()
+    const machine = new PlayerControlMachine(
+      { dispatchEvent: vi.fn() },
+      {
+        states: createPlayerControlStateDefinitions({
+          idle: { handleKeyboard },
+        }),
+      }
+    )
+
+    machine.update(16, { editorMode: false })
+
+    expect(handleKeyboard).toHaveBeenCalledExactlyOnceWith(16)
+  })
+
   it('skips interact and keyboard phases in editor mode but still ticks', () => {
     const handleInteractKey = vi.fn()
     const handleKeyboard = vi.fn()

--- a/client/src/lib/components/player-control/fsm/machine.ts
+++ b/client/src/lib/components/player-control/fsm/machine.ts
@@ -78,7 +78,7 @@ export class PlayerControlMachine {
 
     if (!options.editorMode) {
       this.handleInteractKey()
-      this.handleKeyboard()
+      this.handleKeyboard(deltaTime)
     }
 
     this.tick(deltaTime)
@@ -114,8 +114,8 @@ export class PlayerControlMachine {
     this.currentDefinition?.handleInteractKey?.()
   }
 
-  private handleKeyboard() {
-    this.currentDefinition?.handleKeyboard?.()
+  private handleKeyboard(deltaTime: number) {
+    this.currentDefinition?.handleKeyboard?.(deltaTime)
   }
 
   private tick(deltaTime: number) {

--- a/client/src/lib/components/player-control/fsm/state-definitions.test.ts
+++ b/client/src/lib/components/player-control/fsm/state-definitions.test.ts
@@ -77,7 +77,7 @@ describe('composePlayerControlStateOverrides', () => {
       { idle: { handleKeyboard: third } }
     )
 
-    expect(overrides.idle?.handleKeyboard?.()).toBe(true)
+    expect(overrides.idle?.handleKeyboard?.(16)).toBe(true)
     expect(first).toHaveBeenCalledOnce()
     expect(second).toHaveBeenCalledOnce()
     expect(third).not.toHaveBeenCalled()
@@ -154,11 +154,11 @@ describe('createFramePhaseStateOverrides', () => {
     })
 
     expect(overrides.moving?.handleInteractKey?.()).toBe(true)
-    expect(overrides.moving?.handleKeyboard?.()).toBe(true)
+    expect(overrides.moving?.handleKeyboard?.(16)).toBe(true)
     expect(overrides.moving?.tick?.(16)).toBe(true)
 
     expect(handleInteractKey).toHaveBeenCalledOnce()
-    expect(handleKeyboard).toHaveBeenCalledOnce()
+    expect(handleKeyboard).toHaveBeenCalledExactlyOnceWith(16)
     expect(tick).toHaveBeenCalledWith(16)
   })
 })

--- a/client/src/lib/components/player-control/fsm/state-definitions.ts
+++ b/client/src/lib/components/player-control/fsm/state-definitions.ts
@@ -12,7 +12,7 @@ export interface PlayerControlStateDefinition {
   exit?: () => void
   handleEvent?: (event: PlayerControlEvent) => boolean | void
   handleInteractKey?: () => boolean | void
-  handleKeyboard?: () => boolean | void
+  handleKeyboard?: (deltaTime: number) => boolean | void
   tick?: (deltaTime: number) => boolean | void
 }
 
@@ -87,9 +87,9 @@ function mergeStateOverrides(
         : undefined,
     handleKeyboard:
       previous.handleKeyboard || next.handleKeyboard
-        ? () =>
-            previous.handleKeyboard?.() === true ||
-            next.handleKeyboard?.() === true
+        ? (deltaTime) =>
+            previous.handleKeyboard?.(deltaTime) === true ||
+            next.handleKeyboard?.(deltaTime) === true
         : undefined,
     tick:
       previous.tick || next.tick
@@ -149,7 +149,7 @@ export function createAnimationEventStateOverrides({
 
 export interface FramePhaseStateActions {
   handleInteractKey: () => void
-  handleKeyboard: () => void
+  handleKeyboard: (deltaTime: number) => void
   tick: (deltaTime: number) => void
 }
 
@@ -177,8 +177,8 @@ export function createFramePhaseStateOverrides({
           handleInteractKey()
           return true
         },
-        handleKeyboard: () => {
-          handleKeyboard()
+        handleKeyboard: (deltaTime: number) => {
+          handleKeyboard(deltaTime)
           return true
         },
         tick: (deltaTime: number) => {


### PR DESCRIPTION
Three fixes that bring keyboard (WASD) movement up to par with click-to-move. One commit per fix.

## 1. Frame-rate dependent movement speed (`6f57e1e`)

`applyKeyboardMovement` advanced a fixed distance per frame assuming 120 FPS (`maxSpeed * (1000 / 120 / 1000)`), while click-to-move integrates with the real frame delta. With the game loop running at 60 FPS, keyboard players walked at half the intended speed (1.5 u/s vs `maxSpeed` 3.0).

The fix threads `deltaTime` from `PlayerControlMachine.update` through the keyboard phase and integrates with `maxSpeed * min(deltaTimeSeconds, 0.1)`. The 0.1 s cap follows the existing convention (grass/water/torch layers) so a background-tab delta spike can't teleport the player; click-move needs no cap since its destination bounds the step.

## 2. Run animation stuck after releasing movement keys (`4a83fc3`)

Releasing keys after a hold longer than the tap step left the control machine in `keyboard_moving` forever: the tap-glide release path settles to idle through its click-move arrival, but the long-hold flush path never transitioned. `isMovingNow()` stayed true, so the projected player state stayed `moving` and the run animation looped in place indefinitely (position itself was frozen — verified by logging the store position during the runaway).

The flush path now settles the machine to idle, gated on `keyboard_moving` so idle frames can't yank other states (attacking, interacting) to idle. This bug predates fix 1 — reproduced on the old fixed-step code with an A/B toggle.

## 3. Missing acceleration ramp (`8caa588`)

Keyboard movement snapped to full speed on the first frame while the idle→run animation was still blending in, which read as a brief foot-slide. Click-to-move ramps up via `config.acceleration`. A session-scoped `KeyboardSpeedRamp` now applies the same curve to keyboard starts and resets on release, so both input methods share one acceleration feel.

## Verification

- 250 vitest tests pass (10 new: delta integration, clamp, release settle, state isolation, ramp behavior)
- `npm run check` (svelte-check + tsc): 0 errors
- `npm run lint`, `prettier --check`: clean
- Manually verified in-game: keyboard speed matches click speed, no run-in-place after release, smooth acceleration from standstill

Related TODO item: "키보드로 움직이면 다른 플레이어에게는 움찔거리며 움직이는 것으로 보인다" — fix 1 doubles the effective sample rate toward `KEYBOARD_SEND_INTERVAL`, which should reduce (though not fully solve) the remote jerkiness.
