### PR TITLE
Fix Korean IME chat double-send on Enter

### DIFF
--- a/client/src/lib/chat-input-keys.test.ts
+++ b/client/src/lib/chat-input-keys.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { chatInputKeyIntent } from './chat-input-keys'
+
+function key(
+  key: string,
+  opts: { isComposing?: boolean; keyCode?: number } = {}
+) {
+  return {
+    key,
+    isComposing: opts.isComposing ?? false,
+    keyCode: opts.keyCode ?? 0,
+  }
+}
+
+describe('chatInputKeyIntent', () => {
+  it('sends on plain Enter', () => {
+    expect(chatInputKeyIntent(key('Enter', { keyCode: 13 }))).toBe('send')
+  })
+
+  it('does not send on Enter during IME composition', () => {
+    expect(
+      chatInputKeyIntent(key('Enter', { isComposing: true, keyCode: 13 }))
+    ).toBe('none')
+  })
+
+  it('does not send on IME keydown reported as keyCode 229', () => {
+    expect(chatInputKeyIntent(key('Enter', { keyCode: 229 }))).toBe('none')
+  })
+
+  it('sends on the Enter that follows a committed composition', () => {
+    const composing = key('Enter', { isComposing: true, keyCode: 13 })
+    const committed = key('Enter', { keyCode: 13 })
+    expect(chatInputKeyIntent(composing)).toBe('none')
+    expect(chatInputKeyIntent(committed)).toBe('send')
+  })
+
+  it('completes commands on Tab', () => {
+    expect(chatInputKeyIntent(key('Tab', { keyCode: 9 }))).toBe(
+      'complete-command'
+    )
+  })
+
+  it('ignores other keys', () => {
+    expect(chatInputKeyIntent(key('a', { keyCode: 65 }))).toBe('none')
+    expect(chatInputKeyIntent(key('Escape', { keyCode: 27 }))).toBe('none')
+  })
+})

--- a/client/src/lib/chat-input-keys.ts
+++ b/client/src/lib/chat-input-keys.ts
@@ -1,0 +1,16 @@
+export type ChatKeyIntent = 'complete-command' | 'send' | 'none'
+
+/** Enter pressed while an IME composition is active (e.g. Korean) only commits
+ *  the composing syllable; sending then would clear the input mid-composition
+ *  and leave the committed syllable behind as a stray follow-up message.
+ *  keyCode 229 covers browsers that fire IME keydowns without isComposing. */
+export function chatInputKeyIntent(event: {
+  key: string
+  isComposing: boolean
+  keyCode: number
+}): ChatKeyIntent {
+  if (event.key === 'Tab') return 'complete-command'
+  if (event.key !== 'Enter') return 'none'
+  if (event.isComposing || event.keyCode === 229) return 'none'
+  return 'send'
+}

--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -2,6 +2,7 @@
   import { gameStore } from '../stores/gameStore'
   import { networkManager } from '../network/socket'
   import { handleCommand, visibleCommandNames } from '../chat-commands'
+  import { chatInputKeyIntent } from '../chat-input-keys'
   import { chatFocusRequest } from '../stores/npcMenuStore'
 
   type Tab = 'say' | 'combat'
@@ -77,12 +78,11 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Tab') {
+    const intent = chatInputKeyIntent(event)
+    if (intent === 'complete-command') {
       event.preventDefault()
       completeCommand()
-      return
-    }
-    if (event.key === 'Enter') {
+    } else if (intent === 'send') {
       event.preventDefault()
       sendMessage()
     }


### PR DESCRIPTION
## Problem

Typing Korean in chat and pressing Enter delivered two messages: the full text plus the last syllable as a stray follow-up (e.g. `안녕하세요` → `안녕하세요` + `요`).

## Cause

`ChatPanel.svelte` sent on every Enter keydown without checking for an active IME composition. While the last syllable is still composing, Chrome fires the Enter keydown with `isComposing: true` **before** `compositionend`. The handler sent the message and cleared the input mid-composition, so the IME re-committed the composing syllable into the emptied input, and it went out with the next send.

## Fix

Extracted the keydown decision into `chat-input-keys.ts` and ignore Enter while `event.isComposing` is set (or legacy `keyCode === 229` for browsers that report IME keydowns that way). The composing Enter now only commits the syllable; the next Enter sends the complete message once.

## Testing

- Added `chat-input-keys.test.ts` (vitest, colocated per existing convention); full client suite passes (24 files, 251 tests).
- Verified end-to-end in a real Chrome against the Vite dev server with the real `ChatPanel` mounted (network layer mocked), replaying the exact Chrome/macOS Korean IME event sequence (`compositionstart/update` → Enter with `isComposing` → IME commit → Enter):
  - Before the fix the harness reproduces the report exactly: sends `["안녕하세요", "요"]`.
  - After the fix: sends `["안녕하세요"]` once, input cleared.
  - Legacy `keyCode 229` variant and plain ASCII Enter also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)