### PR TITLE
Show the pickup crouch to nearby players

### DIFF
--- a/client/src/lib/components/PlayerModel.svelte
+++ b/client/src/lib/components/PlayerModel.svelte
@@ -828,7 +828,15 @@
     if (playerState !== 'interact') {
       interactionFinishedNotified = false
       pickupGrabNotified = false
-    } else if (isCurrentPlayer && currentAction && interactionAnim) {
+    } else if (
+      currentAction &&
+      interactionAnim &&
+      // Pickup is the one interaction remote players end on their own: the
+      // server broadcast is transient (no StopInteraction follows), so the
+      // finish callback must fire for remotes too. Held poses (bench, forge)
+      // keep waiting for their StopInteraction.
+      (isCurrentPlayer || interactionAnim === 'pickup')
+    ) {
       const clip = currentAction.getClip()
       if (clip.name === interactionAnim) {
         if (

--- a/client/src/lib/components/game-scene/GameScenePlayersLayer.svelte
+++ b/client/src/lib/components/game-scene/GameScenePlayersLayer.svelte
@@ -456,6 +456,8 @@
         torchOn={player.torchOn}
         {torchEffectsDisabled}
         npcPlayerId={player.isNpc ? player.id : undefined}
+        onInteractionFinished={() =>
+          remotePlayerManager.handleStopInteraction(player.id)}
       />
     {/if}
   {/each}

--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -3,6 +3,7 @@ use crate::item_defs::UseEffect;
 use crate::types::{PlayerId, ServerMessage};
 use crate::world_config::world_config;
 use onlinerpg_shared::inventory::{EquipSlot, GroundItem, ItemInstance, PlayerInventory};
+use onlinerpg_shared::Position;
 use rand::Rng;
 use tracing::{info, warn};
 
@@ -828,6 +829,31 @@ impl super::GameState {
             None,
         )
         .await;
+        self.broadcast_pickup_animation(player_id, &item_position, player_floor)
+            .await;
+    }
+
+    /// Show the pickup crouch on nearby clients. Transient: it bypasses the
+    /// player's stored `object_type`, so no `StopInteraction` follows and a
+    /// late joiner never sees a held pickup pose — remotes end the clip on
+    /// their own.
+    async fn broadcast_pickup_animation(
+        &self,
+        player_id: &PlayerId,
+        position: &Position,
+        floor_level: i8,
+    ) {
+        self.send_direct_message_to_players_within_position(
+            position,
+            floor_level,
+            super::EVENT_DELIVERY_RADIUS,
+            ServerMessage::PlayerInteractionChanged {
+                player_id: *player_id,
+                object_type: Some("pickup".to_string()),
+            },
+            None,
+        )
+        .await;
     }
 
     /// Pick up a dungeon coin pile: claim it (first picker wins), credit a
@@ -877,6 +903,8 @@ impl super::GameState {
             None,
         )
         .await;
+        self.broadcast_pickup_animation(player_id, &ground_item.position, player_floor)
+            .await;
     }
 
     pub async fn tick_ground_item_despawn(&self) {

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -1079,6 +1079,59 @@ async fn player_attack_at_melee_range_is_allowed() {
     );
 }
 
+#[tokio::test]
+async fn pickup_broadcasts_the_pickup_animation() {
+    let game_state = make_test_game_state("pickup_anim_broadcast");
+    game_state.add_player(make_player("picker", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("watcher", 2.0, 0.0))
+        .await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        inventories.insert(pid("picker"), Default::default());
+    }
+    {
+        let mut ground_items = game_state.ground_items.write().await;
+        ground_items.insert(
+            42,
+            ServerGroundItem {
+                item: GroundItem {
+                    instance_id: 42,
+                    item_def_id: "test_item".to_string(),
+                    position: Position {
+                        x: 0.5,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    floor_level: 0,
+                    enchant: 0,
+                },
+                dropped_at_ms: 0,
+            },
+        );
+    }
+    let mut watcher_rx = game_state.register_direct_channel(&pid("watcher")).await;
+
+    game_state.pickup_item(&pid("picker"), 42).await;
+
+    let mut saw_animation = false;
+    while let Ok(msg) = watcher_rx.try_recv() {
+        if let ServerMessage::PlayerInteractionChanged {
+            player_id,
+            object_type,
+        } = msg
+        {
+            assert_eq!(player_id, pid("picker"));
+            assert_eq!(object_type.as_deref(), Some("pickup"));
+            saw_animation = true;
+        }
+    }
+    assert!(
+        saw_animation,
+        "nearby players must see the pickup animation"
+    );
+}
+
 // --- Haggling (economy phase 2) ---
 
 fn make_merchant_npc(id: &str, x: f32, z: f32) -> Player {


### PR DESCRIPTION
# Show the pickup crouch to nearby players

Fixes the TODO item: **"물건을 집을 때 나오는 애니메이션이 다른 플레이어에게 안 보임"** (doc/TODO.md)

## Demo

![pickup sync demo](https://raw.githubusercontent.com/treestar84/OpenMMO/demo-assets/doc/assets/pickup-sync-demo.gif)

*Two clients side by side, watching the same player pick up a dropped sword. Before: the item vanishes next to an idle-standing character. After: nearby players see the crouch.*

## Root cause

The pickup crouch was purely local: the client FSM plays the clip and sends only `PickupItem`, and the server's `pickup_item` broadcasts just `GroundItemRemoved`. Unlike attacks (`PlayerAttacked`) and object interactions (`PlayerInteractionChanged`), nothing ever told nearby clients that a pickup motion happened.

## Fix

Reuse the existing interaction broadcast, with one twist for its one-shot nature:

- **Server**: the pickup success paths (bag items and coin piles) broadcast `PlayerInteractionChanged { object_type: Some("pickup") }` to `EVENT_DELIVERY_RADIUS`. The broadcast is transient — it bypasses the player's stored `object_type`, so no `StopInteraction` follows and a late joiner never sees a held pickup pose.
- **Client**: remote models end the one-shot themselves. The interaction-finished callback (previously current-player-only) now also fires for remote `pickup` interactions and drops the player back to idle. Held poses (bench, forge) are untouched — they keep waiting for their `StopInteraction`.

No protocol change: `"pickup"` rides the existing `object_type: Option<String>` field, and the client's catalog fallback already resolves it to the right clip.

## Testing

- New server test: a nearby player receives `PlayerInteractionChanged { object_type: Some("pickup") }` on pickup.
- Full workspace suite passes; `cargo fmt` / `cargo clippy` (no new warnings) / `npm run check` / `npm run lint` all clean.
- Verified end-to-end with two local clients (the GIF above).
