### PR TITLE
Add toroidal wrapping across both world axes

### DIFF
--- a/agent-client/src/geom.rs
+++ b/agent-client/src/geom.rs
@@ -4,10 +4,10 @@
 //! keeps callers focused on WHY they care about distance, not HOW it's
 //! derived.
 
-use onlinerpg_shared::Position;
+use onlinerpg_shared::{shortest_world_delta_x, shortest_world_delta_z, Position};
 
-/// Planar (X-Z) displacement and Euclidean distance from `from` to `to`.
-/// Y is ignored.
+/// Planar (X-Z) displacement and shortest-periodic distance from `from` to
+/// `to` on the toroidal world. Y is ignored.
 pub struct PlanarDelta {
     pub dx: f32,
     pub dz: f32,
@@ -24,8 +24,8 @@ impl PlanarDelta {
     }
 
     pub fn xz(from_x: f32, from_z: f32, to_x: f32, to_z: f32) -> Self {
-        let dx = to_x - from_x;
-        let dz = to_z - from_z;
+        let dx = shortest_world_delta_x(from_x, to_x);
+        let dz = shortest_world_delta_z(from_z, to_z);
         Self {
             dx,
             dz,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1107,7 +1107,6 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -1234,7 +1233,6 @@
       "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1250,7 +1248,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
       "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -1317,7 +1314,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1425,7 +1421,6 @@
       "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1648,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2019,7 +2013,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2474,7 +2467,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2788,7 +2780,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2816,7 +2807,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -2950,7 +2940,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3174,7 +3163,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.6.tgz",
       "integrity": "sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3255,8 +3243,7 @@
       "version": "0.185.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-instanced-uniforms-mesh": {
       "version": "0.52.4",
@@ -3416,7 +3403,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3479,7 +3465,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/client/src/lib/components/PlayerControl.svelte
+++ b/client/src/lib/components/PlayerControl.svelte
@@ -100,7 +100,7 @@
     PlayerControlStateName,
   } from './player-control/fsm/control-state'
   import { createLocalPlayerControlMachine } from './player-control/fsm/state-definitions'
-  import { wrapWorldX } from '../terrain/world-wrap'
+  import { wrapWorldX, wrapWorldZ } from '../terrain/world-wrap'
 
   interface Props {
     onStateChange: (state: PlayerState) => void
@@ -373,7 +373,11 @@
     rotation: number,
     append = false
   ) {
-    const wrappedPosition = { ...position, x: wrapWorldX(position.x) }
+    const wrappedPosition = {
+      ...position,
+      x: wrapWorldX(position.x),
+      z: wrapWorldZ(position.z),
+    }
     lastSentPosition = wrappedPosition
     const floorLevel = wireFloorLevel()
     lastSentFloorLevel = floorLevel
@@ -385,9 +389,10 @@
 
   function writePlayerPosition(position: Position, rotation: number) {
     const wrappedX = wrapWorldX(position.x)
+    const wrappedZ = wrapWorldZ(position.z)
     gameStore.update((state) => {
       if (state.currentPlayer) {
-        state.currentPlayer.position.set(wrappedX, position.y, position.z)
+        state.currentPlayer.position.set(wrappedX, position.y, wrappedZ)
         state.currentPlayer.rotation = rotation
       }
       return state
@@ -677,7 +682,8 @@
     },
     requestMove: (target: { x: number; z: number }) => {
       const tx = wrapWorldX(target.x)
-      handleClickToMove({ x: tx, y: sampleHeight(tx, target.z), z: target.z })
+      const tz = wrapWorldZ(target.z)
+      handleClickToMove({ x: tx, y: sampleHeight(tx, tz), z: tz })
     },
   }
 

--- a/client/src/lib/components/WorldMapDialog.svelte
+++ b/client/src/lib/components/WorldMapDialog.svelte
@@ -70,7 +70,12 @@
     graphicsQuality,
     getEffectivePreset,
   } from '../stores/graphicsSettings'
-  import { wrapWorldX } from '../terrain/world-wrap'
+  import {
+    unwrapWorldXNear,
+    unwrapWorldZNear,
+    wrapWorldX,
+    wrapWorldZ,
+  } from '../terrain/world-wrap'
 
   const graphicsPreset = $derived(getEffectivePreset($graphicsQuality))
   const mobileMapBudget = $derived(graphicsPreset.renderBudget === 'mobile')
@@ -112,7 +117,7 @@
   let containerH = $state(0)
 
   let playerX = $derived(wrapWorldX($gameStore.currentPlayer?.position.x ?? 0))
-  let playerZ = $derived($gameStore.currentPlayer?.position.z ?? 0)
+  let playerZ = $derived(wrapWorldZ($gameStore.currentPlayer?.position.z ?? 0))
 
   // --- Camera state (world coordinates of view center) ---
   let camX = $state(0)
@@ -248,8 +253,8 @@
       if (gen !== renderGeneration) return
 
       // Player marker (also rotated with the map)
-      const playerCanvasX = (px - viewLeft) * scale
-      const playerCanvasZ = (pz - viewTop) * scale
+      const playerCanvasX = (unwrapWorldXNear(cx, px) - viewLeft) * scale
+      const playerCanvasZ = (unwrapWorldZNear(cz, pz) - viewTop) * scale
 
       ctx.save()
       ctx.translate(cw / 2, ch / 2)
@@ -299,8 +304,8 @@
       if (zoomSpan < tier.min || zoomSpan > tier.max) continue
 
       // World -> pre-rotation canvas coords (matches the player marker).
-      const lx = (label.x - viewLeft) * scale
-      const ly = (label.z - viewTop) * scale
+      const lx = (unwrapWorldXNear(camX, label.x) - viewLeft) * scale
+      const ly = (unwrapWorldZNear(camZ, label.z) - viewTop) * scale
       // Rotate around canvas center to match ctx.rotate(ROTATE_ANGLE).
       const ox = lx - cw / 2
       const oy = ly - ch / 2
@@ -485,7 +490,7 @@
     const cosA = Math.cos(angle)
     const sinA = Math.sin(angle)
     const worldX = wrapWorldX(camX + (sx * cosA - sz * sinA))
-    const worldZ = camZ + (sx * sinA + sz * cosA)
+    const worldZ = wrapWorldZ(camZ + (sx * sinA + sz * cosA))
 
     const position = { x: worldX, y: 0, z: worldZ }
 

--- a/client/src/lib/components/game-scene/GameScenePlayersLayer.svelte
+++ b/client/src/lib/components/game-scene/GameScenePlayersLayer.svelte
@@ -35,6 +35,7 @@
   import {
     shortestWrappedDeltaX,
     unwrapWorldXNear,
+    unwrapWorldZNear,
   } from '../../terrain/world-wrap'
   import { OFFSCREEN_Y } from '../../utils/house-geo-utils'
   import { torchLightEnabled } from '../../stores/debugStore'
@@ -268,10 +269,11 @@
     }
     if (bestRp) {
       const displayX = unwrapWorldXNear(playerPos.x, bestRp.position.x)
+      const displayZ = unwrapWorldZNear(playerPos.z, bestRp.position.z)
       return {
         target: setTorchTargetFromPose(
           displayX,
-          bestRp.position.z,
+          displayZ,
           bestRp.position.y,
           bestRp.rotation
         ),
@@ -429,6 +431,9 @@
       {@const displayX = currentPlayer
         ? unwrapWorldXNear(currentPlayer.position.x, remotePlayer.position.x)
         : remotePlayer.position.x}
+      {@const displayZ = currentPlayer
+        ? unwrapWorldZNear(currentPlayer.position.z, remotePlayer.position.z)
+        : remotePlayer.position.z}
       <!-- position.y is ground-resampled per tick by remotePlayerManager -->
       {@const baseY = remotePlayer.position.y}
       <PlayerModel
@@ -436,7 +441,7 @@
         position={new THREE.Vector3(
           displayX,
           visible ? baseY : OFFSCREEN_Y,
-          remotePlayer.position.z
+          displayZ
         )}
         name={player.name}
         isCurrentPlayer={false}

--- a/client/src/lib/components/player-control/fsm/combat.ts
+++ b/client/src/lib/components/player-control/fsm/combat.ts
@@ -9,7 +9,10 @@ import {
   type PlayerStateName,
   type Position,
 } from '../../../utils/movementUtils'
-import { shortestWrappedDeltaX } from '../../../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+} from '../../../terrain/world-wrap'
 import {
   buildAttackState,
   buildIdleAfterAttack,
@@ -55,7 +58,7 @@ export function applyChaseTargetUpdate({
   if (!changed) return { kind: 'unchanged' }
 
   const dx = shortestWrappedDeltaX(currentPos.x, newTarget.x)
-  const dz = newTarget.z - currentPos.z
+  const dz = shortestWrappedDeltaZ(currentPos.z, newTarget.z)
   const nextMovementState =
     movementState ??
     initMovementState(

--- a/client/src/lib/components/player-control/fsm/keyboard.ts
+++ b/client/src/lib/components/player-control/fsm/keyboard.ts
@@ -1,5 +1,8 @@
 import type { MovementConfig, Position } from '../../../utils/movementUtils'
-import { shortestWrappedDeltaX } from '../../../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+} from '../../../terrain/world-wrap'
 import type { InteractionExitKind } from './interaction'
 import type { SendPlayerMove } from './movement-substrate'
 
@@ -36,7 +39,7 @@ export function createKeyboardMoveSender(
         return
       }
       const dx = shortestWrappedDeltaX(lastSent.x, position.x)
-      const dz = position.z - lastSent.z
+      const dz = shortestWrappedDeltaZ(lastSent.z, position.z)
       if (
         dx * dx + dz * dz >=
         KEYBOARD_SEND_INTERVAL * KEYBOARD_SEND_INTERVAL
@@ -89,7 +92,7 @@ export function createKeyboardTapTracker(): KeyboardTapTracker {
       lastDir = null
       if (!s || !d || !position) return null
       const dx = shortestWrappedDeltaX(s.x, position.x)
-      const dz = position.z - s.z
+      const dz = shortestWrappedDeltaZ(s.z, position.z)
       const moved = Math.hypot(dx, dz)
       // No actual step (blocked at a wall, interaction-exit tap): don't
       // conjure movement the player never started.

--- a/client/src/lib/components/player-control/fsm/move-request.ts
+++ b/client/src/lib/components/player-control/fsm/move-request.ts
@@ -4,7 +4,10 @@ import {
   type Position,
 } from '../../../utils/movementUtils'
 import type { InteractionExitKind } from './interaction'
-import { shortestWrappedDeltaX } from '../../../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+} from '../../../terrain/world-wrap'
 import type { PathWaypoint, SendPlayerMove } from './movement-substrate'
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -137,7 +140,7 @@ export function startClickMovement({
   }
 
   const dx = shortestWrappedDeltaX(currentPos.x, wpPos.x)
-  const dz = wpPos.z - currentPos.z
+  const dz = shortestWrappedDeltaZ(currentPos.z, wpPos.z)
   const playerRotation = Math.atan2(dx, dz)
   const movementState = initMovementState(currentPos, wpPos, 0)
 

--- a/client/src/lib/components/player-control/fsm/movement-substrate.ts
+++ b/client/src/lib/components/player-control/fsm/movement-substrate.ts
@@ -5,7 +5,10 @@ import {
   type MovementState,
   type Position,
 } from '../../../utils/movementUtils'
-import { shortestWrappedDeltaX } from '../../../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+} from '../../../terrain/world-wrap'
 
 export interface PathWaypoint {
   x: number
@@ -180,7 +183,7 @@ export function stepMovementSubstrate({
       }
 
       const ndx = shortestWrappedDeltaX(movementTarget.x, wpPos.x)
-      const ndz = wpPos.z - movementTarget.z
+      const ndz = shortestWrappedDeltaZ(movementTarget.z, wpPos.z)
       const nextRotation = Math.atan2(ndx, ndz)
       const nextMovementState = initMovementState(
         movementTarget,

--- a/client/src/lib/components/player-control/player-physics.ts
+++ b/client/src/lib/components/player-control/player-physics.ts
@@ -6,7 +6,7 @@ import {
   isSlopeTooSteepUphill,
   SLOPE_LOOKAHEAD_DISTANCE,
 } from '../../utils/movementUtils'
-import { wrapWorldX } from '../../terrain/world-wrap'
+import { wrapWorldX, wrapWorldZ } from '../../terrain/world-wrap'
 
 export interface PlayerPhysicsDeps {
   /** Live read — heightManager is a Svelte prop and may change identity. */
@@ -49,6 +49,7 @@ export interface PlayerPhysics {
 export function createPlayerPhysics(deps: PlayerPhysicsDeps): PlayerPhysics {
   function sampleHeight(x: number, z: number): number {
     x = wrapWorldX(x)
+    z = wrapWorldZ(z)
     // Dungeon floors and stair-shaft ramps replace terrain entirely while
     // underground (and on the surface entrance ramp).
     const dungeonY = dungeonManager.sampleHeightAt(x, z)
@@ -66,6 +67,7 @@ export function createPlayerPhysics(deps: PlayerPhysicsDeps): PlayerPhysics {
 
   function waypointHeight(floor: number, x: number, z: number): number {
     x = wrapWorldX(x)
+    z = wrapWorldZ(z)
     const dungeonY = dungeonManager.sampleHeightAt(x, z)
     if (dungeonY !== null) return dungeonY
     // Floor-keyed, so the stairwell ramp resolves per position instead of
@@ -130,7 +132,10 @@ export function createPlayerPhysics(deps: PlayerPhysicsDeps): PlayerPhysics {
     // reduces to the raw terrain slope under the house and walls off a whole
     // contour line across the rooms. House floors are flat and walkable.
     // Checked only on rejection — the house scan is the expensive half.
-    return !housingManager.isPointUnderHouseXZ(wrapWorldX(fromX), fromZ)
+    return !housingManager.isPointUnderHouseXZ(
+      wrapWorldX(fromX),
+      wrapWorldZ(fromZ)
+    )
   }
 
   return { sampleHeight, waypointHeight, isMovementBlocked, isUphillTooSteep }

--- a/client/src/lib/managers/dungeonManager.ts
+++ b/client/src/lib/managers/dungeonManager.ts
@@ -27,7 +27,10 @@ import {
   dungeonPropsRevision,
 } from '../stores/dungeonStore'
 import { DUNGEON_ENTRANCES } from '../data/dungeonDefs'
-import { shortestWrappedDeltaX } from '../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+} from '../terrain/world-wrap'
 import type { DungeonWall } from '../utils/dungeon-geo-constants'
 
 export interface DungeonRoom {
@@ -916,7 +919,7 @@ class DungeonManager {
     if (!this.active) {
       for (const e of DUNGEON_ENTRANCES) {
         const dx = shortestWrappedDeltaX(e.x, x)
-        const dz = z - e.z
+        const dz = shortestWrappedDeltaZ(e.z, z)
         if (dx * dx + dz * dz < r * r) {
           this.enter(e.id, { x: e.x, y: e.y, z: e.z })
           return
@@ -926,7 +929,7 @@ class DungeonManager {
     }
     if (get(currentDungeonDepth) === 0 && this.entrance) {
       const dx = shortestWrappedDeltaX(this.entrance.x, x)
-      const dz = z - this.entrance.z
+      const dz = shortestWrappedDeltaZ(this.entrance.z, z)
       const d2 = dx * dx + dz * dz
       const inside = d2 < r * r
       if (inside && !this.doorSyncInside) this.doorSnapshotRequest = this.id

--- a/client/src/lib/managers/entity-ground.ts
+++ b/client/src/lib/managers/entity-ground.ts
@@ -1,4 +1,4 @@
-import { wrapWorldX } from '../terrain/world-wrap'
+import { wrapWorldX, wrapWorldZ } from '../terrain/world-wrap'
 import { bridgeManager } from './bridgeManager'
 import { dungeonManager } from './dungeonManager'
 import { housingManager } from './housingManager'
@@ -19,28 +19,29 @@ export function entityGroundY(
   fallbackY: number
 ): number {
   const wx = wrapWorldX(x)
+  const wz = wrapWorldZ(z)
 
   if (floorLevel < 0) {
-    return dungeonManager.floorHeightAt(-floorLevel, wx, z) ?? fallbackY
+    return dungeonManager.floorHeightAt(-floorLevel, wx, wz) ?? fallbackY
   }
   if (floorLevel > 0) {
-    return housingManager.floorHeightAt(floorLevel, wx, z) ?? fallbackY
+    return housingManager.floorHeightAt(floorLevel, wx, wz) ?? fallbackY
   }
 
   // Floor 0 still checks both structures: the dungeon entrance ramp and a
   // house stairwell (which spans floors 0..1) are both reported as floor 0
   // until the climber crosses into the floor above.
-  const rampY = dungeonManager.entranceRampHeightAt(wx, z)
+  const rampY = dungeonManager.entranceRampHeightAt(wx, wz)
   if (rampY !== null) return rampY
-  const houseY = housingManager.floorHeightAt(0, wx, z)
+  const houseY = housingManager.floorHeightAt(0, wx, wz)
   if (houseY !== null) return houseY
-  const deckY = bridgeManager.findDeckYAt(wx, z, null)
+  const deckY = bridgeManager.findDeckYAt(wx, wz, null)
   if (deckY !== null) return deckY
 
   // getHeightAtWorldPosition returns 0 for unloaded tiles rather than null,
   // so the guard is what keeps an entity from snapping to sea level.
-  if (heightManager?.hasHeightDataForGrid(wx, z)) {
-    return heightManager.getHeightAtWorldPosition(wx, z)
+  if (heightManager?.hasHeightDataForGrid(wx, wz)) {
+    return heightManager.getHeightAtWorldPosition(wx, wz)
   }
   return fallbackY
 }

--- a/client/src/lib/terrain/world-wrap.test.ts
+++ b/client/src/lib/terrain/world-wrap.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   WORLD_MAX_X,
+  WORLD_MAX_Z,
   WORLD_MIN_X,
+  WORLD_MIN_Z,
   shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
   unwrapWorldXNear,
+  unwrapWorldZNear,
   wrapWorldX,
+  wrapWorldZ,
 } from './world-wrap'
 
 describe('wrapWorldX', () => {
@@ -25,6 +30,28 @@ describe('shortestWrappedDeltaX', () => {
   it('unwraps a canonical coordinate next to a local reference', () => {
     expect(unwrapWorldXNear(WORLD_MAX_X - 1, WORLD_MIN_X + 1)).toBe(
       WORLD_MAX_X + 1
+    )
+  })
+})
+
+describe('wrapWorldZ', () => {
+  it('wraps across the baked north and south terrain edges', () => {
+    expect(wrapWorldZ(WORLD_MIN_Z)).toBe(WORLD_MIN_Z)
+    expect(wrapWorldZ(WORLD_MAX_Z)).toBe(WORLD_MIN_Z)
+    expect(wrapWorldZ(WORLD_MAX_Z + 0.25)).toBe(WORLD_MIN_Z + 0.25)
+    expect(wrapWorldZ(WORLD_MIN_Z - 0.25)).toBe(WORLD_MAX_Z - 0.25)
+  })
+})
+
+describe('shortestWrappedDeltaZ', () => {
+  it('uses the short path across both world edges', () => {
+    expect(shortestWrappedDeltaZ(WORLD_MAX_Z - 1, WORLD_MIN_Z + 1)).toBe(2)
+    expect(shortestWrappedDeltaZ(WORLD_MIN_Z + 1, WORLD_MAX_Z - 1)).toBe(-2)
+  })
+
+  it('unwraps a canonical coordinate next to a local reference', () => {
+    expect(unwrapWorldZNear(WORLD_MAX_Z - 1, WORLD_MIN_Z + 1)).toBe(
+      WORLD_MAX_Z + 1
     )
   })
 })

--- a/client/src/lib/terrain/world-wrap.ts
+++ b/client/src/lib/terrain/world-wrap.ts
@@ -1,11 +1,15 @@
 import { REGION_CELLS } from './terrain-constants'
 
-/** Full baked circumference: regions -16 through +15. */
+/** Full baked circumference per axis (the world is a torus): regions -16 through +15. */
 export const WORLD_WIDTH_X = 32 * REGION_CELLS
 /** Tile -256 extends half a 64 m tile west of its center at -16,384. */
 export const WORLD_MIN_X = -16 * REGION_CELLS - 32
 /** Exclusive east edge; periodically identical to WORLD_MIN_X. */
 export const WORLD_MAX_X = WORLD_MIN_X + WORLD_WIDTH_X
+/** North-south circumference and edges — same values as X (square torus). */
+export const WORLD_WIDTH_Z = WORLD_WIDTH_X
+export const WORLD_MIN_Z = WORLD_MIN_X
+export const WORLD_MAX_Z = WORLD_MIN_Z + WORLD_WIDTH_Z
 
 export function wrapWorldX(x: number): number {
   return (
@@ -14,7 +18,14 @@ export function wrapWorldX(x: number): number {
   )
 }
 
-/** Shortest signed X offset from `fromX` to `toX` on the cylindrical world. */
+export function wrapWorldZ(z: number): number {
+  return (
+    ((((z - WORLD_MIN_Z) % WORLD_WIDTH_Z) + WORLD_WIDTH_Z) % WORLD_WIDTH_Z) +
+    WORLD_MIN_Z
+  )
+}
+
+/** Shortest signed X offset from `fromX` to `toX` on the toroidal world. */
 export function shortestWrappedDeltaX(fromX: number, toX: number): number {
   const rawDelta = toX - fromX
   if (rawDelta >= -WORLD_WIDTH_X / 2 && rawDelta < WORLD_WIDTH_X / 2) {
@@ -27,7 +38,25 @@ export function shortestWrappedDeltaX(fromX: number, toX: number): number {
   )
 }
 
+/** Shortest signed Z offset from `fromZ` to `toZ` on the toroidal world. */
+export function shortestWrappedDeltaZ(fromZ: number, toZ: number): number {
+  const rawDelta = toZ - fromZ
+  if (rawDelta >= -WORLD_WIDTH_Z / 2 && rawDelta < WORLD_WIDTH_Z / 2) {
+    return rawDelta
+  }
+  return (
+    ((((rawDelta + WORLD_WIDTH_Z / 2) % WORLD_WIDTH_Z) + WORLD_WIDTH_Z) %
+      WORLD_WIDTH_Z) -
+    WORLD_WIDTH_Z / 2
+  )
+}
+
 /** Periodic representation of `x` nearest to the given reference position. */
 export function unwrapWorldXNear(referenceX: number, x: number): number {
   return referenceX + shortestWrappedDeltaX(referenceX, x)
+}
+
+/** Periodic representation of `z` nearest to the given reference position. */
+export function unwrapWorldZNear(referenceZ: number, z: number): number {
+  return referenceZ + shortestWrappedDeltaZ(referenceZ, z)
 }

--- a/client/src/lib/utils/movementUtils.ts
+++ b/client/src/lib/utils/movementUtils.ts
@@ -1,6 +1,11 @@
 // Common movement calculation utilities shared between local and remote players
 
-import { shortestWrappedDeltaX, unwrapWorldXNear } from '../terrain/world-wrap'
+import {
+  shortestWrappedDeltaX,
+  shortestWrappedDeltaZ,
+  unwrapWorldXNear,
+  unwrapWorldZNear,
+} from '../terrain/world-wrap'
 
 export type MovementMode = 'walk' | 'jog' | 'run'
 
@@ -143,7 +148,7 @@ export function calculateMovementStep(
 
   // Calculate remaining distance on XZ plane (Y is handled by terrain)
   const dx = shortestWrappedDeltaX(currentPos.x, targetPos.x)
-  const dz = targetPos.z - currentPos.z
+  const dz = shortestWrappedDeltaZ(currentPos.z, targetPos.z)
   const remainingDistance = Math.sqrt(dx * dx + dz * dz)
 
   // Check if arrived
@@ -152,7 +157,7 @@ export function calculateMovementStep(
       newPos: {
         x: unwrapWorldXNear(currentPos.x, targetPos.x),
         y: currentPos.y,
-        z: targetPos.z,
+        z: unwrapWorldZNear(currentPos.z, targetPos.z),
       },
       newSpeed: 0,
       rotation: Math.atan2(dx, dz),
@@ -191,7 +196,7 @@ export function calculateMovementStep(
     newPos = {
       x: unwrapWorldXNear(currentPos.x, targetPos.x),
       y: currentPos.y,
-      z: targetPos.z,
+      z: unwrapWorldZNear(currentPos.z, targetPos.z),
     }
     return {
       newPos,
@@ -232,7 +237,7 @@ export function initMovementState(
   currentSpeed: number = 0
 ): MovementState {
   const dx = shortestWrappedDeltaX(currentPos.x, targetPos.x)
-  const dz = targetPos.z - currentPos.z
+  const dz = shortestWrappedDeltaZ(currentPos.z, targetPos.z)
   const totalDistance = Math.sqrt(dx * dx + dz * dz)
 
   return {

--- a/server/src/game_state/deals.rs
+++ b/server/src/game_state/deals.rs
@@ -180,7 +180,7 @@ impl super::GameState {
             }
 
             let dx = onlinerpg_shared::shortest_world_delta_x(target.position.x, npc.position.x);
-            let dz = npc.position.z - target.position.z;
+            let dz = onlinerpg_shared::shortest_world_delta_z(target.position.z, npc.position.z);
             if dx * dx + dz * dz > NPC_SIGHT_RADIUS * NPC_SIGHT_RADIUS {
                 return self
                     .reject_deal(

--- a/server/src/game_state/dungeon.rs
+++ b/server/src/game_state/dungeon.rs
@@ -248,7 +248,7 @@ impl GameState {
             } else {
                 let chest_pos = cell_center(&entrance.position(), total, chest);
                 let dx = onlinerpg_shared::shortest_world_delta_x(chest_pos.x, player_pos.x);
-                let dz = player_pos.z - chest_pos.z;
+                let dz = onlinerpg_shared::shortest_world_delta_z(chest_pos.z, player_pos.z);
                 if dx * dx + dz * dz > CHEST_INTERACT_RANGE * CHEST_INTERACT_RANGE {
                     Some("Too far from the chest")
                 } else if rt.floors.get(&total).is_some_and(|fr| {
@@ -539,7 +539,7 @@ impl GameState {
             } else {
                 let prop_pos = cell_center(&entrance.position(), depth, (prop.x, prop.z));
                 let dx = onlinerpg_shared::shortest_world_delta_x(prop_pos.x, player_pos.x);
-                let dz = player_pos.z - prop_pos.z;
+                let dz = onlinerpg_shared::shortest_world_delta_z(prop_pos.z, player_pos.z);
                 if dx * dx + dz * dz > PROP_INTERACT_RANGE * PROP_INTERACT_RANGE {
                     Some(Err(format!("Too far from the {noun}")))
                 } else if select_state(rt).entry(depth).or_default().insert(prop_id) {

--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -752,7 +752,7 @@ impl super::GameState {
         };
 
         let dx = onlinerpg_shared::shortest_world_delta_x(ground_item.position.x, player_pos.x);
-        let dz = player_pos.z - ground_item.position.z;
+        let dz = onlinerpg_shared::shortest_world_delta_z(ground_item.position.z, player_pos.z);
         if dx * dx + dz * dz > MAX_PICKUP_DISTANCE * MAX_PICKUP_DISTANCE {
             self.send_inventory_error(player_id, "Too far away").await;
             return;

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -389,7 +389,7 @@ fn is_player_near_door(
 
     // XZ distance check
     let dx = onlinerpg_shared::shortest_world_delta_x(world_x, player_pos.x);
-    let dz = player_pos.z - world_z;
+    let dz = onlinerpg_shared::shortest_world_delta_z(world_z, player_pos.z);
     let dist_sq = dx * dx + dz * dz;
     if dist_sq > MAX_DOOR_DISTANCE * MAX_DOOR_DISTANCE {
         warn!(

--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -139,6 +139,8 @@ impl super::GameState {
         state: MonsterState,
         target_position: Position,
     ) {
+        let new_position = new_position.wrapped_xz();
+        let target_position = target_position.wrapped_xz();
         let (old_position, owner_id, monster) = {
             let mut monsters = self.monsters.write().await;
 
@@ -377,7 +379,7 @@ impl super::GameState {
             }
         };
         let dx = onlinerpg_shared::shortest_world_delta_x(player_pos.x, position.x);
-        let dz = position.z - player_pos.z;
+        let dz = onlinerpg_shared::shortest_world_delta_z(player_pos.z, position.z);
         let max = rule.max_distance + 10.0; // tolerance
         dx * dx + dz * dz <= max * max
     }

--- a/server/src/game_state/passability.rs
+++ b/server/src/game_state/passability.rs
@@ -15,7 +15,9 @@ use onlinerpg_shared::dungeon::{
 use onlinerpg_shared::furniture::{self, FurniturePlacement};
 use onlinerpg_shared::housing::HouseData;
 use onlinerpg_shared::pathfinding;
-use onlinerpg_shared::{WORLD_MAX_X, WORLD_MIN_X, WORLD_WIDTH_X};
+use onlinerpg_shared::{
+    WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, WORLD_WIDTH_X, WORLD_WIDTH_Z,
+};
 use serde::Deserialize;
 use tracing::{info, warn};
 
@@ -26,14 +28,9 @@ struct RegionObjects {
     placements: Vec<FurniturePlacement>,
 }
 
-/// Query a short local movement sweep on both representations of the wrapped
-/// X seam. The player's stored position is canonical, while a seam-crossing
-/// step is deliberately left unwrapped so it remains a short segment. Shifting
-/// that segment by one world width lets it see passability near the destination
-/// edge as well as the source edge.
-///
-/// See `pathfinding::blocking_entry_for_mover` for why a sealed-in player is
-/// let out.
+/// Query a short movement sweep at each toroidal representation. Stored
+/// positions are canonical, while shifted copies cover X, Z, and corner seams.
+/// `blocking_entry_for_mover` also lets a sealed-in player move out.
 pub(super) fn wrapped_block_info<'a>(
     cache: &'a pathfinding::PassabilityCache,
     from_x: f32,
@@ -43,34 +40,48 @@ pub(super) fn wrapped_block_info<'a>(
     floor_level: u8,
     y: f32,
 ) -> Option<pathfinding::BlockInfo<'a>> {
-    if let Some(info) = pathfinding::blocking_entry_for_mover(
-        cache,
-        from_x,
-        from_z,
-        to_x,
-        to_z,
-        floor_level,
-        Some(y),
-    ) {
-        return Some(info);
-    }
-
-    let seam_offset = if to_x >= WORLD_MAX_X {
+    let off_x = if to_x >= WORLD_MAX_X {
         -WORLD_WIDTH_X
     } else if to_x < WORLD_MIN_X {
         WORLD_WIDTH_X
     } else {
-        return None;
+        0.0
     };
-    pathfinding::blocking_entry_for_mover(
-        cache,
-        from_x + seam_offset,
-        from_z,
-        to_x + seam_offset,
-        to_z,
-        floor_level,
-        Some(y),
-    )
+    let off_z = if to_z >= WORLD_MAX_Z {
+        -WORLD_WIDTH_Z
+    } else if to_z < WORLD_MIN_Z {
+        WORLD_WIDTH_Z
+    } else {
+        0.0
+    };
+    let mut shifts: [(f32, f32); 4] = [(0.0, 0.0); 4];
+    let mut n = 1;
+    if off_x != 0.0 {
+        shifts[n] = (off_x, 0.0);
+        n += 1;
+    }
+    if off_z != 0.0 {
+        shifts[n] = (0.0, off_z);
+        n += 1;
+    }
+    if off_x != 0.0 && off_z != 0.0 {
+        shifts[n] = (off_x, off_z);
+        n += 1;
+    }
+    for &(sx, sz) in &shifts[..n] {
+        if let Some(info) = pathfinding::blocking_entry_for_mover(
+            cache,
+            from_x + sx,
+            from_z + sz,
+            to_x + sx,
+            to_z + sz,
+            floor_level,
+            Some(y),
+        ) {
+            return Some(info);
+        }
+    }
+    None
 }
 
 /// Cache floor index for a player, derived from the server's own position

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -1,7 +1,9 @@
 use crate::auth::{AuthError, AuthService, CharacterSaveData};
 use crate::types::{CharacterAttributes, Player, PlayerId, Position, ServerMessage};
 use crate::world_config::world_config;
-use onlinerpg_shared::{shortest_world_delta_x, wrap_world_x, PLAYER_MOVE_SPEED};
+use onlinerpg_shared::{
+    shortest_world_delta_x, shortest_world_delta_z, wrap_world_x, wrap_world_z, PLAYER_MOVE_SPEED,
+};
 use std::collections::{HashMap, HashSet, VecDeque};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -257,6 +259,7 @@ impl super::GameState {
         // Normalize persisted legacy positions before they enter the spatial
         // index or are sent to clients.
         player.position.x = onlinerpg_shared::wrap_world_x(player.position.x);
+        player.position.z = onlinerpg_shared::wrap_world_z(player.position.z);
         let player_id = player.id;
         let player_name = player.name.clone();
         let player_number = self.get_or_assign_player_number(&player_id).await;
@@ -421,6 +424,7 @@ impl super::GameState {
             return;
         }
         new_position.x = wrap_world_x(new_position.x);
+        new_position.z = wrap_world_z(new_position.z);
         // Dungeon floors (negative) are validated against the entrance
         // registry and the floor's expected world Y before being stored.
         // Deliberately does not carry the name out: this runs for every move
@@ -533,13 +537,13 @@ impl super::GameState {
                 while let Some(intent) = waypoints.front() {
                     let target = &intent.target;
                     let dx = shortest_world_delta_x(player.position.x, target.x);
-                    let dz = target.z - player.position.z;
+                    let dz = shortest_world_delta_z(player.position.z, target.z);
                     let dist = (dx * dx + dz * dz).sqrt();
                     let snap = dist <= budget;
-                    // Step in unwrapped X so a seam-crossing move stays a
+                    // Step in unwrapped X/Z so a seam-crossing move stays a
                     // short local sweep for the collision query.
                     let (step_x, step_y, step_z) = if snap {
-                        (player.position.x + dx, target.y, target.z)
+                        (player.position.x + dx, target.y, player.position.z + dz)
                     } else {
                         let t = budget / dist;
                         (
@@ -593,7 +597,7 @@ impl super::GameState {
                         player.position = Position {
                             x: wrap_world_x(step_x),
                             y: step_y,
-                            z: step_z,
+                            z: wrap_world_z(step_z),
                         };
                         break;
                     }
@@ -755,6 +759,7 @@ impl super::GameState {
         new_floor_level: i8,
     ) {
         new_position.x = wrap_world_x(new_position.x);
+        new_position.z = wrap_world_z(new_position.z);
         self.apply_player_position(
             player_id,
             new_position,
@@ -1163,39 +1168,49 @@ impl super::GameState {
         let cells = self.player_spatial_cells.read().await;
         let mut player_ids = HashSet::new();
 
-        // The spatial hash itself stores canonical positions. Near either X
-        // edge, query translated copies one circumference away so cells from
-        // the opposite edge participate in the same periodic neighborhood.
-        for shift_x in [
-            -onlinerpg_shared::WORLD_WIDTH_X,
+        // The spatial hash itself stores canonical positions. Near a world
+        // edge, query translated copies one circumference away on each axis
+        // (3×3 grid) so cells from the opposite edge participate in the
+        // same periodic neighborhood.
+        for shift_z in [
+            -onlinerpg_shared::WORLD_WIDTH_Z,
             0.0,
-            onlinerpg_shared::WORLD_WIDTH_X,
+            onlinerpg_shared::WORLD_WIDTH_Z,
         ] {
-            let shifted = Position {
-                x: position.x + shift_x,
-                ..*position
-            };
-            let shifted_center = super::SpatialCell::from_position(&shifted);
-            for cell_x in (shifted_center.x - cell_radius)..=(shifted_center.x + cell_radius) {
-                for cell_z in (shifted_center.z - cell_radius)..=(shifted_center.z + cell_radius) {
-                    let cell = super::SpatialCell {
-                        x: cell_x,
-                        z: cell_z,
-                    };
+            for shift_x in [
+                -onlinerpg_shared::WORLD_WIDTH_X,
+                0.0,
+                onlinerpg_shared::WORLD_WIDTH_X,
+            ] {
+                let shifted = Position {
+                    x: position.x + shift_x,
+                    z: position.z + shift_z,
+                    ..*position
+                };
+                let shifted_center = super::SpatialCell::from_position(&shifted);
+                for cell_x in (shifted_center.x - cell_radius)..=(shifted_center.x + cell_radius) {
+                    for cell_z in
+                        (shifted_center.z - cell_radius)..=(shifted_center.z + cell_radius)
+                    {
+                        let cell = super::SpatialCell {
+                            x: cell_x,
+                            z: cell_z,
+                        };
 
-                    let Some(cell_player_ids) = cells.get(&cell) else {
-                        continue;
-                    };
-
-                    for player_id in cell_player_ids {
-                        let Some(player) = players.get(player_id) else {
+                        let Some(cell_player_ids) = cells.get(&cell) else {
                             continue;
                         };
 
-                        if player.floor_level == floor_level
-                            && position.dist_xz_sq(&player.position) <= radius_sq
-                        {
-                            player_ids.insert(*player_id);
+                        for player_id in cell_player_ids {
+                            let Some(player) = players.get(player_id) else {
+                                continue;
+                            };
+
+                            if player.floor_level == floor_level
+                                && position.dist_xz_sq(&player.position) <= radius_sq
+                            {
+                                player_ids.insert(*player_id);
+                            }
                         }
                     }
                 }

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -396,6 +396,34 @@ async fn player_aoi_crosses_world_x_seam() {
 }
 
 #[tokio::test]
+async fn player_aoi_crosses_world_z_seam() {
+    let game_state = make_test_game_state("player_aoi_z_wrap");
+    let south_id = pid("south_player");
+    let north_id = pid("north_player");
+
+    game_state
+        .add_player(make_player(
+            "south_player",
+            0.0,
+            onlinerpg_shared::WORLD_MAX_Z - 1.0,
+        ))
+        .await;
+    game_state
+        .add_player(make_player(
+            "north_player",
+            0.0,
+            onlinerpg_shared::WORLD_MIN_Z + 1.0,
+        ))
+        .await;
+
+    let nearby = game_state
+        .player_ids_within(&south_id, onlinerpg_shared::NPC_SIGHT_RADIUS)
+        .await;
+    assert!(nearby.contains(&south_id));
+    assert!(nearby.contains(&north_id));
+}
+
+#[tokio::test]
 async fn movement_into_aoi_sends_existing_monsters_and_ground_items() {
     let game_state = make_test_game_state("movement_world_entity_aoi");
     let player_id = pid("walker");

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -154,7 +154,7 @@ impl super::GameState {
         let def = trader_def_by_name(&npc.name).ok_or("This NPC does not trade")?;
 
         let dx = onlinerpg_shared::shortest_world_delta_x(npc.position.x, player.position.x);
-        let dz = player.position.z - npc.position.z;
+        let dz = onlinerpg_shared::shortest_world_delta_z(npc.position.z, player.position.z);
         if dx * dx + dz * dz > MAX_TRADE_DISTANCE * MAX_TRADE_DISTANCE {
             return Err("Too far away to trade");
         }
@@ -217,7 +217,8 @@ impl super::GameState {
                 (Some(npc), Some(target)) => {
                     let dx =
                         onlinerpg_shared::shortest_world_delta_x(target.position.x, npc.position.x);
-                    let dz = npc.position.z - target.position.z;
+                    let dz =
+                        onlinerpg_shared::shortest_world_delta_z(target.position.z, npc.position.z);
                     if dx * dx + dz * dz > MAX_TRADE_DISTANCE * MAX_TRADE_DISTANCE {
                         Err("the player is too far away to trade — ask them to come closer")
                     } else {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -32,9 +32,9 @@ pub use messages::{
     ActiveDeal, ClientMessage, DealKind, ServerMessage,
 };
 pub use world::{
-    shortest_world_delta_x, wrap_world_x, GameDateTime, NoSpawnZone, Position,
-    EVENT_DELIVERY_RADIUS, NPC_SIGHT_RADIUS, PLAYER_MOVE_SPEED, WORLD_MAX_X, WORLD_MIN_X,
-    WORLD_WIDTH_X,
+    shortest_world_delta_x, shortest_world_delta_z, wrap_world_x, wrap_world_z, GameDateTime,
+    NoSpawnZone, Position, EVENT_DELIVERY_RADIUS, NPC_SIGHT_RADIUS, PLAYER_MOVE_SPEED, WORLD_MAX_X,
+    WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, WORLD_WIDTH_X, WORLD_WIDTH_Z,
 };
 
 #[cfg(test)]

--- a/shared/src/monster_ai/behavior.rs
+++ b/shared/src/monster_ai/behavior.rs
@@ -8,6 +8,7 @@ use super::{
     DEFAULT_LEASH_RANGE, DEFAULT_MAX_MOVE_DIST, DEFAULT_MIN_MOVE_DIST, DEFAULT_PATH_RECALC_MS,
     DEFAULT_RETURN_ARRIVE_DIST, DEFAULT_TARGET_MOVE_THRESHOLD, FLEE_SAFE_DIST_MARGIN,
 };
+use crate::world::{shortest_world_delta_x, shortest_world_delta_z};
 use crate::MonsterState;
 use rand::Rng;
 use std::collections::HashMap;
@@ -85,8 +86,8 @@ impl MonsterBrain {
             }
             "is_beyond_leash" => {
                 let range = param(params, "range", DEFAULT_LEASH_RANGE);
-                let dx = self.position.x - self.spawn_position.x;
-                let dz = self.position.z - self.spawn_position.z;
+                let dx = shortest_world_delta_x(self.spawn_position.x, self.position.x);
+                let dz = shortest_world_delta_z(self.spawn_position.z, self.position.z);
                 (self.state == AiState::Return || dx * dx + dz * dz > range * range).into()
             }
             "health_below_ratio" => {
@@ -171,8 +172,8 @@ impl MonsterBrain {
         path_provider: &dyn PathProvider,
     ) -> BehaviorStatus {
         let arrive_dist = param(params, "arriveDist", DEFAULT_RETURN_ARRIVE_DIST);
-        let dx = self.spawn_position.x - self.position.x;
-        let dz = self.spawn_position.z - self.position.z;
+        let dx = shortest_world_delta_x(self.position.x, self.spawn_position.x);
+        let dz = shortest_world_delta_z(self.position.z, self.spawn_position.z);
         if dx * dx + dz * dz <= arrive_dist * arrive_dist {
             self.transition_to_idle(commands);
             return BehaviorStatus::Success;
@@ -279,8 +280,8 @@ impl MonsterBrain {
             None => return BehaviorStatus::Failure,
         };
 
-        let dx = target.position.x - self.position.x;
-        let dz = target.position.z - self.position.z;
+        let dx = shortest_world_delta_x(self.position.x, target.position.x);
+        let dz = shortest_world_delta_z(self.position.z, target.position.z);
         let range = param(params, "range", self.attack_range);
         if dx * dx + dz * dz > range * range {
             return BehaviorStatus::Failure;

--- a/shared/src/monster_ai/movement.rs
+++ b/shared/src/monster_ai/movement.rs
@@ -3,6 +3,7 @@
 //! the next waypoint.
 
 use super::{AiCommand, AiState, MonsterBrain, PathProvider};
+use crate::world::{shortest_world_delta_x, shortest_world_delta_z, wrap_world_x, wrap_world_z};
 use crate::Position;
 use rand::Rng;
 
@@ -101,8 +102,8 @@ impl MonsterBrain {
     /// blocked. Leaves `waypoints` empty when no path is available.
     pub(super) fn start_flee_path(&mut self, safe_dist: f32, path_provider: &dyn PathProvider) {
         if let Some(threat) = self.last_known_target_pos {
-            let dx = self.position.x - threat.x;
-            let dz = self.position.z - threat.z;
+            let dx = shortest_world_delta_x(threat.x, self.position.x);
+            let dz = shortest_world_delta_z(threat.z, self.position.z);
             let dist = (dx * dx + dz * dz).sqrt();
             if dist > f32::EPSILON {
                 let dest_x = self.position.x + dx / dist * safe_dist;
@@ -140,8 +141,8 @@ impl MonsterBrain {
 
     pub(super) fn face_first_waypoint(&mut self) {
         if let Some(wp) = self.waypoints.first() {
-            let wdx = wp.x - self.position.x;
-            let wdz = wp.z - self.position.z;
+            let wdx = shortest_world_delta_x(self.position.x, wp.x);
+            let wdz = shortest_world_delta_z(self.position.z, wp.z);
             self.rotation = wdx.atan2(wdz);
         }
     }
@@ -152,6 +153,11 @@ impl MonsterBrain {
         goal_z: f32,
         path_provider: &dyn PathProvider,
     ) {
+        // Unwrap the goal next to the monster so the non-periodic A* sees a
+        // short local segment instead of a world-spanning one when the goal
+        // sits across a seam.
+        let goal_x = self.position.x + shortest_world_delta_x(self.position.x, goal_x);
+        let goal_z = self.position.z + shortest_world_delta_z(self.position.z, goal_z);
         let result = path_provider.find_path(
             self.position.x,
             self.position.z,
@@ -172,14 +178,14 @@ impl MonsterBrain {
         }
 
         let wp = &self.waypoints[self.current_waypoint_idx];
-        let dx = wp.x - self.position.x;
-        let dz = wp.z - self.position.z;
+        let dx = shortest_world_delta_x(self.position.x, wp.x);
+        let dz = shortest_world_delta_z(self.position.z, wp.z);
         let dist = (dx * dx + dz * dz).sqrt();
         let step = self.move_speed * delta_ms / 1000.0;
 
         if dist <= step {
-            self.position.x = wp.x;
-            self.position.z = wp.z;
+            self.position.x = wrap_world_x(wp.x);
+            self.position.z = wrap_world_z(wp.z);
             self.current_waypoint_idx += 1;
 
             if self.current_waypoint_idx >= self.waypoints.len() {
@@ -187,14 +193,14 @@ impl MonsterBrain {
             }
 
             let next = &self.waypoints[self.current_waypoint_idx];
-            let ndx = next.x - self.position.x;
-            let ndz = next.z - self.position.z;
+            let ndx = shortest_world_delta_x(self.position.x, next.x);
+            let ndz = shortest_world_delta_z(self.position.z, next.z);
             self.rotation = ndx.atan2(ndz);
         } else {
             let nx = dx / dist;
             let nz = dz / dist;
-            self.position.x += nx * step;
-            self.position.z += nz * step;
+            self.position.x = wrap_world_x(self.position.x + nx * step);
+            self.position.z = wrap_world_z(self.position.z + nz * step);
             self.rotation = dx.atan2(dz);
         }
 
@@ -209,8 +215,8 @@ impl MonsterBrain {
         match &self.last_known_target_pos {
             None => true,
             Some(last) => {
-                let dx = target_pos.x - last.x;
-                let dz = target_pos.z - last.z;
+                let dx = shortest_world_delta_x(last.x, target_pos.x);
+                let dz = shortest_world_delta_z(last.z, target_pos.z);
                 (dx * dx + dz * dz) > threshold * threshold
             }
         }

--- a/shared/src/monster_ai/tests.rs
+++ b/shared/src/monster_ai/tests.rs
@@ -656,3 +656,44 @@ fn attack_command_uses_monster_cooldown() {
         .iter()
         .any(|c| matches!(c, AiCommand::Attack { .. })));
 }
+
+/// PathProvider that records the goal it was asked for.
+struct RecordingPath(std::cell::Cell<(f32, f32)>);
+impl PathProvider for RecordingPath {
+    fn find_path(&self, _sx: f32, _sz: f32, _sf: u8, gx: f32, gz: f32, gf: u8) -> PathResult {
+        self.0.set((gx, gz));
+        PathResult {
+            waypoints: vec![PathWaypoint {
+                x: gx,
+                z: gz,
+                floor: gf,
+            }],
+            found: true,
+        }
+    }
+}
+
+#[test]
+fn compute_path_unwraps_goal_across_z_seam() {
+    use crate::{WORLD_MAX_Z, WORLD_MIN_Z};
+    let mut brain = make_brain();
+    brain.position.z = WORLD_MAX_Z - 2.0;
+    // Goal canonically sits just across the Z seam — a few meters away on
+    // the torus, half a world away in raw coordinates.
+    let goal_z = WORLD_MIN_Z + 2.0;
+    let recorder = RecordingPath(std::cell::Cell::new((0.0, 0.0)));
+    brain.compute_path(brain.position.x, goal_z, &recorder);
+    let (_, asked_z) = recorder.0.get();
+    assert!(
+        (asked_z - (WORLD_MAX_Z + 2.0)).abs() < 1e-3,
+        "goal must be unwrapped next to the monster, got z={asked_z}"
+    );
+    // Following the path snaps onto the wrapped canonical position.
+    let done = brain.follow_path(10_000_000.0);
+    assert!(done);
+    assert!(
+        (brain.position.z - goal_z).abs() < 1e-3,
+        "snapped position must be canonical, got z={}",
+        brain.position.z
+    );
+}

--- a/shared/src/world.rs
+++ b/shared/src/world.rs
@@ -5,7 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
-/// East-west circumference of the baked world, in meters.
+/// East-west circumference of the baked world, in meters. The world is a
+/// torus: the north-south circumference is identical.
 pub const WORLD_WIDTH_X: f32 = 32_768.0;
 /// West edge of the first baked terrain tile. Tile -256 is centered at
 /// -16,384 and extends another half tile west.
@@ -14,6 +15,10 @@ pub const WORLD_MIN_X: f32 = -16_416.0;
 /// location as `WORLD_MIN_X` and therefore belongs to the wrapped interval's
 /// exclusive end.
 pub const WORLD_MAX_X: f32 = WORLD_MIN_X + WORLD_WIDTH_X;
+/// North-south circumference and edges — same values as X (square torus).
+pub const WORLD_WIDTH_Z: f32 = WORLD_WIDTH_X;
+pub const WORLD_MIN_Z: f32 = WORLD_MIN_X;
+pub const WORLD_MAX_Z: f32 = WORLD_MIN_Z + WORLD_WIDTH_Z;
 
 /// Normalize a world X coordinate into the terrain's canonical baked range.
 #[inline]
@@ -21,7 +26,13 @@ pub fn wrap_world_x(x: f32) -> f32 {
     (x - WORLD_MIN_X).rem_euclid(WORLD_WIDTH_X) + WORLD_MIN_X
 }
 
-/// Shortest signed X offset from `from_x` to `to_x` on the cylindrical world.
+/// Z counterpart of `wrap_world_x`.
+#[inline]
+pub fn wrap_world_z(z: f32) -> f32 {
+    (z - WORLD_MIN_Z).rem_euclid(WORLD_WIDTH_Z) + WORLD_MIN_Z
+}
+
+/// Shortest signed X offset from `from_x` to `to_x` on the toroidal world.
 #[inline]
 pub fn shortest_world_delta_x(from_x: f32, to_x: f32) -> f32 {
     let raw_delta = to_x - from_x;
@@ -33,6 +44,18 @@ pub fn shortest_world_delta_x(from_x: f32, to_x: f32) -> f32 {
     }
 }
 
+/// Z counterpart of `shortest_world_delta_x`.
+#[inline]
+pub fn shortest_world_delta_z(from_z: f32, to_z: f32) -> f32 {
+    let raw_delta = to_z - from_z;
+    let half_width = WORLD_WIDTH_Z * 0.5;
+    if raw_delta >= -half_width && raw_delta < half_width {
+        raw_delta
+    } else {
+        (raw_delta + half_width).rem_euclid(WORLD_WIDTH_Z) - half_width
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Position {
     pub x: f32,
@@ -41,10 +64,11 @@ pub struct Position {
 }
 
 impl Position {
-    /// Return this position with X normalized across the cylindrical world
-    /// seam. Y and Z are unchanged.
-    pub fn wrapped_x(mut self) -> Self {
+    /// Return this position with X and Z normalized across the world seams.
+    /// Y (height) is unchanged.
+    pub fn wrapped_xz(mut self) -> Self {
         self.x = wrap_world_x(self.x);
+        self.z = wrap_world_z(self.z);
         self
     }
 
@@ -54,10 +78,10 @@ impl Position {
     }
 
     /// Squared shortest-periodic distance in the X-Z ground plane, ignoring
-    /// height. X wraps around the world; Z remains bounded.
+    /// height. Both ground axes wrap around the torus.
     pub fn dist_xz_sq(&self, other: &Position) -> f32 {
         let dx = shortest_world_delta_x(self.x, other.x);
-        let dz = self.z - other.z;
+        let dz = shortest_world_delta_z(self.z, other.z);
         dx * dx + dz * dz
     }
 }
@@ -72,6 +96,33 @@ mod tests {
         assert_eq!(wrap_world_x(WORLD_MAX_X), WORLD_MIN_X);
         assert_eq!(wrap_world_x(WORLD_MAX_X + 0.25), WORLD_MIN_X + 0.25);
         assert_eq!(wrap_world_x(WORLD_MIN_X - 0.25), WORLD_MAX_X - 0.25);
+    }
+
+    #[test]
+    fn world_z_wraps_at_baked_terrain_edges() {
+        assert_eq!(wrap_world_z(WORLD_MIN_Z), WORLD_MIN_Z);
+        assert_eq!(wrap_world_z(WORLD_MAX_Z), WORLD_MIN_Z);
+        assert_eq!(wrap_world_z(WORLD_MAX_Z + 0.25), WORLD_MIN_Z + 0.25);
+        assert_eq!(wrap_world_z(WORLD_MIN_Z - 0.25), WORLD_MAX_Z - 0.25);
+    }
+
+    #[test]
+    fn world_z_distance_uses_short_path_across_seam() {
+        assert_eq!(
+            shortest_world_delta_z(WORLD_MAX_Z - 1.0, WORLD_MIN_Z + 1.0),
+            2.0
+        );
+        let north = Position {
+            x: 4.0,
+            y: 0.0,
+            z: WORLD_MIN_Z + 1.0,
+        };
+        let south = Position {
+            x: 7.0,
+            y: 99.0,
+            z: WORLD_MAX_Z - 1.0,
+        };
+        assert_eq!(north.dist_xz_sq(&south), 13.0);
     }
 
     #[test]
@@ -129,17 +180,20 @@ pub struct NoSpawnZone {
 }
 
 impl NoSpawnZone {
+    /// Periodic containment: the query point is folded relative to the
+    /// rect's min corner, so a zone whose unwrapped extent crosses a world
+    /// seam (max stored past min by the true width) still matches points
+    /// on the far side.
     pub fn contains(&self, x: f32, z: f32) -> bool {
-        x >= self.min_x && x <= self.max_x && z >= self.min_z && z <= self.max_z
+        self.contains_with_margin(x, z, 0.0)
     }
 
     /// Like `contains`, but with the rectangle expanded by `margin` on all
     /// sides — used to keep spawns clear of the area *around* a town too.
     pub fn contains_with_margin(&self, x: f32, z: f32, margin: f32) -> bool {
-        x >= self.min_x - margin
-            && x <= self.max_x + margin
-            && z >= self.min_z - margin
-            && z <= self.max_z + margin
+        let lx = (x - (self.min_x - margin)).rem_euclid(WORLD_WIDTH_X);
+        let lz = (z - (self.min_z - margin)).rem_euclid(WORLD_WIDTH_Z);
+        lx <= self.max_x - self.min_x + margin * 2.0 && lz <= self.max_z - self.min_z + margin * 2.0
     }
 }
 

--- a/shared/src/worldgen/coasts.rs
+++ b/shared/src/worldgen/coasts.rs
@@ -4,15 +4,14 @@
 //! Each 2×2 cell window of the land mask is classified into one of 16
 //! Marching Squares cases, emitting 0–2 line segments inside the window.
 //! Adjacent segments share endpoints exactly (cell-edge midpoints), so
-//! chaining them by endpoint yields closed loops (around islands and
-//! continents) and open polylines (those whose endpoints touch the world's
-//! Y border, which doesn't wrap).
+//! chaining them by endpoint yields closed loops. On the torus every
+//! contour closes — there is no world border for a chain to terminate at.
 //!
 //! Output vertex coordinates are in **cell-coord half-integer space** —
 //! every vertex sits on the midpoint between two adjacent cell centers, so
-//! its X or Y component is always either an integer or `n + 0.5`. X is
-//! wrap-aware: a polyline edge whose two endpoints differ by more than
-//! `res/2` in X crosses the world's east-west seam (downstream consumers
+//! its X or Y component is always either an integer or `n + 0.5`. Both
+//! axes are wrap-aware: a polyline edge whose two endpoints differ by more
+//! than `res/2` in X or Y crosses a world seam (downstream consumers
 //! handle the seam-split themselves).
 //!
 //! Saddle cases (5, 10) are resolved as **disjoint** contours — the two
@@ -28,8 +27,9 @@ use std::collections::HashMap;
 pub struct CoastPolyline {
     pub points: Vec<[f32; 2]>,
     /// `true` if the chain is a closed loop (e.g. an island), in which case
-    /// `points.first() == points.last()`. `false` for open chains terminating
-    /// at the world's Y border.
+    /// `points.first() == points.last()`. On the torus every well-formed
+    /// contour closes; `false` survives only as a defensive marker for
+    /// degenerate input.
     pub closed: bool,
 }
 
@@ -92,10 +92,9 @@ fn trace_chain(
 
 /// Extract coastline polylines from a binary land mask.
 ///
-/// `land_mask[y * res + x]` is `1` for land, `0` for sea. X wraps; Y doesn't.
-/// Returns one `CoastPolyline` per maximal chain of segments. Closed loops
-/// surround islands or continents (not touching the Y border); open
-/// polylines start and end at the top or bottom edge of the world.
+/// `land_mask[y * res + x]` is `1` for land, `0` for sea. Both axes wrap.
+/// Returns one `CoastPolyline` per maximal chain of segments; every chain
+/// is a closed loop around an island, a continent, or the world itself.
 pub fn extract_coasts(land_mask: &[u8], res: usize) -> Vec<CoastPolyline> {
     if res < 2 {
         return Vec::new();
@@ -105,22 +104,32 @@ pub fn extract_coasts(land_mask: &[u8], res: usize) -> Vec<CoastPolyline> {
     let mut segs: Vec<[i64; 2]> = Vec::new();
     let mut adj: HashMap<i64, Vec<u32>> = HashMap::new();
 
-    for gy in 0..(res - 1) {
+    for gy in 0..res {
         let gy_i = gy as i32;
+        let gy1 = if gy + 1 == res { 0 } else { gy + 1 };
         for gx in 0..res {
             let gx_i = gx as i32;
             let gx1 = if gx + 1 == res { 0 } else { gx + 1 };
             let tl = land_mask[gy * res + gx] & 1;
             let tr = land_mask[gy * res + gx1] & 1;
-            let bl = land_mask[(gy + 1) * res + gx] & 1;
-            let br = land_mask[(gy + 1) * res + gx1] & 1;
+            let bl = land_mask[gy1 * res + gx] & 1;
+            let br = land_mask[gy1 * res + gx1] & 1;
             let case = (tl << 3) | (tr << 2) | (br << 1) | bl;
 
-            // Edge midpoint vertex keys (vx_2x, vy_2x), X wrapped.
+            // Edge midpoint vertex keys (vx_2x, vy_2x), both axes wrapped.
             let v_t = vkey((gx_i * 2 + 1).rem_euclid(two_res), gy_i * 2);
-            let v_r = vkey((gx_i * 2 + 2).rem_euclid(two_res), gy_i * 2 + 1);
-            let v_b = vkey((gx_i * 2 + 1).rem_euclid(two_res), gy_i * 2 + 2);
-            let v_l = vkey((gx_i * 2).rem_euclid(two_res), gy_i * 2 + 1);
+            let v_r = vkey(
+                (gx_i * 2 + 2).rem_euclid(two_res),
+                (gy_i * 2 + 1).rem_euclid(two_res),
+            );
+            let v_b = vkey(
+                (gx_i * 2 + 1).rem_euclid(two_res),
+                (gy_i * 2 + 2).rem_euclid(two_res),
+            );
+            let v_l = vkey(
+                (gx_i * 2).rem_euclid(two_res),
+                (gy_i * 2 + 1).rem_euclid(two_res),
+            );
 
             match case {
                 0 | 15 => {}
@@ -154,10 +163,10 @@ pub fn extract_coasts(land_mask: &[u8], res: usize) -> Vec<CoastPolyline> {
     let mut visited = vec![false; segs.len()];
     let mut out: Vec<CoastPolyline> = Vec::new();
 
-    // 1) Open chains first: start at any vertex with valence 1 (only one
-    // segment touches it), which only happens at the Y border where the
-    // marching-squares scan stops short. Sort the start keys for
-    // determinism — HashMap iteration order is otherwise hash-randomized.
+    // 1) Open chains first: start at any vertex with valence 1. On the
+    // torus this shouldn't occur (every contour closes), but the pass stays
+    // as a cheap defensive net for degenerate input. Sort the start keys
+    // for determinism — HashMap iteration is otherwise hash-randomized.
     let mut open_starts: Vec<i64> = adj
         .iter()
         .filter_map(|(&k, v)| if v.len() == 1 { Some(k) } else { None })
@@ -231,13 +240,13 @@ mod tests {
         );
     }
 
-    /// Open chain at the Y border:
+    /// A block touching row res-1 wraps around to row 0's sea and closes:
     ///   . . . .
     ///   . . . .
     ///   . # # .
-    ///   . # # .   <-- bottom row touches Y=res-1, so the chain is open
+    ///   . # # .   <-- bottom row wraps to the top row's sea
     #[test]
-    fn block_against_y_border_opens_chain() {
+    fn block_at_y_seam_still_closes() {
         let res = 4;
         #[rustfmt::skip]
         let mask: Vec<u8> = vec![
@@ -250,9 +259,37 @@ mod tests {
         assert_eq!(coasts.len(), 1);
         let poly = &coasts[0];
         assert!(
-            !poly.closed,
-            "block touching Y border must produce an open chain"
+            poly.closed,
+            "block at the Y seam must close across the wrap"
         );
+        assert_eq!(
+            poly.points.first(),
+            poly.points.last(),
+            "closed loop must start == end"
+        );
+    }
+
+    /// Y-wrap: a vertical land strip wrapping the seam should produce two
+    /// closed loops (left and right edges of the strip), each going around
+    /// the world in Y.
+    #[test]
+    fn y_wrap_strip_closes_around_world() {
+        let res = 4;
+        // Middle two columns are all land; left and right columns all sea.
+        #[rustfmt::skip]
+        let mask: Vec<u8> = vec![
+            0,1,1,0,
+            0,1,1,0,
+            0,1,1,0,
+            0,1,1,0,
+        ];
+        let coasts = extract_coasts(&mask, res);
+        assert_eq!(coasts.len(), 2, "vertical strip → 2 closed loops");
+        for poly in &coasts {
+            assert!(poly.closed);
+            // 4 segments around the world (one per Y cell), closed → 5 points.
+            assert_eq!(poly.points.len(), 5);
+        }
     }
 
     /// X-wrap: a horizontal land strip wrapping the seam should produce two

--- a/shared/src/worldgen/config.rs
+++ b/shared/src/worldgen/config.rs
@@ -166,15 +166,6 @@ pub struct WorldGenConfig {
     /// classic red-noise mountain ranges.
     pub initial_relief_gain: f32,
 
-    /// Number of cells of the north/south border where land is boosted
-    /// toward `max_elevation_m` to form an impassable mountain wall (since
-    /// Y doesn't wrap). 0 = disabled.
-    pub y_border_wall_cells: u32,
-
-    /// Peak height of the Y-border mountain wall, in meters. Typically
-    /// close to `max_elevation_m` so the wall reliably blocks traversal.
-    pub y_border_wall_height_m: f32,
-
     // --- Phase 3: hydraulic erosion (dandrino simulation) ----------------
     // Faithful port of https://github.com/dandrino/terrain-erosion-3-ways
     // simulation.py. Terrain is internally normalized to [0, 1] (= [0,
@@ -396,13 +387,6 @@ pub struct WorldGenConfig {
     /// so islands and along-road villages aren't starved.
     pub settlement_phase_a_spacing_mult: f32,
 
-    /// Settlements within this distance (meters) of the south map edge are
-    /// rejected. The southern strip is dominated by the Y-border wall and
-    /// reads as polar terrain; villages clustered there look out of place.
-    /// 0 = disabled. North edge is unaffected (the wall ramp on the north
-    /// side currently blocks placement on its own).
-    pub settlement_south_edge_exclusion_m: f32,
-
     /// Maximum allowable distance (meters) from any habitable cell to its
     /// nearest settlement. After Phases A-C run, a coverage-fill pass adds
     /// settlements at the most isolated habitable cells until every cell
@@ -475,8 +459,6 @@ impl Default for WorldGenConfig {
             initial_relief_wavelength_cells: 700.0,
             initial_relief_octaves: 6,
             initial_relief_gain: 0.5,
-            y_border_wall_cells: 16,
-            y_border_wall_height_m: 2200.0,
             // Erosion: dandrino simulation.py defaults. sim_res 1024 keeps
             // a single preview under ~1 min on a typical workstation while
             // matching dandrino's visual style.
@@ -553,7 +535,6 @@ impl Default for WorldGenConfig {
             settlement_coastal_spacing_mult: 1.6,
             settlement_mouth_count: 500,
             settlement_phase_a_spacing_mult: 2.0,
-            settlement_south_edge_exclusion_m: 1700.0,
             settlement_max_gap_m: 4000.0,
             river_gap_max_m: 3500.0,
             road_extra_neighbors: 5,
@@ -589,7 +570,7 @@ impl WorldGenConfig {
     }
 
     /// Convert a frequency declared in cycles-per-reference-cell to the
-    /// per-actual-cell frequency consumed by `fbm_wrap_x` etc.
+    /// per-actual-cell frequency consumed by `fbm_wrap_xy` etc.
     pub fn scaled_freq(&self, ref_freq: f32) -> f32 {
         ref_freq / self.res_scale()
     }

--- a/shared/src/worldgen/continent.rs
+++ b/shared/src/worldgen/continent.rs
@@ -12,7 +12,7 @@
 use super::config::WorldGenConfig;
 use super::global_map::GlobalMap;
 use super::growth;
-use super::noise::{fbm_wrap_x, PerlinNoise3D};
+use super::noise::{fbm_wrap_xy, PerlinNoise4D};
 
 const CONTINENT_LACUNARITY: f32 = 2.0;
 
@@ -21,8 +21,8 @@ pub fn generate_continent_mask(config: &WorldGenConfig) -> GlobalMap {
     let res = config.global_res as usize;
     let total = res * res;
 
-    let noise = PerlinNoise3D::new(config.seed ^ 0xC00C_00C0_0C00_u64);
-    let channel_noise = PerlinNoise3D::new(config.seed ^ 0x5EAC_5EAC_5EAC_u64);
+    let noise = PerlinNoise4D::new(config.seed ^ 0xC00C_00C0_0C00_u64);
+    let channel_noise = PerlinNoise4D::new(config.seed ^ 0x5EAC_5EAC_5EAC_u64);
     let world_width = config.global_res as f32;
     let base_freq = config.scaled_freq(config.continent_frequency);
     let channel_freq = config.scaled_freq(1.0 / config.sea_channel_wavelength.max(1.0));
@@ -33,7 +33,7 @@ pub fn generate_continent_mask(config: &WorldGenConfig) -> GlobalMap {
         let yf = y as f32;
         for x in 0..res {
             let xf = x as f32;
-            let base = fbm_wrap_x(
+            let base = fbm_wrap_xy(
                 &noise,
                 xf,
                 yf,
@@ -48,7 +48,7 @@ pub fn generate_continent_mask(config: &WorldGenConfig) -> GlobalMap {
             // to a power narrows the ridge so channels feel more stroke-like
             // than blob-like.
             let ridge_bias = if channel_strength > 0.0 {
-                let n = fbm_wrap_x(
+                let n = fbm_wrap_xy(
                     &channel_noise,
                     xf,
                     yf,
@@ -118,10 +118,10 @@ pub fn generate_continent_mask(config: &WorldGenConfig) -> GlobalMap {
     }
 }
 
-/// 4-connected flood fill (X-periodic) that drops land components smaller
-/// than `min_cells`. X wrap matters here: a continent that straddles the
-/// x=0/x=res-1 boundary is a single component in a toroidal-in-X world, and
-/// must be treated as such so it doesn't get mistakenly split and culled.
+/// 4-connected flood fill on the torus that drops land components smaller
+/// than `min_cells`. Wrapping matters here: a continent that straddles a
+/// world seam is a single component and must be treated as such so it
+/// doesn't get mistakenly split and culled.
 fn remove_small_islands(mask: &mut [u8], res: usize, min_cells: usize) {
     let total = res * res;
     let mut visited = vec![false; total];
@@ -141,22 +141,19 @@ fn remove_small_islands(mask: &mut [u8], res: usize, min_cells: usize) {
             component.push(i);
             let x = i % res;
             let y = i / res;
-            // 4-connected neighbors, with X wrapped.
+            // 4-connected neighbors, both axes wrapped.
             let left = if x == 0 { res - 1 } else { x - 1 };
             let right = if x + 1 == res { 0 } else { x + 1 };
+            let up = if y == 0 { res - 1 } else { y - 1 };
+            let down = if y + 1 == res { 0 } else { y + 1 };
             let neighbors = [
                 y * res + left,
                 y * res + right,
-                if y > 0 { Some((y - 1) * res + x) } else { None }.unwrap_or(usize::MAX),
-                if y + 1 < res {
-                    Some((y + 1) * res + x)
-                } else {
-                    None
-                }
-                .unwrap_or(usize::MAX),
+                up * res + x,
+                down * res + x,
             ];
             for &n in &neighbors {
-                if n != usize::MAX && mask[n] == 1 && !visited[n] {
+                if mask[n] == 1 && !visited[n] {
                     visited[n] = true;
                     stack.push(n);
                 }
@@ -175,10 +172,7 @@ fn remove_small_islands(mask: &mut [u8], res: usize, min_cells: usize) {
 /// dilate by `radius`. Removes land features narrower than `2 * radius`
 /// while preserving thicker land's shape and coastline.
 ///
-/// X-axis wraps (consistent with the world's east-west periodicity).
-/// Y-axis does not wrap; out-of-bounds cells are treated as sea during
-/// erosion (so land touching the N/S border gets eroded along that edge,
-/// which is fine — Phase 2 turns those into mountain walls anyway).
+/// Both axes wrap (the world is a torus).
 ///
 /// Separable (row pass then column pass) for O(radius · res²) per erosion
 /// or dilation instead of O(radius² · res²).
@@ -204,19 +198,14 @@ fn erode_box(mask: &[u8], res: usize, radius: usize) -> Vec<u8> {
             h[y * res + x] = if ok { 1 } else { 0 };
         }
     }
-    // Column pass on h (Y does not wrap). Out-of-bounds Y is treated as
-    // LAND so that land adjacent to the north/south border isn't falsely
-    // eroded — those cells are expected to become Phase 2 mountain walls.
+    // Column pass on h (Y wraps).
     let mut v = vec![0u8; mask.len()];
     for y in 0..res {
         for x in 0..res {
             let mut ok = true;
             for dy in -(radius as isize)..=(radius as isize) {
-                let yy = y as isize + dy;
-                if yy < 0 || yy >= res as isize {
-                    continue;
-                }
-                if h[(yy as usize) * res + x] == 0 {
+                let yy = (y as isize + dy).rem_euclid(res as isize) as usize;
+                if h[yy * res + x] == 0 {
                     ok = false;
                     break;
                 }
@@ -243,17 +232,14 @@ fn dilate_box(mask: &[u8], res: usize, radius: usize) -> Vec<u8> {
             h[y * res + x] = if any { 1 } else { 0 };
         }
     }
-    // Column pass on h (Y does not wrap; out-of-bounds contributes nothing).
+    // Column pass on h (Y wraps).
     let mut v = vec![0u8; mask.len()];
     for y in 0..res {
         for x in 0..res {
             let mut any = false;
             for dy in -(radius as isize)..=(radius as isize) {
-                let yy = y as isize + dy;
-                if yy < 0 || yy >= res as isize {
-                    continue;
-                }
-                if h[(yy as usize) * res + x] == 1 {
+                let yy = (y as isize + dy).rem_euclid(res as isize) as usize;
+                if h[yy * res + x] == 1 {
                     any = true;
                     break;
                 }
@@ -446,8 +432,6 @@ mod tests {
             small_island_count: 0,
             small_island_radius_cells: 0,
             small_island_min_clearance_cells: 0,
-            y_border_wall_cells: 0,
-            y_border_wall_height_m: 0.0,
             river_gap_max_m: 0.0,
             ..Default::default()
         }
@@ -566,12 +550,12 @@ mod tests {
         // the world seamlessly connects east-to-west. We test this via the
         // noise function directly since the stored grid only covers
         // [0, res-1]; x=res would be written as x=0.
-        use super::super::noise::{fbm_wrap_x, PerlinNoise3D};
+        use super::super::noise::{fbm_wrap_xy, PerlinNoise4D};
         let cfg = test_config(64, 0.4);
-        let noise = PerlinNoise3D::new(cfg.seed ^ 0xC00C_00C0_0C00_u64);
+        let noise = PerlinNoise4D::new(cfg.seed ^ 0xC00C_00C0_0C00_u64);
         let world_width = cfg.global_res as f32;
         for y in 0..cfg.global_res {
-            let a = fbm_wrap_x(
+            let a = fbm_wrap_xy(
                 &noise,
                 0.0,
                 y as f32,
@@ -581,7 +565,7 @@ mod tests {
                 CONTINENT_LACUNARITY,
                 cfg.continent_gain,
             );
-            let b = fbm_wrap_x(
+            let b = fbm_wrap_xy(
                 &noise,
                 world_width,
                 y as f32,

--- a/shared/src/worldgen/elevation.rs
+++ b/shared/src/worldgen/elevation.rs
@@ -6,8 +6,6 @@
 //! else stays out of the way:
 //!
 //! * Sea cells are pinned at 0 m.
-//! * The Y-border wall (since Y doesn't wrap) is added as a max-blend
-//!   ramp toward `y_border_wall_height_m`.
 //! * Config-driven `elevation_hotspots` and `river_carve_paths` are
 //!   applied here so that art-directed peaks/channels are present in the
 //!   pre-erosion clay (and thus get eroded into shape rather than appearing
@@ -15,8 +13,8 @@
 
 use super::config::{ElevationHotspot, WorldGenConfig};
 use super::global_map::GlobalMap;
-use super::grid::{bfs_distance_extend_from_cell, bfs_distance_from, fold_x_delta_f32};
-use super::noise::{fbm_wrap_x, smoothstep, PerlinNoise, PerlinNoise3D};
+use super::grid::{bfs_distance_extend_from_cell, bfs_distance_from, fold_delta_f32};
+use super::noise::{fbm_wrap_xy, PerlinNoise, PerlinNoise4D};
 use super::rivers::{RiverMap, RIVER_PEAK_ELEVATION_FRAC};
 use super::vector_features::project_point_to_segment;
 
@@ -29,7 +27,7 @@ pub fn generate_elevation(map: &mut GlobalMap) {
     let world_width = res as f32;
 
     let seed = map.config.seed;
-    let noise = PerlinNoise3D::new(seed ^ 0xE1EE_1EE1_EE1E_u64);
+    let noise = PerlinNoise4D::new(seed ^ 0xE1EE_1EE1_EE1E_u64);
     let base_freq = map
         .config
         .scaled_freq(1.0 / map.config.initial_relief_wavelength_cells.max(1.0));
@@ -39,10 +37,6 @@ pub fn generate_elevation(map: &mut GlobalMap) {
     let max_h = map.config.max_elevation_m.max(1.0);
     let base_h = map.config.base_elevation_m.clamp(0.0, max_h);
     let relief = (map.config.initial_relief_amp.max(0.0)) * max_h;
-    let wall_cells = map
-        .config
-        .scaled_cells_usize(map.config.y_border_wall_cells);
-    let wall_h = map.config.y_border_wall_height_m;
 
     let mut elevation = vec![0.0f32; total];
     for y in 0..res {
@@ -51,7 +45,7 @@ pub fn generate_elevation(map: &mut GlobalMap) {
             if map.land_mask[i] == 0 {
                 continue;
             }
-            let n = fbm_wrap_x(
+            let n = fbm_wrap_xy(
                 &noise,
                 x as f32,
                 y as f32,
@@ -61,22 +55,7 @@ pub fn generate_elevation(map: &mut GlobalMap) {
                 LACUNARITY,
                 gain,
             );
-            let mut h = base_h + n * relief;
-
-            // Y-border mountain wall: max-blend a ramp toward `wall_h` so
-            // the impassable wall reads as a range that subsequent erosion
-            // can carve into rather than a sheer cliff.
-            if wall_cells > 0 {
-                let d_border = y.min(res - 1 - y);
-                if d_border < wall_cells {
-                    let t = 1.0 - (d_border as f32 / wall_cells as f32);
-                    let wall = smoothstep(0.0, 1.0, t) * wall_h;
-                    if wall > h {
-                        h = wall;
-                    }
-                }
-            }
-
+            let h = base_h + n * relief;
             elevation[i] = h.clamp(0.0, max_h);
         }
     }
@@ -169,12 +148,16 @@ pub(crate) fn apply_hotspots_to(
         let detail_freq = HOTSPOT_DETAIL_LOBES / r_cells;
         let r_max = r_cells * (1.0 + HOTSPOT_RADIUS_PERTURB);
         let pad = r_max.ceil() as i32 + 1;
-        let y_min = ((cy as i32) - pad).max(0) as usize;
-        let y_max = ((cy as i32) + pad).min(res as i32 - 1) as usize;
+        let y_min_i = (cy as i32) - pad;
+        let y_max_i = (cy as i32) + pad;
         let x_min_i = (cx as i32) - pad;
         let x_max_i = (cx as i32) + pad;
 
-        for y in y_min..=y_max {
+        // Unwrapped loop coords, wrapped array indices: the disk is evaluated
+        // in one continuous pass, so its local noise stays seam-free without
+        // needing periodicity.
+        for yi in y_min_i..=y_max_i {
+            let y = yi.rem_euclid(res as i32) as usize;
             for xi in x_min_i..=x_max_i {
                 let x = xi.rem_euclid(res as i32) as usize;
                 let i = y * res + x;
@@ -182,19 +165,20 @@ pub(crate) fn apply_hotspots_to(
                     continue;
                 }
                 let dx = xi as f32 - cx;
-                let dy = y as f32 - cy;
+                let dy = yi as f32 - cy;
                 let d_sq = dx * dx + dy * dy;
                 if d_sq >= r_max * r_max {
                     continue;
                 }
-                let s = shape_noise.sample(x as f32 * shape_freq, y as f32 * shape_freq);
+                let s = shape_noise.sample(xi as f32 * shape_freq, yi as f32 * shape_freq);
                 let eff_r = r_cells * (1.0 + HOTSPOT_RADIUS_PERTURB * s);
                 if d_sq >= eff_r * eff_r {
                     continue;
                 }
                 let t = 1.0 - d_sq.sqrt() / eff_r;
                 let falloff = t * t;
-                let n_detail = detail_noise.sample(x as f32 * detail_freq, y as f32 * detail_freq);
+                let n_detail =
+                    detail_noise.sample(xi as f32 * detail_freq, yi as f32 * detail_freq);
                 let modulation = 1.0 + HOTSPOT_DETAIL_AMPLITUDE * n_detail * t;
                 let boost = spot.peak_m * falloff * modulation;
                 if boost > 0.0 {
@@ -247,10 +231,6 @@ pub fn seed_river_gap_mountains(
     let max_gap_cells = (max_gap_m / mpc).round() as u16;
     let peak_m = map.config.max_elevation_m * RIVER_GAP_PEAK_FRAC;
     let lowland_thresh = map.config.max_elevation_m * RIVER_GAP_LOWLAND_FRAC;
-    let wall_margin = map
-        .config
-        .scaled_cells_usize(map.config.y_border_wall_cells)
-        * 2;
     let mut river_mask = vec![0u8; total];
     for poly in &river_map.rivers {
         for &(x, y) in &poly.points {
@@ -271,10 +251,6 @@ pub fn seed_river_gap_mountains(
             continue;
         }
         if map.elevation_m[i] >= lowland_thresh {
-            continue;
-        }
-        let iy = i / res;
-        if iy < wall_margin || iy + wall_margin >= res {
             continue;
         }
         if coast_dist[i] < coast_buffer_cells {
@@ -425,7 +401,7 @@ pub fn seed_small_island_hills(map: &mut GlobalMap) -> SmallIslandHillsOut {
         let mut max_d: u16 = 0;
         for &i in &component {
             island_cells.push(i as u32);
-            sum_dx += fold_x_delta_f32((i % res) as f32 - anchor_x, res_f);
+            sum_dx += fold_delta_f32((i % res) as f32 - anchor_x, res_f);
             sum_dy += (i / res) as f32 - anchor_y;
             let d = coast_dist[i];
             if d != u16::MAX && d > max_d {
@@ -478,8 +454,6 @@ mod tests {
             target_continent_count: 3,
             continent_gap_cells: 10,
             small_island_count: 0,
-            y_border_wall_cells: 8,
-            y_border_wall_height_m: 2200.0,
             river_gap_max_m: 0.0,
             initial_relief_wavelength_cells: (res as f32 / 4.0).max(8.0),
             ..Default::default()
@@ -512,32 +486,6 @@ mod tests {
                 "elevation {e} out of range"
             );
         }
-    }
-
-    #[test]
-    fn y_border_land_reaches_wall_height() {
-        let mut cfg = test_config(128);
-        cfg.sea_ratio = 0.1;
-        cfg.continent_gap_cells = 0;
-        cfg.target_continent_count = 1;
-        cfg.continent_seed_count = 2;
-        let mut map = continent::generate_continent_mask(&cfg);
-        generate_elevation(&mut map);
-        let res = cfg.global_res as usize;
-        let margin = cfg.y_border_wall_cells as usize;
-        let mut max_at_border = 0.0f32;
-        for y in 0..margin {
-            for x in 0..res {
-                let i = y * res + x;
-                if map.land_mask[i] == 1 && map.elevation_m[i] > max_at_border {
-                    max_at_border = map.elevation_m[i];
-                }
-            }
-        }
-        assert!(
-            max_at_border > cfg.y_border_wall_height_m * 0.5,
-            "border wall not reaching height: max {max_at_border}"
-        );
     }
 
     #[test]

--- a/shared/src/worldgen/erosion.rs
+++ b/shared/src/worldgen/erosion.rs
@@ -43,7 +43,7 @@ use rand::{Rng, SeedableRng};
 
 use super::global_map::GlobalMap;
 use super::grid::bfs_distance_from;
-use super::noise::{fbm_wrap_x, smoothstep, PerlinNoise3D};
+use super::noise::{fbm_wrap_xy, smoothstep, PerlinNoise4D};
 
 const SLIPPAGE_BLUR_SIGMA: f32 = 1.5;
 /// Subsystem salt mixed into the sim RNG so erosion's stream is independent
@@ -147,7 +147,7 @@ fn apply_min_land_floor(map: &mut GlobalMap) {
         .scaled_cells(cfg.min_land_height_noise_wavelength_cells)
         .max(1.0);
     let freq = 1.0 / wavelength;
-    let noise = PerlinNoise3D::new(cfg.seed ^ MIN_LAND_FLOOR_NOISE_SALT);
+    let noise = PerlinNoise4D::new(cfg.seed ^ MIN_LAND_FLOOR_NOISE_SALT);
 
     let res = cfg.global_res as usize;
     let world_width = res as f32;
@@ -159,7 +159,7 @@ fn apply_min_land_floor(map: &mut GlobalMap) {
             }
             // Half-amplitude noise in [-1, 1] → modulation in [-amp/2, +amp/2]
             // so peak-to-peak is `amp` as documented.
-            let n = fbm_wrap_x(&noise, x as f32, y as f32, world_width, freq, 1, 2.0, 0.5);
+            let n = fbm_wrap_xy(&noise, x as f32, y as f32, world_width, freq, 1, 2.0, 0.5);
             let floor = min_h + n * amp * 0.5;
             if map.elevation_m[i] < floor {
                 map.elevation_m[i] = floor;
@@ -231,7 +231,7 @@ fn apply_coast_beach_ramp(map: &mut GlobalMap) {
 
     let res = cfg.global_res as usize;
     let dist = bfs_distance_from(&map.land_mask, res, 0, None);
-    let cliff_noise = PerlinNoise3D::new(cfg.seed ^ COAST_CLIFF_NOISE_SALT);
+    let cliff_noise = PerlinNoise4D::new(cfg.seed ^ COAST_CLIFF_NOISE_SALT);
     let world_width = res as f32;
 
     for y in 0..res {
@@ -247,7 +247,7 @@ fn apply_coast_beach_ramp(map: &mut GlobalMap) {
             // Slow X-wrapped noise on the world grid: clusters adjacent
             // coast cells into homogenous beach- or cliff-classified
             // stretches, so the pattern doesn't dither cell-by-cell.
-            let n = fbm_wrap_x(
+            let n = fbm_wrap_xy(
                 &cliff_noise,
                 x as f32,
                 y as f32,
@@ -434,7 +434,7 @@ fn compute_gradient(
     }
 }
 
-/// Central-difference of `field` at `(x, y)`, X-wrapping, Y-clamping.
+/// Central-difference of `field` at `(x, y)`, both axes wrapping.
 /// Returns the unscaled `(left-right, up-down)/2` so callers apply their
 /// own per-cell-width or normalization step.
 #[inline]
@@ -443,8 +443,8 @@ fn central_diff(field: &[f32], res: usize, x: usize, y: usize) -> (f32, f32) {
     let last = res - 1;
     let xl = ((x as i32 - 1).rem_euclid(res_i)) as usize;
     let xr = ((x as i32 + 1).rem_euclid(res_i)) as usize;
-    let yu = if y == 0 { 0 } else { y - 1 };
-    let yd = if y == last { last } else { y + 1 };
+    let yu = if y == 0 { last } else { y - 1 };
+    let yd = if y == last { 0 } else { y + 1 };
     let dx = 0.5 * (field[y * res + xl] - field[y * res + xr]);
     let dy = 0.5 * (field[yu * res + x] - field[yd * res + x]);
     (dx, dy)
@@ -517,8 +517,8 @@ fn displace(src: &[f32], gx: &[f32], gy: &[f32], res: usize, dst: &mut [f32]) {
     let res_i = res as i32;
     let last = res - 1;
     for y in 0..res {
-        let ym = if y == 0 { 0 } else { y - 1 };
-        let yp = if y == last { last } else { y + 1 };
+        let ym = if y == 0 { last } else { y - 1 };
+        let yp = if y == last { 0 } else { y + 1 };
         for x in 0..res {
             let i = y * res + x;
             let v = src[i];
@@ -656,8 +656,8 @@ fn bilinear_sample(field: &[f32], res: usize, fx: f32, fy: f32) -> f32 {
     let res_i = res as i32;
     let ix0 = ix.rem_euclid(res_i) as usize;
     let ix1 = (ix + 1).rem_euclid(res_i) as usize;
-    let iy0 = iy.clamp(0, res_i - 1) as usize;
-    let iy1 = (iy + 1).clamp(0, res_i - 1) as usize;
+    let iy0 = iy.rem_euclid(res_i) as usize;
+    let iy1 = (iy + 1).rem_euclid(res_i) as usize;
     let v00 = field[iy0 * res + ix0];
     let v10 = field[iy0 * res + ix1];
     let v01 = field[iy1 * res + ix0];
@@ -701,13 +701,13 @@ fn gaussian_blur(src: &[f32], res: usize, kernel: &[f32], tmp: &mut [f32], dst: 
             tmp[row + x] = s;
         }
     }
-    // Vertical pass (Y clamps).
+    // Vertical pass (Y wraps).
     for y in 0..res {
         for x in 0..res {
             let mut s = 0.0f32;
             for (k_idx, &w) in kernel.iter().enumerate() {
                 let dy = k_idx as i32 - radius as i32;
-                let yi = (y as i32 + dy).clamp(0, res_i - 1) as usize;
+                let yi = (y as i32 + dy).rem_euclid(res_i) as usize;
                 s += w * tmp[yi * res + x];
             }
             dst[y * res + x] = s;
@@ -835,8 +835,6 @@ mod tests {
             target_continent_count: 1,
             continent_gap_cells: 0,
             small_island_count: 0,
-            y_border_wall_cells: 0,
-            y_border_wall_height_m: 0.0,
             // Run the sim at the test resolution (skip downsample) and use a
             // small iteration count so the test finishes quickly.
             erosion_sim_res: res,
@@ -941,12 +939,6 @@ mod tests {
         let mut gx = vec![0.0f32; total];
         let mut gy = vec![0.0f32; total];
         for i in 0..total {
-            // Restrict gradients to interior cells so Y-boundary clamping
-            // doesn't spuriously dump mass on the edges.
-            let y = i / res;
-            if y == 0 || y + 1 >= res {
-                continue;
-            }
             let a = rng.gen::<f32>() * std::f32::consts::TAU;
             gx[i] = a.cos() * 0.7;
             gy[i] = a.sin() * 0.7;

--- a/shared/src/worldgen/grass_patches.rs
+++ b/shared/src/worldgen/grass_patches.rs
@@ -7,18 +7,18 @@
 //! stronger patch wins (ties broken to primary).
 //!
 //! Seeds are derived on demand from `(master_seed, layer_salt, gx, gz)` via
-//! `SmallRng` — no seed table. The X axis wraps (`rem_euclid` on the grid
-//! index, wrap-aware Euclidean distance); Z does not.
+//! `SmallRng` — no seed table. Both axes wrap (`rem_euclid` on the grid
+//! indices, wrap-aware Euclidean distance) to match the toroidal world.
 
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-use super::noise::{fbm_wrap_x, smoothstep, PerlinNoise3D};
+use super::noise::{fbm_wrap_xy, smoothstep, PerlinNoise4D};
 
 #[derive(Clone, Copy)]
 struct LayerCfg {
     /// Target grid spacing (m). World width is rounded to an integer count
-    /// of cells so the X-wrap seam lands on a cell edge.
+    /// of cells so the wrap seams land on cell edges.
     target_grid_m: f32,
     radius_mean_m: f32,
     /// `actual_radius = mean * (1 + jitter * R)`, R uniform in [-1, 1].
@@ -94,8 +94,8 @@ impl LayerGrid {
 }
 
 pub struct GrassPatchField {
-    warp_x: PerlinNoise3D,
-    warp_y: PerlinNoise3D,
+    warp_x: PerlinNoise4D,
+    warp_y: PerlinNoise4D,
     world_size_m: f32,
     world_half: f32,
     master_seed: u64,
@@ -106,8 +106,8 @@ pub struct GrassPatchField {
 impl GrassPatchField {
     pub fn new(master_seed: u64, world_size_m: f32) -> Self {
         Self {
-            warp_x: PerlinNoise3D::new(master_seed ^ 0x6B61_7373_0001_0001),
-            warp_y: PerlinNoise3D::new(master_seed ^ 0x6B61_7373_0001_0002),
+            warp_x: PerlinNoise4D::new(master_seed ^ 0x6B61_7373_0001_0001),
+            warp_y: PerlinNoise4D::new(master_seed ^ 0x6B61_7373_0001_0002),
             world_size_m,
             world_half: world_size_m * 0.5,
             master_seed,
@@ -122,8 +122,8 @@ impl GrassPatchField {
         let nz = wz + self.world_half;
         // Shared warp coords; only the noise field differs between axes. The
         // fBm calls are the dominant per-cell cost.
-        let warp = |field: &PerlinNoise3D| {
-            fbm_wrap_x(
+        let warp = |field: &PerlinNoise4D| {
+            fbm_wrap_xy(
                 field,
                 nx,
                 nz,
@@ -160,18 +160,16 @@ impl GrassPatchField {
         for ogz in -1..=1 {
             for ogx in -1..=1 {
                 let sgx = (gx0 + ogx).rem_euclid(layer.grid_count);
-                let sgz = gz0 + ogz;
-                if sgz < 0 || sgz >= layer.grid_count {
-                    continue;
-                }
+                let sgz = (gz0 + ogz).rem_euclid(layer.grid_count);
                 let Some(seed) = self.seed_at(layer, grid_m, sgx, sgz) else {
                     continue;
                 };
 
                 let dx_raw = (qx - seed.wx).abs();
                 let dx_w = dx_raw.min(self.world_size_m - dx_raw);
-                let ddz = qz - seed.wz;
-                let d_sq = dx_w * dx_w + ddz * ddz;
+                let dz_raw = (qz - seed.wz).abs();
+                let dz_w = dz_raw.min(self.world_size_m - dz_raw);
+                let d_sq = dx_w * dx_w + dz_w * dz_w;
 
                 if d_sq >= seed.radius * seed.radius {
                     continue;
@@ -314,6 +312,26 @@ mod tests {
                 right.strength
             );
             assert_eq!(left.is_tall, right.is_tall);
+        }
+    }
+
+    #[test]
+    fn z_wrap_continuity() {
+        // The world is toroidal — the Z seam must not show a discontinuity
+        // either.
+        let world = 1024.0;
+        let field = GrassPatchField::new(42, world);
+        for i in 0..16 {
+            let x = (i as f32 - 8.0) * 50.0;
+            let north = field.sample(x, -world * 0.5);
+            let south = field.sample(x, world * 0.5);
+            assert!(
+                (north.strength - south.strength).abs() < 1e-4,
+                "z-seam discontinuity at x={x}: {} vs {}",
+                north.strength,
+                south.strength
+            );
+            assert_eq!(north.is_tall, south.is_tall);
         }
     }
 

--- a/shared/src/worldgen/grid.rs
+++ b/shared/src/worldgen/grid.rs
@@ -1,8 +1,8 @@
 //! Small grid-topology helpers shared across worldgen phases.
 //!
-//! The global map is X-periodic (wraps east-west) but Y is bounded, so all
-//! neighborhood operations need this asymmetric treatment. Keeping these
-//! helpers in one place avoids subtle divergence between phases.
+//! The global map is a torus — both axes wrap — so every neighborhood
+//! operation treats X and Y symmetrically. Keeping these helpers in one
+//! place avoids subtle divergence between phases.
 
 use std::cmp::Ordering;
 use std::collections::VecDeque;
@@ -29,12 +29,12 @@ impl PartialOrd for MinF32 {
     }
 }
 
-/// Fold a raw X delta into the shorter wrap direction (≤ res/2 in magnitude).
-/// Used wherever cell-coord polylines or maps span the X-wrapping seam and
-/// callers need a signed displacement that doesn't read as a world-spanning
-/// jump.
+/// Fold a raw axis delta into the shorter wrap direction (≤ res/2 in
+/// magnitude). Used wherever cell-coord polylines or maps span a wrapping
+/// seam and callers need a signed displacement that doesn't read as a
+/// world-spanning jump.
 #[inline]
-pub(crate) fn fold_x_delta(mut d: i32, res_i: i32) -> i32 {
+pub(crate) fn fold_delta(mut d: i32, res_i: i32) -> i32 {
     if d > res_i / 2 {
         d -= res_i;
     } else if d < -res_i / 2 {
@@ -43,9 +43,9 @@ pub(crate) fn fold_x_delta(mut d: i32, res_i: i32) -> i32 {
     d
 }
 
-/// Floating-point counterpart of `fold_x_delta`.
+/// Floating-point counterpart of `fold_delta`.
 #[inline]
-pub(crate) fn fold_x_delta_f32(d: f32, res_f: f32) -> f32 {
+pub(crate) fn fold_delta_f32(d: f32, res_f: f32) -> f32 {
     if d > res_f * 0.5 {
         d - res_f
     } else if d < -res_f * 0.5 {
@@ -56,7 +56,7 @@ pub(crate) fn fold_x_delta_f32(d: f32, res_f: f32) -> f32 {
 }
 
 /// Multi-source 4-connected BFS over a binary mask, returning the cell-
-/// distance from every cell to the nearest source cell. X wraps, Y doesn't.
+/// distance from every cell to the nearest source cell. Both axes wrap.
 /// Source cells (where `mask[i] == source_val`) have distance 0. Distances
 /// are saturated to `u16::MAX`. Pass `Some(passable)` to constrain expansion
 /// to cells where `passable[n] == 1` (e.g. land-only walking distance);
@@ -124,13 +124,11 @@ fn propagate_bfs(
                 queue.push_back(n);
             }
         };
+        let up = if y == 0 { res - 1 } else { y - 1 };
+        let down = if y + 1 == res { 0 } else { y + 1 };
         visit(y * res + left);
         visit(y * res + right);
-        if y > 0 {
-            visit((y - 1) * res + x);
-        }
-        if y + 1 < res {
-            visit((y + 1) * res + x);
-        }
+        visit(up * res + x);
+        visit(down * res + x);
     }
 }

--- a/shared/src/worldgen/growth.rs
+++ b/shared/src/worldgen/growth.rs
@@ -2,10 +2,10 @@
 //!
 //! Algorithm:
 //!   1. Scatter K seed points across the map (Poisson-disk-style rejection
-//!      for minimum spacing; X wraps).
+//!      for minimum spacing; both axes wrap).
 //!   2. For each cell, perturb its coordinates with a 2-component noise
 //!      warp (fBm_x, fBm_y), then find the nearest seed to the warped point
-//!      (X-wrapped distance). This gives each seed an organic-shaped
+//!      (torus distance). This gives each seed an organic-shaped
 //!      "territory" instead of a straight-edged Voronoi cell.
 //!   3. Record each cell's distance to its assigned seed.
 //!   4. Threshold at the (1 - sea_ratio) quantile: cells closer than the
@@ -23,7 +23,7 @@ use rand::{Rng, SeedableRng};
 
 use super::config::WorldGenConfig;
 use super::grid::bfs_distance_from;
-use super::noise::{fbm_wrap_x, PerlinNoise3D};
+use super::noise::{fbm_wrap_xy, PerlinNoise4D};
 
 /// Warp noise parameters — tuned so the warped-Voronoi boundaries look
 /// organic without being chaotic. Both values are in *reference cells*;
@@ -54,8 +54,8 @@ pub fn growth_mask(config: &WorldGenConfig) -> Vec<u8> {
     let n_groups = (config.target_continent_count.max(1) as usize).min(seeds.len());
     let seed_group = cluster_seeds(&seeds, n_groups, world_width, &mut rng);
 
-    let noise_x = PerlinNoise3D::new(config.seed ^ 0x7AA7_AA7A_A7AA_u64);
-    let noise_y = PerlinNoise3D::new(config.seed ^ 0x7BB7_BB7B_B7BB_u64);
+    let noise_x = PerlinNoise4D::new(config.seed ^ 0x7AA7_AA7A_A7AA_u64);
+    let noise_y = PerlinNoise4D::new(config.seed ^ 0x7BB7_BB7B_B7BB_u64);
     let warp_freq = config.scaled_freq(1.0 / WARP_WAVELENGTH);
     let warp_strength = config.scaled_cells(WARP_STRENGTH);
 
@@ -76,7 +76,7 @@ pub fn growth_mask(config: &WorldGenConfig) -> Vec<u8> {
 
     for y in 0..res {
         for x in 0..res {
-            let wx_off = fbm_wrap_x(
+            let wx_off = fbm_wrap_xy(
                 &noise_x,
                 x as f32,
                 y as f32,
@@ -86,7 +86,7 @@ pub fn growth_mask(config: &WorldGenConfig) -> Vec<u8> {
                 2.0,
                 0.5,
             ) * warp_strength;
-            let wy_off = fbm_wrap_x(
+            let wy_off = fbm_wrap_xy(
                 &noise_y,
                 x as f32,
                 y as f32,
@@ -103,7 +103,8 @@ pub fn growth_mask(config: &WorldGenConfig) -> Vec<u8> {
             for (id, &(sx, sy)) in seeds.iter().enumerate() {
                 let dx_raw = (wx - sx as f32).abs();
                 let dx = dx_raw.min(world_width - dx_raw);
-                let dy = wy - sy as f32;
+                let dy_raw = (wy - sy as f32).abs();
+                let dy = dy_raw.min(world_width - dy_raw);
                 let d = dx * dx + dy * dy;
                 let g = seed_group[id] as usize;
                 if d < best_group_d[g] {
@@ -187,7 +188,7 @@ fn scatter_small_islands(
     count: usize,
     mean_radius: f32,
     min_clearance: usize,
-    noise: &PerlinNoise3D,
+    noise: &PerlinNoise4D,
     world_width: f32,
     rng: &mut SmallRng,
 ) {
@@ -227,7 +228,8 @@ fn scatter_small_islands(
         let too_close_to_other = placed.iter().any(|&(px, py, pr)| {
             let dx_raw = (px as f32 - cx as f32).abs();
             let dx = dx_raw.min(world_width - dx_raw);
-            let dy = py as f32 - cy as f32;
+            let dy_raw = (py as f32 - cy as f32).abs();
+            let dy = dy_raw.min(world_width - dy_raw);
             let d = (dx * dx + dy * dy).sqrt();
             d < pr + radius + min_clearance as f32
         });
@@ -241,21 +243,21 @@ fn scatter_small_islands(
         let noise_strength = radius * 0.35;
         let bb = (radius + noise_strength + 2.0).ceil() as i32;
         for dy in -bb..=bb {
-            let ny = cy as i32 + dy;
-            if ny < 0 || ny >= res as i32 {
-                continue;
-            }
+            let ny = (cy as i32 + dy).rem_euclid(res as i32) as usize;
             for dx in -bb..=bb {
                 let nx = (cx as i32 + dx).rem_euclid(res as i32) as usize;
                 let dist_from_center = ((dx * dx + dy * dy) as f32).sqrt();
+                // Unwrapped coords: the blob is evaluated in one continuous
+                // pass, so the noise needs no periodicity of its own.
                 let n = noise.sample(
                     (cx as f32 + dx as f32) * noise_scale,
                     (cy as f32 + dy as f32) * noise_scale,
                     0.0,
+                    0.0,
                 );
                 let effective_radius = radius + n * noise_strength;
                 if dist_from_center < effective_radius {
-                    mask[ny as usize * res + nx] = 1;
+                    mask[ny * res + nx] = 1;
                 }
             }
         }
@@ -264,9 +266,9 @@ fn scatter_small_islands(
     }
 }
 
-/// Simple k-means clustering on 2D seed positions with X-wrap awareness
-/// (circular mean in X, regular mean in Y). Returns group id [0, n_groups)
-/// for each seed.
+/// Simple k-means clustering on 2D seed positions with torus awareness
+/// (circular mean on both axes). Returns group id [0, n_groups) for each
+/// seed.
 fn cluster_seeds(
     seeds: &[(usize, usize)],
     n_groups: usize,
@@ -295,7 +297,7 @@ fn cluster_seeds(
 
     let mut assignment = vec![0u8; seeds.len()];
     for _ in 0..30 {
-        // Assign each seed to the closest centroid (X-wrap distance).
+        // Assign each seed to the closest centroid (torus distance).
         let mut changed = false;
         for (i, &(sx, sy)) in seeds.iter().enumerate() {
             let mut best_d = f32::INFINITY;
@@ -303,7 +305,8 @@ fn cluster_seeds(
             for (c, &(cx, cy)) in centroids.iter().enumerate() {
                 let dx_raw = (sx as f32 - cx).abs();
                 let dx = dx_raw.min(world_width - dx_raw);
-                let dy = sy as f32 - cy;
+                let dy_raw = (sy as f32 - cy).abs();
+                let dy = dy_raw.min(world_width - dy_raw);
                 let d = dx * dx + dy * dy;
                 if d < best_d {
                     best_d = d;
@@ -326,19 +329,23 @@ fn cluster_seeds(
             if members.is_empty() {
                 continue;
             }
-            // Circular mean in X (so wrap-adjacent seeds cluster together).
+            // Circular mean on both axes (so wrap-adjacent seeds cluster
+            // together).
+            let tau = 2.0 * std::f32::consts::PI;
             let (mut sx_sin, mut sx_cos) = (0.0f32, 0.0f32);
-            let mut sy_sum = 0.0f32;
+            let (mut sy_sin, mut sy_cos) = (0.0f32, 0.0f32);
             for &&(x, y) in &members {
-                let a = 2.0 * std::f32::consts::PI * (x as f32) / world_width;
-                sx_sin += a.sin();
-                sx_cos += a.cos();
-                sy_sum += y as f32;
+                let ax = tau * (x as f32) / world_width;
+                sx_sin += ax.sin();
+                sx_cos += ax.cos();
+                let ay = tau * (y as f32) / world_width;
+                sy_sin += ay.sin();
+                sy_cos += ay.cos();
             }
-            let angle = sx_sin.atan2(sx_cos);
-            let cx = ((angle / (2.0 * std::f32::consts::PI)) * world_width + world_width)
-                .rem_euclid(world_width);
-            let cy = sy_sum / members.len() as f32;
+            let cx =
+                ((sx_sin.atan2(sx_cos) / tau) * world_width + world_width).rem_euclid(world_width);
+            let cy =
+                ((sy_sin.atan2(sy_cos) / tau) * world_width + world_width).rem_euclid(world_width);
             *centroid = (cx, cy);
         }
         if !changed {
@@ -348,8 +355,8 @@ fn cluster_seeds(
     assignment
 }
 
-/// Flood-fill connected components (4-connected, X-wrap), keep the `n`
-/// largest by cell count, convert the rest to sea.
+/// Flood-fill connected components (4-connected on the torus), keep the
+/// `n` largest by cell count, convert the rest to sea.
 fn keep_top_components(mask: &mut [u8], res: usize, n: usize) {
     let total = res * res;
     let mut label = vec![0u32; total]; // 0 = unvisited or sea
@@ -371,20 +378,18 @@ fn keep_top_components(mask: &mut [u8], res: usize, n: usize) {
             let y = i / res;
             let left = if x == 0 { res - 1 } else { x - 1 };
             let right = if x + 1 == res { 0 } else { x + 1 };
+            let up = if y == 0 { res - 1 } else { y - 1 };
+            let down = if y + 1 == res { 0 } else { y + 1 };
             let cands = [
-                Some(y * res + left),
-                Some(y * res + right),
-                if y > 0 { Some((y - 1) * res + x) } else { None },
-                if y + 1 < res {
-                    Some((y + 1) * res + x)
-                } else {
-                    None
-                },
+                y * res + left,
+                y * res + right,
+                up * res + x,
+                down * res + x,
             ];
-            for c in cands.iter().flatten() {
-                if mask[*c] == 1 && label[*c] == 0 {
-                    label[*c] = next_label;
-                    stack.push(*c);
+            for &c in &cands {
+                if mask[c] == 1 && label[c] == 0 {
+                    label[c] = next_label;
+                    stack.push(c);
                 }
             }
         }
@@ -424,7 +429,8 @@ fn place_seeds(
             let ok = seeds.iter().all(|&(px, py)| {
                 let dx = (sx as i64 - px as i64).abs();
                 let dx = dx.min(res_i - dx);
-                let dy = sy as i64 - py as i64;
+                let dy = (sy as i64 - py as i64).abs();
+                let dy = dy.min(res_i - dy);
                 dx * dx + dy * dy >= min_dist_sq
             });
             if ok {
@@ -530,20 +536,11 @@ mod tests {
                 let y = i / n;
                 let left = if x == 0 { n - 1 } else { x - 1 };
                 let right = if x + 1 == n { 0 } else { x + 1 };
-                for &nb in &[
-                    Some(y * n + left),
-                    Some(y * n + right),
-                    if y > 0 { Some((y - 1) * n + x) } else { None },
-                    if y + 1 < n {
-                        Some((y + 1) * n + x)
-                    } else {
-                        None
-                    },
-                ] {
-                    if let Some(nb) = nb {
-                        if mask[nb] == 1 && !visited[nb] {
-                            stack.push(nb);
-                        }
+                let up = if y == 0 { n - 1 } else { y - 1 };
+                let down = if y + 1 == n { 0 } else { y + 1 };
+                for &nb in &[y * n + left, y * n + right, up * n + x, down * n + x] {
+                    if mask[nb] == 1 && !visited[nb] {
+                        stack.push(nb);
                     }
                 }
             }

--- a/shared/src/worldgen/noise.rs
+++ b/shared/src/worldgen/noise.rs
@@ -78,31 +78,34 @@ fn grad(hash: usize, x: f32, y: f32) -> f32 {
     }
 }
 
-/// 3D Perlin noise. Used for seamless-wrap sampling via circle mapping: a
-/// noise periodic in one (or two) axes is obtained by mapping that axis to
-/// angle and sampling the corresponding (cos·R, sin·R) coordinate.
-pub struct PerlinNoise3D {
+/// 4D Perlin noise. Used for seamless torus sampling: each wrapped axis maps
+/// to a circle (Clifford torus embedding), so the field is exactly periodic
+/// in both world axes.
+pub struct PerlinNoise4D {
     perm: [u16; 512],
 }
 
-impl PerlinNoise3D {
+impl PerlinNoise4D {
     pub fn new(seed: u64) -> Self {
         Self {
             perm: build_perm_table(seed),
         }
     }
 
-    pub fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
+    pub fn sample(&self, x: f32, y: f32, z: f32, w: f32) -> f32 {
         let xi = x.floor() as i32;
         let yi = y.floor() as i32;
         let zi = z.floor() as i32;
+        let wi = w.floor() as i32;
         let xf = x - xi as f32;
         let yf = y - yi as f32;
         let zf = z - zi as f32;
+        let wf = w - wi as f32;
 
         let xi = (xi & 255) as usize;
         let yi = (yi & 255) as usize;
         let zi = (zi & 255) as usize;
+        let wi = (wi & 255) as usize;
 
         let a = self.perm[xi] as usize + yi;
         let b = self.perm[xi + 1] as usize + yi;
@@ -110,76 +113,94 @@ impl PerlinNoise3D {
         let ab = self.perm[a + 1] as usize + zi;
         let ba = self.perm[b] as usize + zi;
         let bb = self.perm[b + 1] as usize + zi;
+        let aaa = self.perm[aa] as usize + wi;
+        let aab = self.perm[aa + 1] as usize + wi;
+        let aba = self.perm[ab] as usize + wi;
+        let abb = self.perm[ab + 1] as usize + wi;
+        let baa = self.perm[ba] as usize + wi;
+        let bab = self.perm[ba + 1] as usize + wi;
+        let bba = self.perm[bb] as usize + wi;
+        let bbb = self.perm[bb + 1] as usize + wi;
 
         let u = fade(xf);
         let v = fade(yf);
-        let w = fade(zf);
+        let s = fade(zf);
+        let t = fade(wf);
 
-        let g000 = grad3(self.perm[aa] as usize, xf, yf, zf);
-        let g100 = grad3(self.perm[ba] as usize, xf - 1.0, yf, zf);
-        let g010 = grad3(self.perm[ab] as usize, xf, yf - 1.0, zf);
-        let g110 = grad3(self.perm[bb] as usize, xf - 1.0, yf - 1.0, zf);
-        let g001 = grad3(self.perm[aa + 1] as usize, xf, yf, zf - 1.0);
-        let g101 = grad3(self.perm[ba + 1] as usize, xf - 1.0, yf, zf - 1.0);
-        let g011 = grad3(self.perm[ab + 1] as usize, xf, yf - 1.0, zf - 1.0);
-        let g111 = grad3(self.perm[bb + 1] as usize, xf - 1.0, yf - 1.0, zf - 1.0);
+        let (x0, y0, z0, w0) = (xf, yf, zf, wf);
+        let (x1, y1, z1, w1) = (xf - 1.0, yf - 1.0, zf - 1.0, wf - 1.0);
 
-        let x00 = lerp(g000, g100, u);
-        let x10 = lerp(g010, g110, u);
-        let y0 = lerp(x00, x10, v);
+        // 16 corners, quadrilinear blend.
+        let c0000 = grad4(self.perm[aaa] as usize, x0, y0, z0, w0);
+        let c1000 = grad4(self.perm[baa] as usize, x1, y0, z0, w0);
+        let c0100 = grad4(self.perm[aba] as usize, x0, y1, z0, w0);
+        let c1100 = grad4(self.perm[bba] as usize, x1, y1, z0, w0);
+        let c0010 = grad4(self.perm[aab] as usize, x0, y0, z1, w0);
+        let c1010 = grad4(self.perm[bab] as usize, x1, y0, z1, w0);
+        let c0110 = grad4(self.perm[abb] as usize, x0, y1, z1, w0);
+        let c1110 = grad4(self.perm[bbb] as usize, x1, y1, z1, w0);
+        let c0001 = grad4(self.perm[aaa + 1] as usize, x0, y0, z0, w1);
+        let c1001 = grad4(self.perm[baa + 1] as usize, x1, y0, z0, w1);
+        let c0101 = grad4(self.perm[aba + 1] as usize, x0, y1, z0, w1);
+        let c1101 = grad4(self.perm[bba + 1] as usize, x1, y1, z0, w1);
+        let c0011 = grad4(self.perm[aab + 1] as usize, x0, y0, z1, w1);
+        let c1011 = grad4(self.perm[bab + 1] as usize, x1, y0, z1, w1);
+        let c0111 = grad4(self.perm[abb + 1] as usize, x0, y1, z1, w1);
+        let c1111 = grad4(self.perm[bbb + 1] as usize, x1, y1, z1, w1);
 
-        let x01 = lerp(g001, g101, u);
-        let x11 = lerp(g011, g111, u);
-        let y1 = lerp(x01, x11, v);
-
-        lerp(y0, y1, w)
+        let w0_blend = lerp(
+            lerp(lerp(c0000, c1000, u), lerp(c0100, c1100, u), v),
+            lerp(lerp(c0010, c1010, u), lerp(c0110, c1110, u), v),
+            s,
+        );
+        let w1_blend = lerp(
+            lerp(lerp(c0001, c1001, u), lerp(c0101, c1101, u), v),
+            lerp(lerp(c0011, c1011, u), lerp(c0111, c1111, u), v),
+            s,
+        );
+        lerp(w0_blend, w1_blend, t)
     }
 }
 
-fn grad3(hash: usize, x: f32, y: f32, z: f32) -> f32 {
-    // Ken Perlin's 12 edge-vector gradients; extra 4 slots duplicate to fill
-    // a 16-entry table (indexed by hash & 15).
-    match hash & 15 {
-        0 | 12 => x + y,
-        1 | 14 => -x + y,
-        2 => x - y,
-        3 => -x - y,
-        4 => x + z,
-        5 => -x + z,
-        6 => x - z,
-        7 => -x - z,
-        8 => y + z,
-        9 | 13 => -y + z,
-        10 => y - z,
-        11 | 15 => -y - z,
-        _ => 0.0,
-    }
+fn grad4(hash: usize, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    // 32 gradients: drop one of the 4 coords (bits 3-4), ±1 signs on the
+    // remaining three (bits 0-2).
+    let h = hash & 31;
+    let (a, b, c) = match h >> 3 {
+        0 => (y, z, w),
+        1 => (x, z, w),
+        2 => (x, y, w),
+        _ => (x, y, z),
+    };
+    let s0 = if h & 1 == 0 { a } else { -a };
+    let s1 = if h & 2 == 0 { b } else { -b };
+    let s2 = if h & 4 == 0 { c } else { -c };
+    s0 + s1 + s2
 }
 
-/// fBm sampled on a 3D noise with the X axis mapped to a circle of
-/// circumference equal to `world_width * base_freq` in noise units. This
-/// produces a noise field that is exactly periodic in X with period
-/// `world_width` (so cell x=0 and cell x=world_width see identical values).
-/// The Y axis is linear (non-wrapping).
+/// fBm on 4D noise with both world axes mapped to circles (Clifford torus).
+/// The field is exactly periodic in X and Y with period `world_size`. Circle
+/// radius keeps arc length equal to planar noise distance, so feature scale
+/// matches a non-wrapped fBm at the same `base_freq`.
 #[allow(clippy::too_many_arguments)]
-pub fn fbm_wrap_x(
-    noise: &PerlinNoise3D,
+pub fn fbm_wrap_xy(
+    noise: &PerlinNoise4D,
     x: f32,
     y: f32,
-    world_width: f32,
+    world_size: f32,
     base_freq: f32,
     octaves: u32,
     lacunarity: f32,
     gain: f32,
 ) -> f32 {
-    let (cx, ny, cz) = wrap_x_to_circle(x, y, world_width, base_freq);
+    let (cx, cy, cz, cw) = wrap_xy_to_torus(x, y, world_size, base_freq);
 
     let mut f = 1.0f32;
     let mut a = 1.0f32;
     let mut sum = 0.0f32;
     let mut norm = 0.0f32;
     for _ in 0..octaves {
-        sum += a * noise.sample(cx * f, ny * f, cz * f);
+        sum += a * noise.sample(cx * f, cy * f, cz * f, cw * f);
         norm += a;
         f *= lacunarity;
         a *= gain;
@@ -191,74 +212,77 @@ pub fn fbm_wrap_x(
     }
 }
 
-/// Map world `(x, y)` onto the 3D circle-wrap parameterization used by both
-/// `fbm_wrap_x` and `fbm_wrap_x_damped`: world X folds to a circle of radius
-/// `world_width·base_freq / 2π`, world Y is linear.
+/// Map world `(x, y)` onto the 4D Clifford-torus parameterization used by
+/// `fbm_wrap_xy` and `fbm_wrap_xy_damped`: each axis folds to a circle of
+/// radius `world_size·base_freq / 2π`.
 #[inline]
-fn wrap_x_to_circle(x: f32, y: f32, world_width: f32, base_freq: f32) -> (f32, f32, f32) {
-    let angle = 2.0 * std::f32::consts::PI * x / world_width;
-    let r = world_width * base_freq / (2.0 * std::f32::consts::PI);
-    (r * angle.cos(), y * base_freq, r * angle.sin())
+fn wrap_xy_to_torus(x: f32, y: f32, world_size: f32, base_freq: f32) -> (f32, f32, f32, f32) {
+    let tau = 2.0 * std::f32::consts::PI;
+    let ax = tau * x / world_size;
+    let ay = tau * y / world_size;
+    let r = world_size * base_freq / tau;
+    (r * ax.cos(), r * ax.sin(), r * ay.cos(), r * ay.sin())
 }
 
-/// 3D value noise (hashed corner values, trilinear interpolation with quintic
-/// fade) that returns the noise value alongside its analytical gradient.
-/// Cheap and exact compared to central-differences sampling — needed for the
-/// derivative-damped fBm pattern (Iñigo Quílez, "morenoise").
-///
-/// Reference: https://iquilezles.org/articles/morenoise/
-pub struct ValueNoise3D {
+/// Derivative of the quintic fade `f(t)=6t⁵-15t⁴+10t³`.
+#[inline]
+fn fade_deriv(t: f32) -> f32 {
+    30.0 * t * t * (t * (t - 2.0) + 1.0)
+}
+
+/// 4D value noise with analytical gradient, for the damped-fBm pattern on
+/// the torus parameterization. Internally interpolates two 3D slices (w=0,
+/// w=1 lattice planes) and fade-blends them along the 4th axis, so the
+/// closed-form 3D gradient math is reused instead of expanding all 16
+/// multilinear terms.
+pub struct ValueNoise4D {
     perm: [u16; 512],
 }
 
-impl ValueNoise3D {
+impl ValueNoise4D {
     pub fn new(seed: u64) -> Self {
         Self {
             perm: build_perm_table(seed),
         }
     }
 
-    /// Hash 3 lattice indices (each masked to 0..256) into a value in [-1, 1].
+    /// Hash 4 lattice indices (each masked to 0..256) into a value in [-1, 1].
     #[inline]
-    fn hash(&self, ix: usize, iy: usize, iz: usize) -> f32 {
-        let h = self.perm[self.perm[self.perm[ix] as usize + iy] as usize + iz] as f32;
+    fn hash(&self, ix: usize, iy: usize, iz: usize, iw: usize) -> f32 {
+        let h = self.perm
+            [self.perm[self.perm[self.perm[ix] as usize + iy] as usize + iz] as usize + iw]
+            as f32;
         h * (2.0 / 255.0) - 1.0
     }
 
-    /// Sample value noise at `(x, y, z)`. Returns `(value, dvalue/dx,
-    /// dvalue/dy, dvalue/dz)` — the gradient is the closed form of the
-    /// quintic-faded trilinear interpolation, so it is exact and matches
-    /// the surface slope of `value` for arbitrarily small offsets.
-    pub fn sample_with_deriv(&self, x: f32, y: f32, z: f32) -> (f32, f32, f32, f32) {
-        let xi = x.floor() as i32;
-        let yi = y.floor() as i32;
-        let zi = z.floor() as i32;
-        let fx = x - xi as f32;
-        let fy = y - yi as f32;
-        let fz = z - zi as f32;
-
-        let ix0 = (xi & 255) as usize;
-        let iy0 = (yi & 255) as usize;
-        let iz0 = (zi & 255) as usize;
+    /// Value + gradient of one 3D slice at lattice w-index `iw`.
+    #[allow(clippy::too_many_arguments)]
+    #[inline]
+    fn slice_with_deriv(
+        &self,
+        ix0: usize,
+        iy0: usize,
+        iz0: usize,
+        iw: usize,
+        u: f32,
+        v: f32,
+        w: f32,
+        du: f32,
+        dv: f32,
+        dw: f32,
+    ) -> (f32, f32, f32, f32) {
         let ix1 = (ix0 + 1) & 255;
         let iy1 = (iy0 + 1) & 255;
         let iz1 = (iz0 + 1) & 255;
 
-        let a = self.hash(ix0, iy0, iz0);
-        let b = self.hash(ix1, iy0, iz0);
-        let c = self.hash(ix0, iy1, iz0);
-        let d = self.hash(ix1, iy1, iz0);
-        let e = self.hash(ix0, iy0, iz1);
-        let f = self.hash(ix1, iy0, iz1);
-        let g = self.hash(ix0, iy1, iz1);
-        let h = self.hash(ix1, iy1, iz1);
-
-        let u = fade(fx);
-        let v = fade(fy);
-        let w = fade(fz);
-        let du = fade_deriv(fx);
-        let dv = fade_deriv(fy);
-        let dw = fade_deriv(fz);
+        let a = self.hash(ix0, iy0, iz0, iw);
+        let b = self.hash(ix1, iy0, iz0, iw);
+        let c = self.hash(ix0, iy1, iz0, iw);
+        let d = self.hash(ix1, iy1, iz0, iw);
+        let e = self.hash(ix0, iy0, iz1, iw);
+        let f = self.hash(ix1, iy0, iz1, iw);
+        let g = self.hash(ix0, iy1, iz1, iw);
+        let h = self.hash(ix1, iy1, iz1, iw);
 
         let k0 = a;
         let k1 = b - a;
@@ -276,42 +300,75 @@ impl ValueNoise3D {
         let dvdz = dw * (k3 + k5 * v + k6 * u + k7 * u * v);
         (value, dvdx, dvdy, dvdz)
     }
+
+    /// Sample at `(x, y, z, w)`. Returns `(value, d/dx, d/dy, d/dz, d/dw)`.
+    pub fn sample_with_deriv(&self, x: f32, y: f32, z: f32, w: f32) -> (f32, f32, f32, f32, f32) {
+        let xi = x.floor() as i32;
+        let yi = y.floor() as i32;
+        let zi = z.floor() as i32;
+        let wi = w.floor() as i32;
+        let fx = x - xi as f32;
+        let fy = y - yi as f32;
+        let fz = z - zi as f32;
+        let fw = w - wi as f32;
+
+        let ix0 = (xi & 255) as usize;
+        let iy0 = (yi & 255) as usize;
+        let iz0 = (zi & 255) as usize;
+        let iw0 = (wi & 255) as usize;
+        let iw1 = (iw0 + 1) & 255;
+
+        let u = fade(fx);
+        let v = fade(fy);
+        let s = fade(fz);
+        let t = fade(fw);
+        let du = fade_deriv(fx);
+        let dv = fade_deriv(fy);
+        let ds = fade_deriv(fz);
+        let dt = fade_deriv(fw);
+
+        let (v0, dx0, dy0, dz0) = self.slice_with_deriv(ix0, iy0, iz0, iw0, u, v, s, du, dv, ds);
+        let (v1, dx1, dy1, dz1) = self.slice_with_deriv(ix0, iy0, iz0, iw1, u, v, s, du, dv, ds);
+
+        let value = lerp(v0, v1, t);
+        let dvdx = lerp(dx0, dx1, t);
+        let dvdy = lerp(dy0, dy1, t);
+        let dvdz = lerp(dz0, dz1, t);
+        let dvdw = (v1 - v0) * dt;
+        (value, dvdx, dvdy, dvdz, dvdw)
+    }
 }
 
-/// Derivative of the quintic fade `f(t)=6t⁵-15t⁴+10t³`.
-#[inline]
-fn fade_deriv(t: f32) -> f32 {
-    30.0 * t * t * (t * (t - 2.0) + 1.0)
-}
-
-/// Derivative-damped fBm with X-axis circle wrap (Iñigo Quílez "morenoise").
-/// Each octave's contribution is divided by `1 + |Σ∇noise|²`, so further
-/// detail is damped wherever the surface is already steep — yielding eroded
-/// ridges and smooth basins instead of uniformly noisy fBm. Output rescaled
-/// to roughly [-1, 1] to match `fbm_wrap_x`'s contract.
+/// Derivative-damped fBm on the Clifford-torus parameterization (Iñigo
+/// Quílez "morenoise"). Each octave's contribution is divided by
+/// `1 + |Σ∇noise|²`, so further detail is damped wherever the surface is
+/// already steep — yielding eroded ridges and smooth basins instead of
+/// uniformly noisy fBm. Output rescaled to roughly [-1, 1] to match
+/// `fbm_wrap_xy`'s contract. Periodic in both world axes.
 #[allow(clippy::too_many_arguments)]
-pub fn fbm_wrap_x_damped(
-    noise: &ValueNoise3D,
+pub fn fbm_wrap_xy_damped(
+    noise: &ValueNoise4D,
     x: f32,
     y: f32,
-    world_width: f32,
+    world_size: f32,
     base_freq: f32,
     octaves: u32,
     lacunarity: f32,
     gain: f32,
 ) -> f32 {
-    let (cx, ny, cz) = wrap_x_to_circle(x, y, world_width, base_freq);
+    let (cx, cy, cz, cw) = wrap_xy_to_torus(x, y, world_size, base_freq);
 
     let mut f = 1.0f32;
     let mut amp = 1.0f32;
     let mut sum = 0.0f32;
-    let (mut dx, mut dy, mut dz) = (0.0f32, 0.0f32, 0.0f32);
+    let (mut dx, mut dy, mut dz, mut dw) = (0.0f32, 0.0f32, 0.0f32, 0.0f32);
     for _ in 0..octaves {
-        let (n, ndx, ndy, ndz) = noise.sample_with_deriv(cx * f, ny * f, cz * f);
+        let (n, ndx, ndy, ndz, ndw) = noise.sample_with_deriv(cx * f, cy * f, cz * f, cw * f);
         dx += ndx;
         dy += ndy;
         dz += ndz;
-        sum += amp * n / (1.0 + dx * dx + dy * dy + dz * dz);
+        dw += ndw;
+        sum += amp * n / (1.0 + dx * dx + dy * dy + dz * dz + dw * dw);
         f *= lacunarity;
         amp *= gain;
     }
@@ -416,132 +473,147 @@ mod tests {
     }
 
     #[test]
-    fn perlin3_same_seed_same_output() {
-        let a = PerlinNoise3D::new(42);
-        let b = PerlinNoise3D::new(42);
+    fn perlin4_same_seed_same_output() {
+        let a = PerlinNoise4D::new(42);
+        let b = PerlinNoise4D::new(42);
         for i in 0..50 {
             let t = i as f32 * 0.21;
-            assert_eq!(a.sample(t, -t, t * 0.7), b.sample(t, -t, t * 0.7));
+            assert_eq!(
+                a.sample(t, -t, t * 0.7, t * 0.3),
+                b.sample(t, -t, t * 0.7, t * 0.3)
+            );
         }
     }
 
     #[test]
-    fn perlin3_at_integer_lattice_is_zero() {
-        let n = PerlinNoise3D::new(1);
-        for x in -3..3 {
-            for y in -3..3 {
-                for z in -3..3 {
-                    let v = n.sample(x as f32, y as f32, z as f32);
-                    assert!(v.abs() < 1e-6, "expected 0 at ({x},{y},{z}), got {v}");
+    fn perlin4_at_integer_lattice_is_zero() {
+        let n = PerlinNoise4D::new(1);
+        for x in -2..2 {
+            for y in -2..2 {
+                for z in -2..2 {
+                    for w in -2..2 {
+                        let v = n.sample(x as f32, y as f32, z as f32, w as f32);
+                        assert!(v.abs() < 1e-6, "expected 0 at ({x},{y},{z},{w}), got {v}");
+                    }
                 }
             }
         }
     }
 
     #[test]
-    fn fbm_wrap_x_is_periodic() {
-        // Sampling at x=0 and x=world_width must return identical values for
-        // any y; this is the core guarantee of the circle-mapping trick.
-        let n = PerlinNoise3D::new(123);
-        let world_width = 4096.0;
+    fn fbm_wrap_xy_is_periodic_in_both_axes() {
+        // Sampling at 0 and world_size must return identical values along
+        // either axis; this is the core guarantee of the torus embedding.
+        let n = PerlinNoise4D::new(123);
+        let world_size = 4096.0;
         let base_freq = 1.0 / 700.0;
-        for yi in 0..20 {
-            let y = yi as f32 * 137.0;
-            let a = fbm_wrap_x(&n, 0.0, y, world_width, base_freq, 4, 2.0, 0.5);
-            let b = fbm_wrap_x(&n, world_width, y, world_width, base_freq, 4, 2.0, 0.5);
-            assert!(
-                (a - b).abs() < 1e-5,
-                "wrap failed at y={y}: {a} vs {b} (diff {})",
-                a - b
-            );
+        for i in 0..20 {
+            let t = i as f32 * 137.0;
+            let a = fbm_wrap_xy(&n, 0.0, t, world_size, base_freq, 4, 2.0, 0.5);
+            let b = fbm_wrap_xy(&n, world_size, t, world_size, base_freq, 4, 2.0, 0.5);
+            assert!((a - b).abs() < 1e-5, "x-wrap failed at y={t}: {a} vs {b}");
+            let c = fbm_wrap_xy(&n, t, 0.0, world_size, base_freq, 4, 2.0, 0.5);
+            let d = fbm_wrap_xy(&n, t, world_size, world_size, base_freq, 4, 2.0, 0.5);
+            assert!((c - d).abs() < 1e-5, "y-wrap failed at x={t}: {c} vs {d}");
         }
     }
 
     #[test]
-    fn fbm_wrap_x_varies_across_width() {
+    fn fbm_wrap_xy_varies_across_both_axes() {
         // Wrap shouldn't collapse all values to the same number; verify
-        // meaningful variation across x.
-        let n = PerlinNoise3D::new(7);
-        let world_width = 4096.0;
+        // meaningful variation along each axis independently.
+        let n = PerlinNoise4D::new(7);
+        let world_size = 4096.0;
         let base_freq = 1.0 / 700.0;
-        let mut mn = f32::INFINITY;
-        let mut mx = f32::NEG_INFINITY;
-        for xi in 0..32 {
-            let x = xi as f32 * (world_width / 32.0);
-            let v = fbm_wrap_x(&n, x, 1000.0, world_width, base_freq, 4, 2.0, 0.5);
-            mn = mn.min(v);
-            mx = mx.max(v);
+        for axis in 0..2 {
+            let mut mn = f32::INFINITY;
+            let mut mx = f32::NEG_INFINITY;
+            for i in 0..32 {
+                let t = i as f32 * (world_size / 32.0);
+                let (x, y) = if axis == 0 { (t, 1000.0) } else { (1000.0, t) };
+                let v = fbm_wrap_xy(&n, x, y, world_size, base_freq, 4, 2.0, 0.5);
+                mn = mn.min(v);
+                mx = mx.max(v);
+            }
+            assert!(
+                mx - mn > 0.1,
+                "wrapped fBm near-constant along axis {axis}: range {}",
+                mx - mn
+            );
         }
-        assert!(
-            mx - mn > 0.1,
-            "wrapped fBm has near-constant output: range {}",
-            mx - mn
-        );
     }
 
     #[test]
-    fn value_noise_analytic_derivative_matches_central_difference() {
-        let n = ValueNoise3D::new(31);
+    fn value_noise4_analytic_derivative_matches_central_difference() {
+        let n = ValueNoise4D::new(31);
         let h = 1e-3f32;
-        for &(x, y, z) in &[(0.37f32, 1.21, -0.55), (-2.4, 3.8, 0.2), (5.5, 0.0, 2.1)] {
-            let (_, dx, dy, dz) = n.sample_with_deriv(x, y, z);
-            let (vp_x, _, _, _) = n.sample_with_deriv(x + h, y, z);
-            let (vm_x, _, _, _) = n.sample_with_deriv(x - h, y, z);
-            let (vp_y, _, _, _) = n.sample_with_deriv(x, y + h, z);
-            let (vm_y, _, _, _) = n.sample_with_deriv(x, y - h, z);
-            let (vp_z, _, _, _) = n.sample_with_deriv(x, y, z + h);
-            let (vm_z, _, _, _) = n.sample_with_deriv(x, y, z - h);
-            let cdx = (vp_x - vm_x) / (2.0 * h);
-            let cdy = (vp_y - vm_y) / (2.0 * h);
-            let cdz = (vp_z - vm_z) / (2.0 * h);
-            assert!(
-                (dx - cdx).abs() < 1e-2,
-                "dx mismatch at ({x},{y},{z}): analytic {dx} vs CD {cdx}"
-            );
-            assert!(
-                (dy - cdy).abs() < 1e-2,
-                "dy mismatch at ({x},{y},{z}): analytic {dy} vs CD {cdy}"
-            );
-            assert!(
-                (dz - cdz).abs() < 1e-2,
-                "dz mismatch at ({x},{y},{z}): analytic {dz} vs CD {cdz}"
-            );
+        for &(x, y, z, w) in &[
+            (0.37f32, 1.21, -0.55, 0.8),
+            (-2.4, 3.8, 0.2, -1.3),
+            (5.5, 0.0, 2.1, 4.2),
+        ] {
+            let (_, dx, dy, dz, dw) = n.sample_with_deriv(x, y, z, w);
+            let cd = |f: &dyn Fn(f32) -> f32| (f(h) - f(-h)) / (2.0 * h);
+            let cdx = cd(&|e| n.sample_with_deriv(x + e, y, z, w).0);
+            let cdy = cd(&|e| n.sample_with_deriv(x, y + e, z, w).0);
+            let cdz = cd(&|e| n.sample_with_deriv(x, y, z + e, w).0);
+            let cdw = cd(&|e| n.sample_with_deriv(x, y, z, w + e).0);
+            for (name, a, b) in [
+                ("dx", dx, cdx),
+                ("dy", dy, cdy),
+                ("dz", dz, cdz),
+                ("dw", dw, cdw),
+            ] {
+                assert!(
+                    (a - b).abs() < 1e-2,
+                    "{name} mismatch at ({x},{y},{z},{w}): analytic {a} vs CD {b}"
+                );
+            }
         }
     }
 
     #[test]
-    fn fbm_wrap_x_damped_is_periodic() {
-        let n = ValueNoise3D::new(7);
-        let world_width = 4096.0;
+    fn fbm_wrap_xy_damped_is_periodic_in_both_axes() {
+        let n = ValueNoise4D::new(7);
+        let world_size = 4096.0;
         let base_freq = 1.0 / 700.0;
-        for yi in 0..16 {
-            let y = yi as f32 * 137.0;
-            let a = fbm_wrap_x_damped(&n, 0.0, y, world_width, base_freq, 6, 2.0, 0.5);
-            let b = fbm_wrap_x_damped(&n, world_width, y, world_width, base_freq, 6, 2.0, 0.5);
+        for i in 0..16 {
+            let t = i as f32 * 137.0;
+            let a = fbm_wrap_xy_damped(&n, 0.0, t, world_size, base_freq, 6, 2.0, 0.5);
+            let b = fbm_wrap_xy_damped(&n, world_size, t, world_size, base_freq, 6, 2.0, 0.5);
             assert!(
                 (a - b).abs() < 1e-5,
-                "damped wrap failed at y={y}: {a} vs {b}"
+                "damped x-wrap failed at y={t}: {a} vs {b}"
+            );
+            let c = fbm_wrap_xy_damped(&n, t, 0.0, world_size, base_freq, 6, 2.0, 0.5);
+            let d = fbm_wrap_xy_damped(&n, t, world_size, world_size, base_freq, 6, 2.0, 0.5);
+            assert!(
+                (c - d).abs() < 1e-5,
+                "damped y-wrap failed at x={t}: {c} vs {d}"
             );
         }
     }
 
     #[test]
-    fn fbm_wrap_x_damped_varies_across_width() {
-        let n = ValueNoise3D::new(11);
-        let world_width = 4096.0;
+    fn fbm_wrap_xy_damped_varies_across_both_axes() {
+        let n = ValueNoise4D::new(11);
+        let world_size = 4096.0;
         let base_freq = 1.0 / 700.0;
-        let mut mn = f32::INFINITY;
-        let mut mx = f32::NEG_INFINITY;
-        for xi in 0..32 {
-            let x = xi as f32 * (world_width / 32.0);
-            let v = fbm_wrap_x_damped(&n, x, 1000.0, world_width, base_freq, 6, 2.0, 0.5);
-            mn = mn.min(v);
-            mx = mx.max(v);
+        for axis in 0..2 {
+            let mut mn = f32::INFINITY;
+            let mut mx = f32::NEG_INFINITY;
+            for i in 0..32 {
+                let t = i as f32 * (world_size / 32.0);
+                let (x, y) = if axis == 0 { (t, 1000.0) } else { (1000.0, t) };
+                let v = fbm_wrap_xy_damped(&n, x, y, world_size, base_freq, 6, 2.0, 0.5);
+                mn = mn.min(v);
+                mx = mx.max(v);
+            }
+            assert!(
+                mx - mn > 0.05,
+                "damped fBm near-constant along axis {axis}: range {}",
+                mx - mn
+            );
         }
-        assert!(
-            mx - mn > 0.05,
-            "damped fBm has near-constant output: range {}",
-            mx - mn
-        );
     }
 }

--- a/shared/src/worldgen/rivers.rs
+++ b/shared/src/worldgen/rivers.rs
@@ -14,7 +14,7 @@
 use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use super::global_map::GlobalMap;
-use super::grid::{fold_x_delta, MinF32};
+use super::grid::{fold_delta, MinF32};
 
 /// Peak elevation threshold (as a fraction of `max_elevation_m`) for
 /// `extract_rivers` to treat a local maximum as a river source. Shared
@@ -82,9 +82,10 @@ struct MergeClaim {
 }
 
 /// Priority-queue-based pit fill (Barnes et al. 2014). Starting from the
-/// sea / Y-border cells, flood inward; each cell is raised just above the
-/// highest point on the least-costly path back to an outlet, guaranteeing
-/// that every land cell has a downhill path to the boundary.
+/// sea cells, flood inward; each cell is raised just above the highest
+/// point on the least-costly path back to an outlet, guaranteeing that
+/// every land cell has a downhill path to the sea. On the closed torus
+/// the sea is the only outlet — there is no map border to drain off.
 fn fill_pits(elev: &[f32], mask: &[u8], res: usize) -> Vec<f32> {
     let total = res * res;
     let mut filled = elev.to_vec();
@@ -92,9 +93,7 @@ fn fill_pits(elev: &[f32], mask: &[u8], res: usize) -> Vec<f32> {
     let mut pq: BinaryHeap<MinF32> = BinaryHeap::new();
 
     for i in 0..total {
-        let y = i / res;
-        let is_border = y == 0 || y == res - 1;
-        if mask[i] == 0 || is_border {
+        if mask[i] == 0 {
             pq.push(MinF32(filled[i], i as u32));
             visited[i] = true;
         }
@@ -110,11 +109,8 @@ fn fill_pits(elev: &[f32], mask: &[u8], res: usize) -> Vec<f32> {
                     continue;
                 }
                 let nx = (x + dx).rem_euclid(res as i32) as usize;
-                let ny = y + dy;
-                if ny < 0 || ny >= res as i32 {
-                    continue;
-                }
-                let ni = ny as usize * res + nx;
+                let ny = (y + dy).rem_euclid(res as i32) as usize;
+                let ni = ny * res + nx;
                 if visited[ni] {
                     continue;
                 }
@@ -136,8 +132,8 @@ fn parallel_merge_radius_cells(res: usize) -> i32 {
 }
 
 fn step_dir(from: (u32, u32), to: (u32, u32), res: usize) -> Option<(i8, i8)> {
-    let dx = fold_x_delta(to.0 as i32 - from.0 as i32, res as i32);
-    let dy = to.1 as i32 - from.1 as i32;
+    let dx = fold_delta(to.0 as i32 - from.0 as i32, res as i32);
+    let dy = fold_delta(to.1 as i32 - from.1 as i32, res as i32);
     if dx == 0 && dy == 0 {
         None
     } else {
@@ -215,16 +211,16 @@ fn cumulative_lengths_cells(points: &[(u32, u32)], res: usize) -> Vec<f32> {
     lengths.push(0.0);
     let res_i = res as i32;
     for i in 1..points.len() {
-        let dx = fold_x_delta(points[i].0 as i32 - points[i - 1].0 as i32, res_i) as f32;
-        let dy = points[i].1 as f32 - points[i - 1].1 as f32;
+        let dx = fold_delta(points[i].0 as i32 - points[i - 1].0 as i32, res_i) as f32;
+        let dy = fold_delta(points[i].1 as i32 - points[i - 1].1 as i32, res_i) as f32;
         lengths.push(lengths[i - 1] + (dx * dx + dy * dy).sqrt());
     }
     lengths
 }
 
 /// Windowed unit tangent at vertex `i` from the cell-coordinate polyline.
-/// Symmetric `±window` window when not near an endpoint; X-folded so a
-/// segment that crosses the world wrap doesn't return a backward tangent.
+/// Symmetric `±window` window when not near an endpoint; both axes folded
+/// so a segment that crosses a world seam doesn't return a backward tangent.
 fn windowed_tangent_cells(
     points: &[(u32, u32)],
     i: usize,
@@ -237,8 +233,8 @@ fn windowed_tangent_cells(
     if lo == hi {
         return None;
     }
-    let dx = fold_x_delta(points[hi].0 as i32 - points[lo].0 as i32, res_i) as f32;
-    let dy = points[hi].1 as f32 - points[lo].1 as f32;
+    let dx = fold_delta(points[hi].0 as i32 - points[lo].0 as i32, res_i) as f32;
+    let dy = fold_delta(points[hi].1 as i32 - points[lo].1 as i32, res_i) as f32;
     let len = (dx * dx + dy * dy).sqrt();
     if len < 1e-6 {
         return None;
@@ -286,8 +282,8 @@ fn append_wrapped_line(
     flow_to: f32,
     res: usize,
 ) {
-    let dx = fold_x_delta(to.0 as i32 - from.0 as i32, res as i32);
-    let dy = to.1 as i32 - from.1 as i32;
+    let dx = fold_delta(to.0 as i32 - from.0 as i32, res as i32);
+    let dy = fold_delta(to.1 as i32 - from.1 as i32, res as i32);
     let steps = dx.abs().max(dy.abs()) as usize;
     if steps == 0 {
         return;
@@ -295,7 +291,7 @@ fn append_wrapped_line(
     for step in 1..=steps {
         let t = step as f32 / steps as f32;
         let x = (from.0 as i32 + (dx as f32 * t).round() as i32).rem_euclid(res as i32) as u32;
-        let y = (from.1 as i32 + (dy as f32 * t).round() as i32).clamp(0, res as i32 - 1) as u32;
+        let y = (from.1 as i32 + (dy as f32 * t).round() as i32).rem_euclid(res as i32) as u32;
         let p = (x, y);
         let f = flow_from + (flow_to - flow_from) * t;
         if points.last().copied() == Some(p) {
@@ -450,13 +446,8 @@ fn naturalize_river_meanders(map: &GlobalMap, rivers: &mut [Polyline]) {
             for scale in [1.0f32, 0.5] {
                 let cand_x = target_x[i] + nx * offset * scale;
                 let cand_y = target_y[i] + ny * offset * scale;
-                let cell_x_i = cand_x.round() as i32;
-                let cell_y_i = cand_y.round() as i32;
-                if cell_y_i < 0 || cell_y_i >= res_i {
-                    continue;
-                }
-                let cell_x = cell_x_i.rem_euclid(res_i) as usize;
-                let cell_y = cell_y_i as usize;
+                let cell_x = (cand_x.round() as i32).rem_euclid(res_i) as usize;
+                let cell_y = (cand_y.round() as i32).rem_euclid(res_i) as usize;
                 if map.land_mask[cell_y * res + cell_x] != 1 {
                     continue;
                 }
@@ -470,14 +461,14 @@ fn naturalize_river_meanders(map: &GlobalMap, rivers: &mut [Polyline]) {
         let mut new_flow: Vec<f32> = Vec::with_capacity(n);
         let p0 = (
             (target_x[0].round() as i32).rem_euclid(res_i) as u32,
-            target_y[0].round().clamp(0.0, (res_i - 1) as f32) as u32,
+            (target_y[0].round() as i32).rem_euclid(res_i) as u32,
         );
         new_points.push(p0);
         new_flow.push(poly.flow[0]);
         for i in 1..n {
             let pi = (
                 (target_x[i].round() as i32).rem_euclid(res_i) as u32,
-                target_y[i].round().clamp(0.0, (res_i - 1) as f32) as u32,
+                (target_y[i].round() as i32).rem_euclid(res_i) as u32,
             );
             let last = *new_points.last().unwrap();
             let last_flow = *new_flow.last().unwrap();
@@ -516,17 +507,14 @@ fn add_parallel_merge_claims(
         };
 
         for dy in -radius..=radius {
-            let ny = y as i32 + dy;
-            if ny < 0 || ny >= res as i32 {
-                continue;
-            }
+            let ny = (y as i32 + dy).rem_euclid(res as i32) as usize;
             for dx in -radius..=radius {
                 let dist_sq = dx * dx + dy * dy;
                 if dist_sq > radius_sq {
                     continue;
                 }
                 let nx = (x as i32 + dx).rem_euclid(res as i32) as usize;
-                let ni = ny as usize * res + nx;
+                let ni = ny * res + nx;
                 let claim = MergeClaim {
                     target: cell as u32,
                     dir_x,
@@ -654,11 +642,8 @@ pub fn compute_flow(map: &GlobalMap) -> RiverMap {
         let mut best_land: Option<u32> = None;
         for &(dx, dy, dist) in &OFFSETS {
             let nx = (x + dx).rem_euclid(res as i32) as usize;
-            let ny = y + dy;
-            if ny < 0 || ny >= res as i32 {
-                continue;
-            }
-            let ni = ny as usize * res + nx;
+            let ny = (y + dy).rem_euclid(res as i32) as usize;
+            let ni = ny * res + nx;
             let dh = h - elev[ni];
             if dh <= 0.0 {
                 continue;
@@ -743,21 +728,9 @@ pub fn extract_rivers(
     // threshold. Candidates are filtered by a minimum-spacing pass so the
     // resulting river network has a handful of main stems rather than one
     // "river" per every rocky bump.
-    // Exclude ~2× the wall band from peak candidacy. The wall's uniform
-    // southward slope generates parallel peaks that trace as straight-line
-    // rivers; the 2× cushion catches peaks just past the wall where the
-    // wall-to-natural-terrain transition still produces a uniform gradient.
-    let wall_margin = map
-        .config
-        .scaled_cells_usize(map.config.y_border_wall_cells)
-        * 2;
     let mut candidates: Vec<(u32, f32)> = Vec::new();
     for i in 0..total {
         if mask[i] == 0 || elev[i] < min_peak_elevation {
-            continue;
-        }
-        let iy = i / res;
-        if iy < wall_margin || iy + wall_margin >= res {
             continue;
         }
         let x = (i % res) as i32;
@@ -770,11 +743,8 @@ pub fn extract_rivers(
                     continue;
                 }
                 let nx = (x + dx).rem_euclid(res as i32) as usize;
-                let ny = y + dy;
-                if ny < 0 || ny >= res as i32 {
-                    continue;
-                }
-                let ni = ny as usize * res + nx;
+                let ny = (y + dy).rem_euclid(res as i32) as usize;
+                let ni = ny * res + nx;
                 if elev[ni] >= h {
                     is_peak = false;
                     break;
@@ -920,11 +890,8 @@ pub fn extract_small_island_rivers(
                     continue;
                 }
                 let nx = (x + dx).rem_euclid(res_i) as usize;
-                let ny = y + dy;
-                if ny < 0 || ny >= res_i {
-                    continue;
-                }
-                let ni = ny as usize * res + nx;
+                let ny = (y + dy).rem_euclid(res_i) as usize;
+                let ni = ny * res + nx;
                 if elev[ni] >= h {
                     is_peak = false;
                     break 'outer;
@@ -1101,13 +1068,10 @@ fn merge_overlapping_polylines(map: &GlobalMap, rivers: &mut Vec<Polyline>) {
         'outer: for i in lo..hi {
             let (x, y) = rivers[ri].points[i];
             for ddy in -MERGE_PROXIMITY_RADIUS_CELLS..=MERGE_PROXIMITY_RADIUS_CELLS {
-                let cy = y as i32 + ddy;
-                if cy < 0 || cy >= res_i {
-                    continue;
-                }
+                let cy = (y as i32 + ddy).rem_euclid(res_i) as usize;
                 for ddx in -MERGE_PROXIMITY_RADIUS_CELLS..=MERGE_PROXIMITY_RADIUS_CELLS {
                     let cx = (x as i32 + ddx).rem_euclid(res_i);
-                    let cell = cy as usize * res + cx as usize;
+                    let cell = cy * res + cx as usize;
                     let owner = claimer[cell];
                     if owner != u32::MAX && owner as usize != ri {
                         truncate_at = Some(i);
@@ -1157,8 +1121,6 @@ mod tests {
             target_continent_count: 1,
             continent_gap_cells: 0,
             small_island_count: 0,
-            y_border_wall_cells: 0,
-            y_border_wall_height_m: 0.0,
             river_gap_max_m: 0.0,
             // Default wavelength is sized for a 4096-cell production map; in
             // the small test resolutions a 700-cell wavelength is wider than

--- a/shared/src/worldgen/roads/astar.rs
+++ b/shared/src/worldgen/roads/astar.rs
@@ -9,7 +9,7 @@
 use std::collections::BinaryHeap;
 
 use super::super::global_map::GlobalMap;
-use super::super::grid::{fold_x_delta_f32, MinF32};
+use super::super::grid::{fold_delta_f32, MinF32};
 use super::super::rivers::RiverMap;
 use super::super::tile_bake::river_geom::{
     flow_log_inv, polyline_arcs, predicted_visible_width, BRIDGE_MAX_VISIBLE_WIDTH_M,
@@ -122,8 +122,8 @@ impl RiverField {
                 let idx = (y as usize) * res + (x as usize);
                 let prev = if i == 0 { pts[i] } else { pts[i - 1] };
                 let next = if i + 1 >= n { pts[i] } else { pts[i + 1] };
-                let dx = fold_x_delta_f32(next.0 as f32 - prev.0 as f32, res_f);
-                let dy = next.1 as f32 - prev.1 as f32;
+                let dx = fold_delta_f32(next.0 as f32 - prev.0 as f32, res_f);
+                let dy = fold_delta_f32(next.1 as f32 - prev.1 as f32, res_f);
                 let len = (dx * dx + dy * dy).sqrt().max(1e-6);
                 tangent[idx] = (dx / len, dy / len);
                 axis[idx] = pick_river_axis(dx / len, dy / len);
@@ -176,7 +176,7 @@ impl RiverField {
 
 /// One-step Chebyshev (8-connected) dilation of `mask`. Output `out[i] != 0`
 /// iff some 8-neighbour of cell `i` is set in `mask`, with `i` itself
-/// excluded. X-wraps; Y is bounded. Used to build the river-buffer flag —
+/// excluded. Both axes wrap. Used to build the river-buffer flag —
 /// a "right next to the river but not on it" mask.
 fn chebyshev_dilate(mask: &[u8], res: usize) -> Vec<u8> {
     let total = res * res;
@@ -194,11 +194,8 @@ fn chebyshev_dilate(mask: &[u8], res: usize) -> Vec<u8> {
                     continue;
                 }
                 let nx = (cx + dx).rem_euclid(res_i) as usize;
-                let ny = cy + dy;
-                if ny < 0 || ny >= res_i {
-                    continue;
-                }
-                let ni = (ny as usize) * res + nx;
+                let ny = (cy + dy).rem_euclid(res_i) as usize;
+                let ni = ny * res + nx;
                 if mask[ni] == 0 {
                     out[ni] = 1;
                 }
@@ -298,11 +295,8 @@ pub(super) fn a_star(
                     continue;
                 }
                 let nx = (cx + dx).rem_euclid(res_i) as usize;
-                let ny = cy + dy;
-                if ny < 0 || ny >= res_i {
-                    continue;
-                }
-                let ni = ny as usize * res + nx;
+                let ny = (cy + dy).rem_euclid(res_i) as usize;
+                let ni = ny * res + nx;
                 if mask[ni] == 0 || scratch.closed[ni] {
                     continue;
                 }
@@ -329,7 +323,7 @@ pub(super) fn a_star(
                     // Pure-land diagonal: reject corner-cuts where a
                     // shoulder is river (would skim past a 1-cell channel).
                     let sh1 = (cy as usize) * res + (cx + dx).rem_euclid(res_i) as usize;
-                    let sh2 = (cy + dy) as usize * res + cx as usize;
+                    let sh2 = (cy + dy).rem_euclid(res_i) as usize * res + cx as usize;
                     if river_field.mask[sh1] != 0 || river_field.mask[sh2] != 0 {
                         continue;
                     }
@@ -369,7 +363,7 @@ pub(super) fn a_star(
                     scratch.touch_if_new(ni);
                     scratch.g_score[ni] = tentative;
                     scratch.came_from[ni] = cur;
-                    let f = tentative + heuristic(nx, ny as usize, gx, gy, res);
+                    let f = tentative + heuristic(nx, ny, gx, gy, res);
                     scratch.open.push(MinF32(f, ni as u32));
                 }
             }
@@ -400,6 +394,7 @@ fn reconstruct(came_from: &[u32], start: usize, goal: usize, res: usize) -> Vec<
 fn heuristic(sx: usize, sy: usize, gx: usize, gy: usize, res: usize) -> f32 {
     let dx_raw = (sx as f32 - gx as f32).abs();
     let dx = dx_raw.min(res as f32 - dx_raw);
-    let dy = sy as f32 - gy as f32;
+    let dy_raw = (sy as f32 - gy as f32).abs();
+    let dy = dy_raw.min(res as f32 - dy_raw);
     (dx * dx + dy * dy).sqrt()
 }

--- a/shared/src/worldgen/roads/graph.rs
+++ b/shared/src/worldgen/roads/graph.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashSet;
 
-use super::super::grid::fold_x_delta_f32;
+use super::super::grid::fold_delta_f32;
 use super::super::settlements::Settlement;
 
 /// Cosine threshold above which two incident edges at the same vertex are
@@ -149,15 +149,16 @@ pub(super) fn prim_mst(settlements: &[Settlement], res_f: f32) -> Vec<(usize, us
 pub(super) fn euclidean_sq(a: &Settlement, b: &Settlement, res_f: f32) -> f32 {
     let dx_raw = (a.cell_x as f32 - b.cell_x as f32).abs();
     let dx = dx_raw.min(res_f - dx_raw);
-    let dy = a.cell_y as f32 - b.cell_y as f32;
+    let dy_raw = (a.cell_y as f32 - b.cell_y as f32).abs();
+    let dy = dy_raw.min(res_f - dy_raw);
     dx * dx + dy * dy
 }
 
-/// Unit direction vector from `a` to `b`, with X-wrap handled by picking
-/// the shorter horizontal side.
+/// Unit direction vector from `a` to `b`, both axes folded onto the
+/// shorter wrapped side.
 fn direction(a: &Settlement, b: &Settlement, res_f: f32) -> (f32, f32) {
-    let dx = fold_x_delta_f32(b.cell_x as f32 - a.cell_x as f32, res_f);
-    let dy = b.cell_y as f32 - a.cell_y as f32;
+    let dx = fold_delta_f32(b.cell_x as f32 - a.cell_x as f32, res_f);
+    let dy = fold_delta_f32(b.cell_y as f32 - a.cell_y as f32, res_f);
     let len = (dx * dx + dy * dy).sqrt().max(1e-6);
     (dx / len, dy / len)
 }

--- a/shared/src/worldgen/roads/merge.rs
+++ b/shared/src/worldgen/roads/merge.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use super::super::grid::fold_x_delta;
+use super::super::grid::fold_delta;
 use super::RoadNetwork;
 
 /// Cell-distance threshold for treating two road points as "co-located"
@@ -397,9 +397,9 @@ fn match_prefix_lengths(
 
 #[inline]
 fn cell_dist_sq(a: (u32, u32), b: (u32, u32), res_i: i32) -> f32 {
-    let dx = fold_x_delta(a.0 as i32 - b.0 as i32, res_i) as f32;
-    let dy = a.1 as i32 - b.1 as i32;
-    dx * dx + (dy as f32).powi(2)
+    let dx = fold_delta(a.0 as i32 - b.0 as i32, res_i) as f32;
+    let dy = fold_delta(a.1 as i32 - b.1 as i32, res_i) as f32;
+    dx * dx + dy * dy
 }
 
 /// True if either polyline endpoint of `a` coincides with either endpoint

--- a/shared/src/worldgen/roads/snap.rs
+++ b/shared/src/worldgen/roads/snap.rs
@@ -6,7 +6,7 @@
 //! First/last index of each polyline is preserved so settlement /
 //! river-source / river-mouth anchors don't drift.
 
-use super::super::grid::fold_x_delta;
+use super::super::grid::fold_delta;
 use super::super::rivers::RiverMap;
 use super::axis::{pick_river_axis, SnapAxis};
 use super::RoadNetwork;
@@ -106,8 +106,8 @@ fn local_dir(points: &[(u32, u32)], idx: usize, half_w: usize, res: usize) -> (i
     let (px, py) = points[i_lo];
     let (qx, qy) = points[i_hi];
     let res_i = res as i32;
-    let dx = fold_x_delta(qx as i32 - px as i32, res_i);
-    let dy = qy as i32 - py as i32;
+    let dx = fold_delta(qx as i32 - px as i32, res_i);
+    let dy = fold_delta(qy as i32 - py as i32, res_i);
     (dx, dy)
 }
 
@@ -162,10 +162,10 @@ fn snap_polyline_window(
     };
     let (x_lo, y_lo) = points[i_start - 1];
     let (x_hi, y_hi) = points[hi_idx];
-    let dx_lo = fold_x_delta(x_lo as i32 - cx_i, res_i);
-    let dy_lo = y_lo as i32 - cy_i;
-    let dx_hi = fold_x_delta(x_hi as i32 - cx_i, res_i);
-    let dy_hi = y_hi as i32 - cy_i;
+    let dx_lo = fold_delta(x_lo as i32 - cx_i, res_i);
+    let dy_lo = fold_delta(y_lo as i32 - cy_i, res_i);
+    let dx_hi = fold_delta(x_hi as i32 - cx_i, res_i);
+    let dy_hi = fold_delta(y_hi as i32 - cy_i, res_i);
     let inv_len_sq = 1.0 / len_sq as f32;
     let s_lo = (dx_lo * ux + dy_lo * uy) as f32 * inv_len_sq;
     let s_hi = (dx_hi * ux + dy_hi * uy) as f32 * inv_len_sq;
@@ -173,7 +173,7 @@ fn snap_polyline_window(
         let t = (k as f32 + 1.0) / span;
         let s = (s_lo + (s_hi - s_lo) * t).round() as i32;
         let x = (cx_i + s * ux).rem_euclid(res_i) as u32;
-        let y = (cy_i + s * uy).clamp(0, res_i - 1) as u32;
+        let y = (cy_i + s * uy).rem_euclid(res_i) as u32;
         points[i_start + k] = (x, y);
     }
     i_end

--- a/shared/src/worldgen/settlements.rs
+++ b/shared/src/worldgen/settlements.rs
@@ -409,16 +409,13 @@ fn best_mouth_cell(
     let my = (mouth / res) as i32;
     let mut best: Option<(usize, f32)> = None;
     for dy in -SEARCH_RADIUS..=SEARCH_RADIUS {
-        let ny = my + dy;
-        if ny < 0 || ny >= res as i32 {
-            continue;
-        }
+        let ny = (my + dy).rem_euclid(res as i32) as usize;
         for dx in -SEARCH_RADIUS..=SEARCH_RADIUS {
             if dx * dx + dy * dy > SEARCH_RADIUS * SEARCH_RADIUS {
                 continue;
             }
             let nx = (mx + dx).rem_euclid(res as i32) as usize;
-            let ni = (ny as usize) * res + nx;
+            let ni = ny * res + nx;
             if !habitable(ni, map, slope, ctx) {
                 continue;
             }
@@ -466,11 +463,7 @@ fn habitable(i: usize, map: &GlobalMap, slope: &[f32], ctx: &FitnessCtx) -> bool
     if map.land_mask[i] != 1 || map.elevation_m[i] > ctx.max_elev || slope[i] > ctx.max_slope {
         return false;
     }
-    if ctx.wide_river[i] {
-        return false;
-    }
-    let cy = i / map.config.global_res as usize;
-    cy <= ctx.max_cy
+    !ctx.wide_river[i]
 }
 
 struct SpacingCtx<'a> {
@@ -498,7 +491,8 @@ fn try_place(idx: usize, score: f32, res: usize, sp: &SpacingCtx, kept: &mut Vec
         };
         let dx_raw = (s.cell_x as f32 - x).abs();
         let dx = dx_raw.min(sp.res_f - dx_raw);
-        let dy = s.cell_y as f32 - y;
+        let dy_raw = (s.cell_y as f32 - y).abs();
+        let dy = dy_raw.min(sp.res_f - dy_raw);
         dx * dx + dy * dy >= required_sq
     });
     if ok {
@@ -538,23 +532,11 @@ struct FitnessCtx<'a> {
     wide_river: &'a [bool],
     max_slope: f32,
     max_elev: f32,
-    /// Largest cell-y (inclusive) that passes habitability. Cells with
-    /// `cy > max_cy` are inside the south-edge exclusion band. `usize::MAX`
-    /// disables the check.
-    max_cy: usize,
 }
 
 impl FitnessCtx<'_> {
     fn from_config<'a>(map: &'a GlobalMap, fields: &'a HabitabilityFields) -> FitnessCtx<'a> {
         let cfg = &map.config;
-        let max_cy = if cfg.settlement_south_edge_exclusion_m > 0.0 {
-            let res = cfg.global_res as usize;
-            let excl_cells =
-                (cfg.settlement_south_edge_exclusion_m / cfg.meters_per_cell()).ceil() as usize;
-            res.saturating_sub(excl_cells + 1)
-        } else {
-            usize::MAX
-        };
         FitnessCtx {
             elev: &map.elevation_m,
             coast_dist: &fields.coast_dist,
@@ -563,7 +545,6 @@ impl FitnessCtx<'_> {
             wide_river: &fields.wide_river,
             max_slope: cfg.settlement_max_slope,
             max_elev: cfg.settlement_max_elevation_m,
-            max_cy,
         }
     }
 }
@@ -739,7 +720,8 @@ mod tests {
             for b in &settlements[i + 1..] {
                 let dx_raw = (a.cell_x as f32 - b.cell_x as f32).abs();
                 let dx = dx_raw.min(res_f - dx_raw);
-                let dy = a.cell_y as f32 - b.cell_y as f32;
+                let dy_raw = (a.cell_y as f32 - b.cell_y as f32).abs();
+                let dy = dy_raw.min(res_f - dy_raw);
                 let d2 = dx * dx + dy * dy;
                 assert!(
                     d2 >= min_sp_sq,

--- a/shared/src/worldgen/tile_bake/bridges.rs
+++ b/shared/src/worldgen/tile_bake/bridges.rs
@@ -33,10 +33,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::super::global_map::GlobalMap;
-use super::super::grid::fold_x_delta_f32;
+use super::super::grid::fold_delta_f32;
 use super::super::rivers::RiverMap;
 use super::super::roads::RoadNetwork;
-use super::super::vector_features::{nearest_river_segment, river_segments_near_tile};
+use super::super::vector_features::{nearest_river_segment, river_segments_near_tile_wrap_xy};
 use super::constants::{TILE_DIM, VERTS_PER_SIDE};
 use super::context::BakeContext;
 use super::heightmap::{sample_natural_height_single, segment_carve_taper_at};
@@ -294,13 +294,14 @@ pub fn detect_bridges(
             // Width at the projection point — pull only segments inside a
             // small local AABB so the nearest_river_segment search stays cheap.
             let probe_margin = TILE_DIM as f32 * 0.5;
-            let local_segs = river_segments_near_tile(
+            let local_segs = river_segments_near_tile_wrap_xy(
                 &ctx.rivers_world,
                 wx - probe_margin,
                 wz - probe_margin,
                 wx + probe_margin,
                 wz + probe_margin,
                 0.0,
+                map_config.world_size_m as f32,
             );
             // Visible water width = baked + taper. See the module doc for
             // why the taper enters once (smoothstep boundary, not
@@ -333,6 +334,7 @@ pub fn detect_bridges(
                     sample_natural_height_single(map, ctx, x, z),
                     settlement_directives,
                     &ctx.detail_noise,
+                    map.config.world_size_m as f32,
                 )
             };
             let h_a = probe(
@@ -381,7 +383,7 @@ fn canonical_deck_angle(theta: f32) -> f32 {
 
 /// Convert a polyline cell-coord direction at index `pi` to a world unit
 /// tangent. Uses central differencing (one-sided at endpoints) and folds
-/// the X-wrap so polyline pieces that span the seam don't read as a
+/// both axes so polyline pieces that span a seam don't read as a
 /// world-spanning jump.
 fn river_world_tangent(
     points: &[(u32, u32)],
@@ -396,8 +398,8 @@ fn river_world_tangent(
         points[pi + 1]
     };
     let res = cfg.global_res as f32;
-    let dx = fold_x_delta_f32(next.0 as f32 - prev.0 as f32, res);
-    let dy = next.1 as f32 - prev.1 as f32;
+    let dx = fold_delta_f32(next.0 as f32 - prev.0 as f32, res);
+    let dy = fold_delta_f32(next.1 as f32 - prev.1 as f32, res);
     let mpc = cfg.meters_per_cell();
     let wx = dx * mpc;
     let wz = dy * mpc;
@@ -412,6 +414,7 @@ fn river_world_tangent(
 pub fn group_flattens_by_tile(
     placements: &[BridgePlacement],
     catalog: &BridgeCatalog,
+    world_size: f32,
 ) -> HashMap<(i32, i32), Vec<BridgeFlatten>> {
     let mut out: HashMap<(i32, i32), Vec<BridgeFlatten>> = HashMap::new();
     for p in placements {
@@ -469,7 +472,11 @@ pub fn group_flattens_by_tile(
         };
         for tz in tile_min_z..=tile_max_z {
             for tx in tile_min_x..=tile_max_x {
-                out.entry((tx, tz)).or_default().push(directive.clone());
+                let key = (
+                    super::wrap_tile(tx, world_size),
+                    super::wrap_tile(tz, world_size),
+                );
+                out.entry(key).or_default().push(directive.clone());
             }
         }
     }
@@ -489,12 +496,19 @@ pub(super) fn apply_bridge_flatten(
     tile_origin_x: f32,
     tile_origin_z: f32,
     flattens: &[BridgeFlatten],
+    world_size: f32,
 ) {
     let last = (VERTS_PER_SIDE - 1) as i32;
     for fl in flattens {
         let cos = fl.rot_rad.cos();
         let sin = fl.rot_rad.sin();
         let blend = BRIDGE_FLATTEN_BLEND_M;
+        // World-shift that brings a seam-straddling directive next to this
+        // tile (one of -W / 0 / +W per axis).
+        let sx =
+            fold_delta_f32(fl.center_x - tile_origin_x, world_size) - (fl.center_x - tile_origin_x);
+        let sz =
+            fold_delta_f32(fl.center_z - tile_origin_z, world_size) - (fl.center_z - tile_origin_z);
         // Two foot rects: one at each deck end, `foot_length_z` long along
         // local Z, full deck width along local X.
         let foot_a_lo = fl.deck_min_z;
@@ -503,16 +517,16 @@ pub(super) fn apply_bridge_flatten(
         let foot_b_hi = fl.deck_max_z;
         // Restrict the per-vertex sweep to the rotated-rect AABB; outside
         // that band the blend evaluates to zero and the loop is wasted.
-        let i0 = ((fl.world_min_x - tile_origin_x).floor() as i32).clamp(0, last) as usize;
-        let i1 = ((fl.world_max_x - tile_origin_x).ceil() as i32).clamp(0, last) as usize;
-        let j0 = ((fl.world_min_z - tile_origin_z).floor() as i32).clamp(0, last) as usize;
-        let j1 = ((fl.world_max_z - tile_origin_z).ceil() as i32).clamp(0, last) as usize;
+        let i0 = ((fl.world_min_x + sx - tile_origin_x).floor() as i32).clamp(0, last) as usize;
+        let i1 = ((fl.world_max_x + sx - tile_origin_x).ceil() as i32).clamp(0, last) as usize;
+        let j0 = ((fl.world_min_z + sz - tile_origin_z).floor() as i32).clamp(0, last) as usize;
+        let j1 = ((fl.world_max_z + sz - tile_origin_z).ceil() as i32).clamp(0, last) as usize;
         for j in j0..=j1 {
             for i in i0..=i1 {
                 let wx = tile_origin_x + i as f32;
                 let wz = tile_origin_z + j as f32;
-                let dx = wx - fl.center_x;
-                let dz = wz - fl.center_z;
+                let dx = wx - (fl.center_x + sx);
+                let dz = wz - (fl.center_z + sz);
                 // World→local with three.js's positive-Y rotation
                 // (matches `flattenRotatedRect`'s lx/lz formulae).
                 let lx = dx * cos - dz * sin;

--- a/shared/src/worldgen/tile_bake/context.rs
+++ b/shared/src/worldgen/tile_bake/context.rs
@@ -10,7 +10,7 @@ use super::super::config::WorldGenConfig;
 use super::super::global_map::GlobalMap;
 use super::super::grass_patches::GrassPatchField;
 use super::super::grid::bfs_distance_from;
-use super::super::noise::{smoothstep, PerlinNoise3D};
+use super::super::noise::{smoothstep, PerlinNoise4D};
 use super::super::rivers::RiverMap;
 use super::super::roads::RoadNetwork;
 use super::super::vector_features::{
@@ -31,7 +31,7 @@ use super::heightmap::cell_elevation_m;
 
 pub struct BakeContext {
     /// Deterministic detail-noise source seeded off the master seed.
-    pub detail_noise: PerlinNoise3D,
+    pub detail_noise: PerlinNoise4D,
     /// Warped-Voronoi patch field that gates grass coverage. Each seed claims
     /// a circular territory (~22 m radius, jittered) with a per-patch tall/
     /// short flag; a domain warp gives the territories organic shapes. Cells
@@ -103,7 +103,7 @@ impl BakeContext {
         );
         orient_coasts_land_left(&mut coasts_world, map, &dist_to_land);
 
-        let detail_noise = PerlinNoise3D::new(map.config.seed ^ 0xD1EA_C17E_0000_0007);
+        let detail_noise = PerlinNoise4D::new(map.config.seed ^ 0xD1EA_C17E_0000_0007);
         let grass_patches = GrassPatchField::new(map.config.seed, map.config.world_size_m as f32);
 
         Self {
@@ -179,7 +179,7 @@ fn sample_base_elevation(map: &GlobalMap, dist_to_land: &[u16], wx: f32, wz: f32
     let tz = fz - iz0 as f32;
     let sample = |ix: i32, iz: i32| -> f32 {
         let cx = ix.rem_euclid(res) as usize;
-        let cz = iz.clamp(0, res - 1) as usize;
+        let cz = iz.rem_euclid(res) as usize;
         cell_elevation_m(map, dist_to_land, cz * res as usize + cx)
     };
     let e00 = sample(ix0, iz0);

--- a/shared/src/worldgen/tile_bake/heightmap.rs
+++ b/shared/src/worldgen/tile_bake/heightmap.rs
@@ -1,9 +1,9 @@
 //! 65×65 heightmap sampling, encoding, and river-carve geometry.
 
 use super::super::global_map::GlobalMap;
-use super::super::noise::{fbm_wrap_x, smoothstep};
+use super::super::noise::{fbm_wrap_xy, smoothstep};
 use super::super::vector_features::{
-    nearest_river_segment, segments_near_tile_wrap_x, signed_min_distance_to_segments,
+    nearest_river_segment, segments_near_tile_wrap_xy, signed_min_distance_to_segments,
     RiverSegment, Segment,
 };
 use super::constants::{
@@ -85,7 +85,7 @@ pub(super) fn coast_segments_near(
     max_z: f32,
     extra_margin: f32,
 ) -> Vec<Segment> {
-    segments_near_tile_wrap_x(
+    segments_near_tile_wrap_xy(
         &ctx.coasts_world,
         min_x,
         min_z,
@@ -147,19 +147,19 @@ pub(super) fn probe_point_impl(
     wx: f32,
     wz: f32,
 ) -> super::PointProbe {
-    use super::super::vector_features::river_segments_near_tile_wrap_x;
+    use super::super::vector_features::river_segments_near_tile_wrap_xy;
 
     let cfg = &map.config;
     let world_size = cfg.world_size_m as f32;
     let inv_mpc = 1.0 / cfg.meters_per_cell();
     let res = cfg.global_res as i32;
     let gx = (((wx + world_size * 0.5) * inv_mpc).floor() as i32).rem_euclid(res);
-    let gy = (((wz + world_size * 0.5) * inv_mpc).floor() as i32).clamp(0, res - 1);
+    let gy = (((wz + world_size * 0.5) * inv_mpc).floor() as i32).rem_euclid(res);
     let cell_idx = gy as usize * res as usize + gx as usize;
 
     let coast_segs = coast_segments_near(ctx, world_size, wx, wz, wx, wz, 0.0);
     let natural = sample_elevation_no_carve(map, ctx, wx, wz, world_size, inv_mpc, &coast_segs);
-    let segs = river_segments_near_tile_wrap_x(
+    let segs = river_segments_near_tile_wrap_xy(
         &ctx.rivers_world,
         wx,
         wz,
@@ -209,7 +209,7 @@ fn sample_elevation_no_carve(
     inv_mpc: f32,
     coast_segs: &[Segment],
 ) -> f32 {
-    let base_raw = catmull_rom_wrap_x(map, world_x, world_z, world_size, inv_mpc, |i| {
+    let base_raw = catmull_rom_wrap_xy(map, world_x, world_z, world_size, inv_mpc, |i| {
         cell_elevation_m(map, &ctx.dist_to_land, i)
     });
     // Catmull-Rom across the coast can overshoot the adjacent sea cell's
@@ -227,7 +227,7 @@ fn sample_elevation_no_carve(
     } else {
         DETAIL_COAST_DAMP + (1.0 - DETAIL_COAST_DAMP) * inland_t
     };
-    let n = fbm_wrap_x(
+    let n = fbm_wrap_xy(
         &ctx.detail_noise,
         world_x + world_size * 0.5,
         world_z + world_size * 0.5,
@@ -239,7 +239,7 @@ fn sample_elevation_no_carve(
     );
     let detail = n * amp * underwater_damp;
     let hills = if base >= 0.0 {
-        let hn = fbm_wrap_x(
+        let hn = fbm_wrap_xy(
             &ctx.detail_noise,
             world_x + world_size * 0.5,
             world_z + world_size * 0.5,
@@ -490,7 +490,7 @@ pub(super) fn containing_cell_index(
 ) -> usize {
     let res = map.config.global_res as i32;
     let gx = (((world_x + world_size * 0.5) * inv_mpc).floor() as i32).rem_euclid(res);
-    let gy = (((world_z + world_size * 0.5) * inv_mpc).floor() as i32).clamp(0, res - 1);
+    let gy = (((world_z + world_size * 0.5) * inv_mpc).floor() as i32).rem_euclid(res);
     gy as usize * res as usize + gx as usize
 }
 
@@ -647,11 +647,11 @@ fn catmull_rom_1d(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
 
 /// Fractional global-cell coordinates for world position `(wx, wz)`: the
 /// integer cell that contains it plus the sub-cell fractions `fx, fy ∈ [0, 1]`.
-/// Y is clamped to `[0, res-1]` so top/bottom borders stay on-grid; X is
-/// returned as a raw (possibly negative) `i32` since callers wrap it into the
-/// cell array themselves via `rem_euclid(res)`. Shared by every fractional
-/// sampler so the two must stay in lockstep — diverging on `- 0.5` or the
-/// clamp between bilinear and bicubic would desync elevation from splat.
+/// Both components are returned as raw (possibly negative or ≥ res) `i32`
+/// since callers wrap them into the cell array themselves via
+/// `rem_euclid(res)`. Shared by every fractional sampler so the two must
+/// stay in lockstep — diverging on `- 0.5` between bilinear and bicubic
+/// would desync elevation from splat.
 #[inline]
 fn fractional_cell_coords(
     map: &GlobalMap,
@@ -661,19 +661,17 @@ fn fractional_cell_coords(
     inv_mpc: f32,
 ) -> (i32, i32, i32, f32, f32) {
     let res = map.config.global_res as i32;
-    let res_f = res as f32;
     let gx_f = (wx + world_size * 0.5) * inv_mpc - 0.5;
-    let gy_f = ((wz + world_size * 0.5) * inv_mpc - 0.5).clamp(0.0, res_f - 1.0);
+    let gy_f = (wz + world_size * 0.5) * inv_mpc - 0.5;
     let gx0 = gx_f.floor() as i32;
     let gy0 = gy_f.floor() as i32;
     (res, gx0, gy0, gx_f - gx0 as f32, gy_f - gy0 as f32)
 }
 
-/// Catmull-Rom bicubic sample of a cell-indexed scalar field. X wraps,
-/// Z clamps. Reads a 4×4 neighborhood around the fractional position, so
-/// Y-border cells collapse shoulders onto the clamped row (still smooth,
-/// degrades toward linear near the top/bottom edge of the world).
-fn catmull_rom_wrap_x<F: Fn(usize) -> f32>(
+/// Catmull-Rom bicubic sample of a cell-indexed scalar field. Both axes
+/// wrap: the 4×4 neighborhood reads periodic cells across either world
+/// seam, so interpolation quality is uniform everywhere on the torus.
+fn catmull_rom_wrap_xy<F: Fn(usize) -> f32>(
     map: &GlobalMap,
     wx: f32,
     wz: f32,
@@ -683,7 +681,7 @@ fn catmull_rom_wrap_x<F: Fn(usize) -> f32>(
 ) -> f32 {
     let (res, gx0, gy0, fx, fy) = fractional_cell_coords(map, wx, wz, world_size, inv_mpc);
     let ix = |x: i32| x.rem_euclid(res) as usize;
-    let iy = |y: i32| y.clamp(0, res - 1) as usize;
+    let iy = |y: i32| y.rem_euclid(res) as usize;
     let idx = |x: usize, y: usize| y * res as usize + x;
     let sample = |ox: i32, oy: i32| f(idx(ix(gx0 + ox), iy(gy0 + oy)));
 

--- a/shared/src/worldgen/tile_bake/mod.rs
+++ b/shared/src/worldgen/tile_bake/mod.rs
@@ -33,9 +33,7 @@ mod water_field;
 use serde::{Deserialize, Serialize};
 
 use super::global_map::GlobalMap;
-use super::vector_features::{
-    river_segments_near_tile_wrap_x, segments_near_tile, segments_near_tile_wrap_x,
-};
+use super::vector_features::{river_segments_near_tile_wrap_xy, segments_near_tile_wrap_xy};
 
 pub use constants::{
     HEIGHT_BIAS, HEIGHT_STEP, PAL_CLIFF, PAL_DIRT, PAL_GROUND, PAL_RIVER_BED, PAL_ROAD, PAL_SAND,
@@ -148,7 +146,7 @@ pub fn bake_tile_with_bridges(
     let tile_max_z = tile_min_z + TILE_DIM as f32;
 
     let river_margin = river_margin_m();
-    let river_segs = river_segments_near_tile_wrap_x(
+    let river_segs = river_segments_near_tile_wrap_xy(
         &ctx.rivers_world,
         tile_min_x,
         tile_min_z,
@@ -161,13 +159,14 @@ pub fn bake_tile_with_bridges(
     // `road_fade`. Shrinking the margin would desynchronize the fade across
     // tile boundaries.
     let road_margin = ROAD_HALF_WIDTH_M + ROAD_FADE_SPAN_M * 2.0;
-    let road_segs = segments_near_tile(
+    let road_segs = segments_near_tile_wrap_xy(
         &ctx.roads_world,
         tile_min_x,
         tile_min_z,
         tile_max_x,
         tile_max_z,
         road_margin,
+        map.config.world_size_m as f32,
     );
     // Coast margin must reach as far as any classification branch consults
     // it: sand-dominant out to COAST_SAND_M, then a slope-dirt fade out to
@@ -181,7 +180,7 @@ pub fn bake_tile_with_bridges(
     // staircase the height blend removes. (`.max` is a no-op today since the
     // sand reach is wider, but keeps the two coupled if either constant moves.)
     let coast_margin = (COAST_SAND_M + COAST_FADE_SPAN_M).max(COAST_HEIGHT_BLEND_M);
-    let coast_segs = segments_near_tile_wrap_x(
+    let coast_segs = segments_near_tile_wrap_xy(
         &ctx.coasts_world,
         tile_min_x,
         tile_min_z,
@@ -203,11 +202,18 @@ pub fn bake_tile_with_bridges(
             tile_min_z,
             settlement_flattens,
             &ctx.detail_noise,
+            map.config.world_size_m as f32,
         );
     }
     apply_river_carve_to_tile(&mut heights, map, tile_min_x, tile_min_z, &river_segs);
     if !bridge_flattens.is_empty() {
-        bridges::apply_bridge_flatten(&mut heights, tile_min_x, tile_min_z, bridge_flattens);
+        bridges::apply_bridge_flatten(
+            &mut heights,
+            tile_min_x,
+            tile_min_z,
+            bridge_flattens,
+            map.config.world_size_m as f32,
+        );
     }
     let river_field = bake_river_field(map, ctx, &heights, tile_min_x, tile_min_z, &river_segs);
     let water_field = bake_water_field(map, ctx, &heights, tile_min_x, tile_min_z, &river_segs);
@@ -239,6 +245,14 @@ pub(super) fn world_to_tile(wx: f32) -> i32 {
     ((wx + TILE_DIM as f32 * 0.5) / TILE_DIM as f32).floor() as i32
 }
 
+/// Wrap a signed tile index (either axis) into the canonical baked range
+/// for a world of `world_size` meters — e.g. -256..=255 at 32,768 m.
+#[inline]
+pub(super) fn wrap_tile(t: i32, world_size: f32) -> i32 {
+    let n = (world_size / TILE_DIM as f32).round() as i32;
+    (t + n / 2).rem_euclid(n) - n / 2
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{continent, elevation, rivers, roads, settlements};
@@ -267,8 +281,6 @@ mod tests {
             settlement_inland_buffer_cells: 0,
             settlement_river_flow_threshold: 20.0,
             settlement_along_road_count: 0,
-            y_border_wall_cells: 0,
-            y_border_wall_height_m: 0.0,
             ..WorldGenConfig::default()
         }
     }
@@ -313,12 +325,23 @@ mod tests {
 
     #[test]
     fn sea_tiles_encode_below_sea_level() {
-        // Pick a tile far inside the sea (corner of the small test world) and
-        // verify the uint16 values decode to negative meters.
+        // Find the sea cell farthest from land (deep ocean on any seed —
+        // on the torus no fixed corner is guaranteed to be offshore), bake
+        // its tile, and verify the uint16 values decode to negative meters.
         let (map, ctx) = build_context();
-        let world_size = map.config.world_size_m as i32;
-        let tile_edge = world_size / (TILE_DIM as i32) / 2 - 1;
-        let baked = bake_tile(&map, &ctx, tile_edge, tile_edge);
+        let res = map.config.global_res as usize;
+        let dist_to_land = crate::worldgen::grid::bfs_distance_from(&map.land_mask, res, 1, None);
+        let (deep_idx, _) = dist_to_land
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| map.land_mask[*i] == 0)
+            .max_by_key(|(_, &d)| d)
+            .expect("test world has no sea");
+        let mpc = map.config.meters_per_cell();
+        let half = map.config.world_size_m as f32 * 0.5;
+        let wx = ((deep_idx % res) as f32 + 0.5) * mpc - half;
+        let wz = ((deep_idx / res) as f32 + 0.5) * mpc - half;
+        let baked = bake_tile(&map, &ctx, world_to_tile(wx), world_to_tile(wz));
         let mut any_below = false;
         for chunk in baked.heightmap.chunks_exact(2) {
             let v = u16::from_le_bytes([chunk[0], chunk[1]]);
@@ -328,11 +351,9 @@ mod tests {
                 break;
             }
         }
-        // Not every seed puts sea at the edge, but for this config we expect
-        // at least some sub-zero vertices in the ocean corner tile.
         assert!(
             any_below,
-            "expected some sub-zero vertices in an offshore tile"
+            "expected some sub-zero vertices in the deep-ocean tile"
         );
     }
 

--- a/shared/src/worldgen/tile_bake/river_geom.rs
+++ b/shared/src/worldgen/tile_bake/river_geom.rs
@@ -9,7 +9,7 @@
 //! the chosen crossing lands upstream of the visible fan.
 
 use super::super::global_map::GlobalMap;
-use super::super::grid::fold_x_delta_f32;
+use super::super::grid::fold_delta_f32;
 use super::super::rivers::{Polyline, RiverMap};
 use super::constants::{
     RIVER_CARVE_TAPER_EXTRA_M, RIVER_CARVE_TAPER_MIN_M, RIVER_MAX_WIDTH_M, RIVER_MIN_WIDTH_M,
@@ -132,8 +132,8 @@ pub fn polyline_arc_lengths_cells(pts: &[(u32, u32)], res_f: f32) -> Vec<f32> {
     for i in 1..n {
         let (px, py) = pts[i - 1];
         let (qx, qy) = pts[i];
-        let dx = fold_x_delta_f32(qx as f32 - px as f32, res_f);
-        let dy = qy as f32 - py as f32;
+        let dx = fold_delta_f32(qx as f32 - px as f32, res_f);
+        let dy = fold_delta_f32(qy as f32 - py as f32, res_f);
         cumulative += (dx * dx + dy * dy).sqrt();
         lens.push(cumulative);
     }

--- a/shared/src/worldgen/tile_bake/settlement_flatten.rs
+++ b/shared/src/worldgen/tile_bake/settlement_flatten.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 
 use super::super::config::WorldGenConfig;
 use super::super::global_map::GlobalMap;
-use super::super::noise::{smoothstep, PerlinNoise3D};
+use super::super::grid::fold_delta_f32;
+use super::super::noise::{fbm_wrap_xy, smoothstep, PerlinNoise4D};
 use super::super::settlements::Settlement;
 use super::constants::VERTS_PER_SIDE;
 use super::context::BakeContext;
@@ -83,9 +84,12 @@ pub fn build_directives(
 
 /// Bucket pre-built directives by tile. A settlement gets cloned into
 /// every tile its (radius + blend) reach overlaps; tiles without any
-/// settlement reach receive nothing.
+/// settlement reach receive nothing. Tile keys are wrapped into the
+/// canonical baked range so pads straddling a world seam land in the
+/// tiles the bake actually enumerates.
 pub fn group_flattens_by_tile(
     directives: &[SettlementFlatten],
+    world_size: f32,
 ) -> HashMap<(i32, i32), Vec<SettlementFlatten>> {
     let mut out: HashMap<(i32, i32), Vec<SettlementFlatten>> = HashMap::new();
     for d in directives {
@@ -95,7 +99,11 @@ pub fn group_flattens_by_tile(
         let tile_max_z = super::world_to_tile(d.center_z + REACH_M);
         for tz in tile_min_z..=tile_max_z {
             for tx in tile_min_x..=tile_max_x {
-                out.entry((tx, tz)).or_default().push(d.clone());
+                let key = (
+                    super::wrap_tile(tx, world_size),
+                    super::wrap_tile(tz, world_size),
+                );
+                out.entry(key).or_default().push(d.clone());
             }
         }
     }
@@ -111,11 +119,12 @@ pub fn flatten_height_at(
     wz: f32,
     natural: f32,
     directives: &[SettlementFlatten],
-    detail_noise: &PerlinNoise3D,
+    detail_noise: &PerlinNoise4D,
+    world_size: f32,
 ) -> f32 {
     let mut h = natural;
     for fl in directives {
-        h = apply_one(h, wx, wz, fl, detail_noise);
+        h = apply_one(h, wx, wz, fl, detail_noise, world_size);
     }
     h
 }
@@ -129,10 +138,11 @@ fn apply_one(
     wx: f32,
     wz: f32,
     fl: &SettlementFlatten,
-    detail_noise: &PerlinNoise3D,
+    detail_noise: &PerlinNoise4D,
+    world_size: f32,
 ) -> f32 {
-    let dx = wx - fl.center_x;
-    let dz = wz - fl.center_z;
+    let dx = fold_delta_f32(wx - fl.center_x, world_size);
+    let dz = fold_delta_f32(wz - fl.center_z, world_size);
     let dist_sq = dx * dx + dz * dz;
     if dist_sq >= OUTER_SQ {
         return h;
@@ -140,7 +150,18 @@ fn apply_one(
     if dist_sq <= INNER_SQ {
         return fl.target_y;
     }
-    let n = detail_noise.sample(wx * BOUNDARY_NOISE_FREQ, wz * BOUNDARY_NOISE_FREQ, 0.5);
+    // Torus-periodic wobble so a pad straddling a world seam reads the same
+    // boundary noise from both sides.
+    let n = fbm_wrap_xy(
+        detail_noise,
+        wx,
+        wz,
+        world_size,
+        BOUNDARY_NOISE_FREQ,
+        1,
+        2.0,
+        0.5,
+    );
     let dist = dist_sq.sqrt();
     let edge = dist + n * BOUNDARY_NOISE_AMP_M - SETTLEMENT_FLAT_RADIUS_M;
     if edge <= 0.0 {
@@ -161,20 +182,25 @@ pub(super) fn apply_settlement_flatten(
     tile_origin_x: f32,
     tile_origin_z: f32,
     flattens: &[SettlementFlatten],
-    detail_noise: &PerlinNoise3D,
+    detail_noise: &PerlinNoise4D,
+    world_size: f32,
 ) {
     let last = (VERTS_PER_SIDE - 1) as i32;
     for fl in flattens {
-        let i0 = ((fl.center_x - REACH_M - tile_origin_x).floor() as i32).clamp(0, last) as usize;
-        let i1 = ((fl.center_x + REACH_M - tile_origin_x).ceil() as i32).clamp(0, last) as usize;
-        let j0 = ((fl.center_z - REACH_M - tile_origin_z).floor() as i32).clamp(0, last) as usize;
-        let j1 = ((fl.center_z + REACH_M - tile_origin_z).ceil() as i32).clamp(0, last) as usize;
+        // Unwrap the pad center next to this tile so the vertex bounding box
+        // works even when the pad sits across a world seam from the tile.
+        let cx = tile_origin_x + fold_delta_f32(fl.center_x - tile_origin_x, world_size);
+        let cz = tile_origin_z + fold_delta_f32(fl.center_z - tile_origin_z, world_size);
+        let i0 = ((cx - REACH_M - tile_origin_x).floor() as i32).clamp(0, last) as usize;
+        let i1 = ((cx + REACH_M - tile_origin_x).ceil() as i32).clamp(0, last) as usize;
+        let j0 = ((cz - REACH_M - tile_origin_z).floor() as i32).clamp(0, last) as usize;
+        let j1 = ((cz + REACH_M - tile_origin_z).ceil() as i32).clamp(0, last) as usize;
         for j in j0..=j1 {
             for i in i0..=i1 {
                 let wx = tile_origin_x + i as f32;
                 let wz = tile_origin_z + j as f32;
                 let idx = j * VERTS_PER_SIDE + i;
-                heights[idx] = apply_one(heights[idx], wx, wz, fl, detail_noise);
+                heights[idx] = apply_one(heights[idx], wx, wz, fl, detail_noise, world_size);
             }
         }
     }

--- a/shared/src/worldgen/tile_bake/splatmap.rs
+++ b/shared/src/worldgen/tile_bake/splatmap.rs
@@ -3,7 +3,7 @@
 
 use super::super::global_map::GlobalMap;
 use super::super::grass_patches::PatchSample;
-use super::super::noise::{fbm_wrap_x, smoothstep};
+use super::super::noise::{fbm_wrap_xy, smoothstep};
 use super::super::vector_features::{
     min_distance_to_segments, nearest_river_segment, signed_min_distance_to_segments, RiverSegment,
     Segment,
@@ -177,7 +177,7 @@ pub(super) fn bake_splatmap(
                         let s = &river_segs[idx];
                         let px = lerp(s.ax, s.bx, t);
                         let pz = lerp(s.az, s.bz, t);
-                        let n = fbm_wrap_x(
+                        let n = fbm_wrap_xy(
                             &ctx.detail_noise,
                             px + world_size * 0.5,
                             pz + world_size * 0.5,

--- a/shared/src/worldgen/tile_bake/water_field.rs
+++ b/shared/src/worldgen/tile_bake/water_field.rs
@@ -59,9 +59,9 @@
 //! exactly what this bake would emit there.
 
 use super::super::global_map::GlobalMap;
-use super::super::noise::{fbm2, smoothstep, PerlinNoise};
+use super::super::noise::{fbm_wrap_xy, smoothstep, PerlinNoise4D};
 use super::super::vector_features::{
-    min_distance_to_segments, project_point_to_segment, segments_near_tile_wrap_x, RiverSegment,
+    min_distance_to_segments, project_point_to_segment, segments_near_tile_wrap_xy, RiverSegment,
     Segment,
 };
 use super::constants::{
@@ -199,7 +199,7 @@ pub fn bake_water_field(
     // that matters, keeping the field seam-consistent.
     let tile_max_x = tile_origin_x + (VERTS_PER_SIDE as f32 - 1.0);
     let tile_max_z = tile_origin_z + (VERTS_PER_SIDE as f32 - 1.0);
-    let coast_segs = segments_near_tile_wrap_x(
+    let coast_segs = segments_near_tile_wrap_xy(
         &ctx.coasts_world,
         tile_origin_x,
         tile_origin_z,
@@ -210,8 +210,9 @@ pub fn bake_water_field(
     );
 
     // Bank-bump noise is seeded from the world seed alone (world-space
-    // coordinates, no tile inputs), so seam tiles sample identical values.
-    let turb_noise = PerlinNoise::new(map.config.seed ^ TURB_NOISE_SALT);
+    // coordinates, no tile inputs) and torus-periodic, so seam tiles
+    // sample identical values across either world seam.
+    let turb_noise = PerlinNoise4D::new(map.config.seed ^ TURB_NOISE_SALT);
 
     let mut out = Vec::with_capacity(WATER_FIELD_TOTAL_SIZE);
     out.extend_from_slice(WATER_FIELD_BIN_MAGIC);
@@ -349,7 +350,7 @@ fn compute_pixel(
     river_segs: &[RiverSegment],
     seg_tangents: &[(f32, f32)],
     coast_segs: &[Segment],
-    turb_noise: &PerlinNoise,
+    turb_noise: &PerlinNoise4D,
 ) -> WaterPixel {
     let Some((flow_x, flow_z, idx, t, dist)) =
         weighted_flow_and_nearest(wx, wz, river_segs, seg_tangents)
@@ -474,10 +475,12 @@ fn compute_pixel(
         //    uneven bank chops the passing current.
         let bank_band = smoothstep(0.55 * half_width, 0.9 * half_width, dist)
             * (1.0 - smoothstep(0.95 * half_width, bank_end, dist));
-        let bumps = fbm2(
+        let bumps = fbm_wrap_xy(
             turb_noise,
-            wx * TURB_BANK_NOISE_FREQ,
-            wz * TURB_BANK_NOISE_FREQ,
+            wx,
+            wz,
+            map.config.world_size_m as f32,
+            TURB_BANK_NOISE_FREQ,
             2,
             2.0,
             0.5,
@@ -660,7 +663,7 @@ mod tests {
         // the coastline distance at the centerline projection — a
         // property of the generated test world, not of the inputs above.
         // Derive the expectation from the same query the bake used.
-        let coast_segs = segments_near_tile_wrap_x(
+        let coast_segs = segments_near_tile_wrap_xy(
             &ctx.coasts_world,
             -32.0,
             -32.0,

--- a/shared/src/worldgen/vector_features.rs
+++ b/shared/src/worldgen/vector_features.rs
@@ -11,7 +11,7 @@
 //! X-axis wrap: the world is cylindrical in X, so polyline segments whose
 //! endpoints wrap across the seam are split into two half-segments ending at
 //! the ±world/2 edges. Callers whose result must remain continuous across
-//! that seam use `segments_near_tile_wrap_x`, which returns translated
+//! that seam use `segments_near_tile_wrap_xy`, which returns translated
 //! periodic copies in the query's local coordinate frame.
 
 use super::config::WorldGenConfig;
@@ -61,11 +61,11 @@ pub struct RiverSegment {
 /// Convert a polyline to world-space meters by mapping each input point
 /// through `to_cell` (returning cell-coord units, where (gx+0.5, gy+0.5) is
 /// the center of cell (gx, gy)) and then applying the world transform
-/// `pos * mpc - half`. Segments whose endpoints straddle the X seam are
-/// split so each output polyline stays on one side of the seam. Source
+/// `pos * mpc - half`. Segments whose endpoints straddle a world seam (X
+/// or Z) are split so each output polyline stays on one side. Source
 /// vertices are assumed to be ≤ 1 cell apart in each axis — that's how
-/// the seam-split detection (|dx| > half world width) distinguishes a wrap
-/// from a long jump.
+/// the seam-split detection (|delta| > half world size) distinguishes a
+/// wrap from a long jump.
 ///
 /// The closure form unifies cell-index polylines (rivers/roads, where
 /// `to_cell = |(x,y)| [x+0.5, y+0.5]`) with cell-edge half-integer
@@ -77,6 +77,16 @@ where
 {
     let mpc = cfg.meters_per_cell();
     let half = cfg.world_size_m as f32 * 0.5;
+    let world_size = half * 2.0;
+    let fold = |d: f32| {
+        if d > half {
+            d - world_size
+        } else if d < -half {
+            d + world_size
+        } else {
+            d
+        }
+    };
     let to_world = |p: &P| -> [f32; 2] {
         let c = to_cell(p);
         [c[0] * mpc - half, c[1] * mpc - half]
@@ -88,23 +98,46 @@ where
     for raw in points {
         let p = to_world(raw);
         if let Some(&last) = current.last() {
-            if (p[0] - last[0]).abs() > half {
-                let edge_last = if last[0] > 0.0 { half } else { -half };
-                let edge_p = -edge_last;
-                // Interpolate the actual crossing in the unwrapped frame.
-                // Reusing `last.z` on one edge and `p.z` on the other leaves
-                // diagonal crossings as two open endpoints at different Z,
-                // which makes signed-distance queries grow a false side
-                // wedge between them.
-                let world_size = half * 2.0;
-                let p_unwrapped_x = if edge_last > 0.0 {
-                    p[0] + world_size
-                } else {
-                    p[0] - world_size
+            // Walk the segment in the unwrapped frame next to `last`,
+            // splitting at every seam plane it crosses (a corner crossing
+            // splits twice). Interpolating the crossing keeps diagonal
+            // splits from leaving two open endpoints at different
+            // coordinates, which would grow a false side wedge in
+            // signed-distance queries.
+            let mut a = last;
+            let mut bx = last[0] + fold(p[0] - last[0]);
+            let mut bz = last[1] + fold(p[1] - last[1]);
+            loop {
+                // Strict comparisons: a vertex exactly ON a seam plane
+                // (marching-squares midpoints at ±half) is kept in place
+                // rather than split — a segment lying inside the plane
+                // would otherwise divide 0/0.
+                let cross = |av: f32, bv: f32| -> Option<(f32, f32)> {
+                    if bv > half {
+                        Some((((half - av) / (bv - av)).clamp(0.0, 1.0), -world_size))
+                    } else if bv < -half {
+                        Some((((-half - av) / (bv - av)).clamp(0.0, 1.0), world_size))
+                    } else {
+                        None
+                    }
                 };
-                let t = ((edge_last - last[0]) / (p_unwrapped_x - last[0])).clamp(0.0, 1.0);
-                let edge_z = last[1] + (p[1] - last[1]) * t;
-                current.push([edge_last, edge_z]);
+                let tx = cross(a[0], bx);
+                let tz = cross(a[1], bz);
+                let (t, shift_x, shift_z) = match (tx, tz) {
+                    (None, None) => break,
+                    (Some((t, s)), None) => (t, s, 0.0),
+                    (None, Some((t, s))) => (t, 0.0, s),
+                    (Some((tx, sx)), Some((tz, sz))) => {
+                        if tx <= tz {
+                            (tx, sx, 0.0)
+                        } else {
+                            (tz, 0.0, sz)
+                        }
+                    }
+                };
+                let cx = a[0] + (bx - a[0]) * t;
+                let cz = a[1] + (bz - a[1]) * t;
+                current.push([cx, cz]);
                 if current.len() >= 2 {
                     out.push(WorldPolyline {
                         points: std::mem::take(&mut current),
@@ -112,7 +145,10 @@ where
                 } else {
                     current.clear();
                 }
-                current.push([edge_p, edge_z]);
+                a = [cx + shift_x, cz + shift_z];
+                bx += shift_x;
+                bz += shift_z;
+                current.push(a);
             }
         }
         current.push(p);
@@ -208,12 +244,12 @@ pub type Segment = [f32; 4];
 /// Convert a cell-coord river polyline (+ per-vertex flow values) into one
 /// or more world-space polylines with normalized flow and per-vertex width.
 ///
-/// Seam splitting follows `polyline_to_world`: when an edge crosses the ±X
-/// seam, the sequence is cut and a synthetic endpoint is inserted at ±half
-/// world-width. The synthetic endpoint inherits its scalar values (flow,
-/// width) from the vertex on the same side of the seam it was inserted for
-/// — visual seam artifacts on the cylindrical world are acceptable for
-/// now.
+/// Seam splitting follows `polyline_to_world`: when an edge crosses a
+/// world seam (X or Z; a corner crossing splits twice), the sequence is
+/// cut and a synthetic endpoint is inserted on the seam plane. Synthetic
+/// endpoints carry scalars (flow, width, bed floor) linearly interpolated
+/// at the crossing parameter, so both sides of the seam meet with the
+/// same channel profile.
 ///
 /// `flow_raw` must have the same length as `points`. `max_flow` is the
 /// world-wide maximum used to normalize; any value ≤ 0 degrades the output
@@ -257,6 +293,17 @@ pub fn river_polyline_to_world(
         ]
     };
 
+    let world_size = half * 2.0;
+    let fold = |d: f32| {
+        if d > half {
+            d - world_size
+        } else if d < -half {
+            d + world_size
+        } else {
+            d
+        }
+    };
+
     let mut out: Vec<RiverWorldPolyline> = Vec::new();
     let mut current = RiverWorldPolyline::default();
 
@@ -265,29 +312,66 @@ pub fn river_polyline_to_world(
         let fn_v = flow_to_norm(fraw);
         let w_v = norm_to_width(fn_v);
         if let Some(&last) = current.points.last() {
-            if (p[0] - last[0]).abs() > half {
-                let edge_last = if last[0] > 0.0 { half } else { -half };
-                let edge_p = -edge_last;
-                // Close current at the seam with the previous vertex's
-                // scalar values.
-                let last_fn = *current.flow_norm.last().unwrap();
-                let last_w = *current.width.last().unwrap();
-                let last_bed = *current.bed_floor.last().unwrap();
-                current.points.push([edge_last, last[1]]);
-                current.flow_norm.push(last_fn);
-                current.width.push(last_w);
-                current.bed_floor.push(last_bed);
+            // Walk the segment in the unwrapped frame next to `last`,
+            // splitting at every seam plane it crosses. Strict comparisons
+            // keep a vertex exactly ON a seam plane in place (a segment
+            // lying inside the plane would otherwise divide 0/0). Scalars
+            // at a crossing are lerped between the segment endpoints via
+            // the accumulated global parameter.
+            let last_fn = *current.flow_norm.last().unwrap();
+            let last_w = *current.width.last().unwrap();
+            let last_bed = *current.bed_floor.last().unwrap();
+            let mut a = last;
+            let mut bx = last[0] + fold(p[0] - last[0]);
+            let mut bz = last[1] + fold(p[1] - last[1]);
+            let mut t_glob = 0.0f32;
+            loop {
+                let cross = |av: f32, bv: f32| -> Option<(f32, f32)> {
+                    if bv > half {
+                        Some((((half - av) / (bv - av)).clamp(0.0, 1.0), -world_size))
+                    } else if bv < -half {
+                        Some((((-half - av) / (bv - av)).clamp(0.0, 1.0), world_size))
+                    } else {
+                        None
+                    }
+                };
+                let tx = cross(a[0], bx);
+                let tz = cross(a[1], bz);
+                let (t, shift_x, shift_z) = match (tx, tz) {
+                    (None, None) => break,
+                    (Some((t, s)), None) => (t, s, 0.0),
+                    (None, Some((t, s))) => (t, 0.0, s),
+                    (Some((tx, sx)), Some((tz, sz))) => {
+                        if tx <= tz {
+                            (tx, sx, 0.0)
+                        } else {
+                            (tz, 0.0, sz)
+                        }
+                    }
+                };
+                let cx = a[0] + (bx - a[0]) * t;
+                let cz = a[1] + (bz - a[1]) * t;
+                t_glob += (1.0 - t_glob) * t;
+                let lerp = |s0: f32, s1: f32| s0 + (s1 - s0) * t_glob;
+                let cross_fn = lerp(last_fn, fn_v);
+                let cross_w = lerp(last_w, w_v);
+                let cross_bed = lerp(last_bed, 0.0);
+                current.points.push([cx, cz]);
+                current.flow_norm.push(cross_fn);
+                current.width.push(cross_w);
+                current.bed_floor.push(cross_bed);
                 if current.points.len() >= 2 {
                     out.push(std::mem::take(&mut current));
                 } else {
                     current = RiverWorldPolyline::default();
                 }
-                // Start a fresh polyline on the other side with the new
-                // vertex's values.
-                current.points.push([edge_p, p[1]]);
-                current.flow_norm.push(fn_v);
-                current.width.push(w_v);
-                current.bed_floor.push(0.0);
+                a = [cx + shift_x, cz + shift_z];
+                bx += shift_x;
+                bz += shift_z;
+                current.points.push(a);
+                current.flow_norm.push(cross_fn);
+                current.width.push(cross_w);
+                current.bed_floor.push(cross_bed);
             }
         }
         current.points.push(p);
@@ -409,10 +493,10 @@ pub fn river_segments_near_tile(
     out
 }
 
-/// X-periodic counterpart to `river_segments_near_tile`. Matching segments
-/// are translated into the query tile's local circumference while retaining
-/// their per-vertex flow, width, and bed-floor metadata.
-pub fn river_segments_near_tile_wrap_x(
+/// Torus-periodic counterpart to `river_segments_near_tile`. Matching
+/// segments are translated into the query tile's local frame while
+/// retaining their per-vertex flow, width, and bed-floor metadata.
+pub fn river_segments_near_tile_wrap_xy(
     polylines: &[RiverWorldPolyline],
     tile_min_x: f32,
     tile_min_z: f32,
@@ -434,31 +518,35 @@ pub fn river_segments_near_tile_wrap_x(
         for i in 0..poly.points.len() - 1 {
             let a = poly.points[i];
             let b = poly.points[i + 1];
-            let sz0 = a[1].min(b[1]);
-            let sz1 = a[1].max(b[1]);
-            if sz1 < qz0 || sz0 > qz1 {
-                continue;
-            }
-            for shift_x in [-world_size, 0.0, world_size] {
-                let ax = a[0] + shift_x;
-                let bx = b[0] + shift_x;
-                let sx0 = ax.min(bx);
-                let sx1 = ax.max(bx);
-                if sx1 < qx0 || sx0 > qx1 {
+            for shift_z in [-world_size, 0.0, world_size] {
+                let az = a[1] + shift_z;
+                let bz = b[1] + shift_z;
+                let sz0 = az.min(bz);
+                let sz1 = az.max(bz);
+                if sz1 < qz0 || sz0 > qz1 {
                     continue;
                 }
-                out.push(RiverSegment {
-                    ax,
-                    az: a[1],
-                    bx,
-                    bz: b[1],
-                    flow_norm_a: poly.flow_norm[i],
-                    flow_norm_b: poly.flow_norm[i + 1],
-                    width_a: poly.width[i],
-                    width_b: poly.width[i + 1],
-                    bed_floor_a: poly.bed_floor[i],
-                    bed_floor_b: poly.bed_floor[i + 1],
-                });
+                for shift_x in [-world_size, 0.0, world_size] {
+                    let ax = a[0] + shift_x;
+                    let bx = b[0] + shift_x;
+                    let sx0 = ax.min(bx);
+                    let sx1 = ax.max(bx);
+                    if sx1 < qx0 || sx0 > qx1 {
+                        continue;
+                    }
+                    out.push(RiverSegment {
+                        ax,
+                        az,
+                        bx,
+                        bz,
+                        flow_norm_a: poly.flow_norm[i],
+                        flow_norm_b: poly.flow_norm[i + 1],
+                        width_a: poly.width[i],
+                        width_b: poly.width[i + 1],
+                        bed_floor_a: poly.bed_floor[i],
+                        bed_floor_b: poly.bed_floor[i + 1],
+                    });
+                }
             }
         }
     }
@@ -521,15 +609,15 @@ pub fn segments_near_tile(
     out
 }
 
-/// Wrap-aware counterpart to `segments_near_tile` for the cylindrical X
-/// axis. Each source segment is considered at x offsets `-world_size`, `0`,
-/// and `+world_size`; matching segments are returned with that offset already
-/// applied, so ordinary Euclidean distance queries measure the shortest
-/// periodic distance near the world seam.
+/// Wrap-aware counterpart to `segments_near_tile` for the torus. Each
+/// source segment is considered at the 3×3 grid of `±world_size` offsets;
+/// matching segments are returned with the offset already applied, so
+/// ordinary Euclidean distance queries measure the shortest periodic
+/// distance near either world seam.
 ///
 /// Tile/sample coordinates are expected to stay within one circumference of
 /// the canonical world range, as all current bake callers do.
-pub fn segments_near_tile_wrap_x(
+pub fn segments_near_tile_wrap_xy(
     polylines: &[WorldPolyline],
     tile_min_x: f32,
     tile_min_z: f32,
@@ -548,20 +636,24 @@ pub fn segments_near_tile_wrap_x(
         for w in poly.points.windows(2) {
             let a = w[0];
             let b = w[1];
-            let sz0 = a[1].min(b[1]);
-            let sz1 = a[1].max(b[1]);
-            if sz1 < qz0 || sz0 > qz1 {
-                continue;
-            }
-            for shift_x in [-world_size, 0.0, world_size] {
-                let ax = a[0] + shift_x;
-                let bx = b[0] + shift_x;
-                let sx0 = ax.min(bx);
-                let sx1 = ax.max(bx);
-                if sx1 < qx0 || sx0 > qx1 {
+            for shift_z in [-world_size, 0.0, world_size] {
+                let az = a[1] + shift_z;
+                let bz = b[1] + shift_z;
+                let sz0 = az.min(bz);
+                let sz1 = az.max(bz);
+                if sz1 < qz0 || sz0 > qz1 {
                     continue;
                 }
-                out.push([ax, a[1], bx, b[1]]);
+                for shift_x in [-world_size, 0.0, world_size] {
+                    let ax = a[0] + shift_x;
+                    let bx = b[0] + shift_x;
+                    let sx0 = ax.min(bx);
+                    let sx1 = ax.max(bx);
+                    if sx1 < qx0 || sx0 > qx1 {
+                        continue;
+                    }
+                    out.push([ax, az, bx, bz]);
+                }
             }
         }
     }
@@ -861,31 +953,31 @@ mod tests {
     }
 
     #[test]
-    fn segments_near_tile_wrap_x_returns_translated_periodic_copy() {
+    fn segments_near_tile_wrap_xy_returns_translated_periodic_copy() {
         let polys = vec![WorldPolyline {
             // A coast 4 m inside the east edge of a 100 m world.
             points: vec![[46.0, -10.0], [46.0, 10.0]],
         }];
-        let west = segments_near_tile_wrap_x(&polys, -50.0, -1.0, -49.0, 1.0, 8.0, 100.0);
+        let west = segments_near_tile_wrap_xy(&polys, -50.0, -1.0, -49.0, 1.0, 8.0, 100.0);
         assert_eq!(west, vec![[-54.0, -10.0, -54.0, 10.0]]);
 
         // The translated segment gives the same signed distance at the two
         // coordinate representations of the seam itself.
-        let east = segments_near_tile_wrap_x(&polys, 50.0, 0.0, 50.0, 0.0, 8.0, 100.0);
+        let east = segments_near_tile_wrap_xy(&polys, 50.0, 0.0, 50.0, 0.0, 8.0, 100.0);
         let east_sd = signed_min_distance_to_segments(50.0, 0.0, &east).unwrap();
         let west_sd = signed_min_distance_to_segments(-50.0, 0.0, &west).unwrap();
         assert!((east_sd - west_sd).abs() < 1e-6, "{east_sd} vs {west_sd}");
     }
 
     #[test]
-    fn river_segments_near_tile_wrap_x_preserves_metadata() {
+    fn river_segments_near_tile_wrap_xy_preserves_metadata() {
         let polys = vec![RiverWorldPolyline {
             points: vec![[46.0, -10.0], [46.0, 10.0]],
             flow_norm: vec![0.25, 0.75],
             width: vec![4.0, 8.0],
             bed_floor: vec![-1.0, -2.0],
         }];
-        let west = river_segments_near_tile_wrap_x(&polys, -50.0, -1.0, -49.0, 1.0, 8.0, 100.0);
+        let west = river_segments_near_tile_wrap_xy(&polys, -50.0, -1.0, -49.0, 1.0, 8.0, 100.0);
         assert_eq!(west.len(), 1);
         let seg = west[0];
         assert_eq!(
@@ -896,7 +988,7 @@ mod tests {
         assert_eq!((seg.width_a, seg.width_b), (4.0, 8.0));
         assert_eq!((seg.bed_floor_a, seg.bed_floor_b), (-1.0, -2.0));
 
-        let east = river_segments_near_tile_wrap_x(&polys, 50.0, 0.0, 50.0, 0.0, 8.0, 100.0);
+        let east = river_segments_near_tile_wrap_xy(&polys, 50.0, 0.0, 50.0, 0.0, 8.0, 100.0);
         let east_nearest = nearest_river_segment(50.0, 0.0, &east).unwrap();
         let west_nearest = nearest_river_segment(-50.0, 0.0, &west).unwrap();
         assert!((east_nearest.0 - west_nearest.0).abs() < 1e-6);
@@ -964,6 +1056,62 @@ mod tests {
         assert!((first_end[0] - half).abs() < 1e-3);
         let second_start = out[1].points.first().unwrap();
         assert!((second_start[0] + half).abs() < 1e-3);
+    }
+
+    #[test]
+    fn polyline_to_world_splits_across_z_seam() {
+        let cfg = test_config(8, 64);
+        let half = (cfg.world_size_m as f32) * 0.5;
+        let points: Vec<(u32, u32)> = vec![(3, 6), (3, 7), (3, 0), (3, 1)];
+        let out = polyline_to_world(&points, &cfg, cell_index_to_center);
+        assert_eq!(out.len(), 2, "z-seam-crossing polyline splits into 2");
+        let first_end = out[0].points.last().unwrap();
+        assert!((first_end[1] - half).abs() < 1e-3);
+        let second_start = out[1].points.first().unwrap();
+        assert!((second_start[1] + half).abs() < 1e-3);
+    }
+
+    #[test]
+    fn river_polyline_to_world_splits_across_z_seam_with_lerped_scalars() {
+        let cfg = test_config(8, 64);
+        let half = (cfg.world_size_m as f32) * 0.5;
+        // Straight north-south river crossing the Z seam; flow doubles at
+        // the far vertex so the seam crossing must carry an interpolated
+        // value strictly between the two endpoint norms.
+        let points: Vec<(u32, u32)> = vec![(3, 6), (3, 7), (3, 0), (3, 1)];
+        let flow: Vec<f32> = vec![4.0, 4.0, 16.0, 16.0];
+        let out = river_polyline_to_world(&points, &flow, 16.0, 2.0, 10.0, &cfg);
+        assert_eq!(out.len(), 2, "z-seam-crossing river splits into 2");
+        for poly in &out {
+            assert_eq!(poly.points.len(), poly.flow_norm.len());
+            assert_eq!(poly.points.len(), poly.width.len());
+            assert_eq!(poly.points.len(), poly.bed_floor.len());
+            for w in poly.points.windows(2) {
+                let dz = (w[1][1] - w[0][1]).abs();
+                assert!(
+                    dz < half,
+                    "no segment may span the world: {:?} -> {:?}",
+                    w[0],
+                    w[1]
+                );
+            }
+        }
+        let first_end = out[0].points.last().unwrap();
+        let second_start = out[1].points.first().unwrap();
+        assert!((first_end[1] - half).abs() < 1e-3);
+        assert!((second_start[1] + half).abs() < 1e-3);
+        let fn_end = *out[0].flow_norm.last().unwrap();
+        let fn_start = *out[1].flow_norm.first().unwrap();
+        assert!(
+            (fn_end - fn_start).abs() < 1e-6,
+            "both seam endpoints carry the same lerped flow"
+        );
+        let fn_lo = flow[1].log2() / 16.0f32.log2();
+        let fn_hi = 1.0;
+        assert!(
+            fn_end > fn_lo && fn_end < fn_hi,
+            "seam flow must be strictly between endpoint norms: {fn_end} vs ({fn_lo}, {fn_hi})"
+        );
     }
 
     #[test]

--- a/terrain/src/coords.rs
+++ b/terrain/src/coords.rs
@@ -1,11 +1,15 @@
 use std::path::{Path, PathBuf};
 
-/// Full baked X circumference in terrain tiles. The canonical files cover
-/// tile X -256 through 255; runtime render grids may request one tile beyond
-/// either edge and must read the periodic tile from the opposite side.
+/// Full baked circumference in terrain tiles, per axis (the world is a
+/// torus). The canonical files cover tile -256 through 255 on both axes;
+/// runtime render grids may request one tile beyond either edge and must
+/// read the periodic tile from the opposite side.
 pub const WORLD_TILES_X: i32 = 512;
 pub const WORLD_MIN_TILE_X: i32 = -256;
 pub const WORLD_MAX_TILE_X: i32 = WORLD_MIN_TILE_X + WORLD_TILES_X;
+pub const WORLD_TILES_Z: i32 = WORLD_TILES_X;
+pub const WORLD_MIN_TILE_Z: i32 = WORLD_MIN_TILE_X;
+pub const WORLD_MAX_TILE_Z: i32 = WORLD_MIN_TILE_Z + WORLD_TILES_Z;
 
 /// Normalize a render/data tile X into the canonical baked file range.
 #[inline]
@@ -13,10 +17,22 @@ pub fn wrap_tile_x(tile_x: i32) -> i32 {
     (tile_x - WORLD_MIN_TILE_X).rem_euclid(WORLD_TILES_X) + WORLD_MIN_TILE_X
 }
 
+/// Z counterpart of `wrap_tile_x`.
+#[inline]
+pub fn wrap_tile_z(tile_z: i32) -> i32 {
+    (tile_z - WORLD_MIN_TILE_Z).rem_euclid(WORLD_TILES_Z) + WORLD_MIN_TILE_Z
+}
+
 /// Region equivalent of `wrap_tile_x` for the 32 baked X regions.
 #[inline]
 pub fn wrap_region_x(region_x: i32) -> i32 {
     (region_x + 16).rem_euclid(32) - 16
+}
+
+/// Region equivalent of `wrap_tile_z` for the 32 baked Z regions.
+#[inline]
+pub fn wrap_region_z(region_z: i32) -> i32 {
+    (region_z + 16).rem_euclid(32) - 16
 }
 
 /// Convert tile coordinate to region coordinate (floor division).
@@ -39,6 +55,7 @@ fn region_dir_name(rx: i32, rz: i32) -> String {
 /// Build filesystem path for a heightmap tile file.
 pub fn heightmap_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     height_region_dir(base, rx, rz).join(format!("h_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -46,6 +63,7 @@ pub fn heightmap_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
 /// Build filesystem path for a splatmap tile file.
 pub fn splatmap_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     splat_region_dir(base, rx, rz).join(format!("s_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -63,6 +81,7 @@ pub fn splat_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// Build filesystem path for a grass placement data file.
 pub fn grass_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     grass_region_dir(base, rx, rz).join(format!("g_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -75,6 +94,7 @@ pub fn grass_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// Build filesystem path for an original (pre-housing) heightmap tile file.
 pub fn original_heightmap_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     original_height_region_dir(base, rx, rz).join(format!("o_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -87,6 +107,7 @@ pub fn original_height_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// Build filesystem path for an original (pre-housing) grass placement data file.
 pub fn original_grass_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     original_grass_region_dir(base, rx, rz).join(format!("g_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -98,12 +119,16 @@ pub fn original_grass_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 
 /// Build filesystem path for a region zone JSON file.
 pub fn zone_path(base: &Path, rx: i32, rz: i32) -> PathBuf {
+    let rx = wrap_region_x(rx);
+    let rz = wrap_region_z(rz);
     base.join("zones")
         .join(format!("r{:+03}_{:+03}.json", rx, rz))
 }
 
 /// Build filesystem path for a region object JSON file.
 pub fn object_path(base: &Path, rx: i32, rz: i32) -> PathBuf {
+    let rx = wrap_region_x(rx);
+    let rz = wrap_region_z(rz);
     base.join("objects")
         .join(format!("r{:+03}_{:+03}.json", rx, rz))
 }
@@ -111,6 +136,7 @@ pub fn object_path(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// Build filesystem path for a tree placement data file.
 pub fn tree_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     tree_region_dir(base, rx, rz).join(format!("t_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -123,6 +149,7 @@ pub fn tree_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// Build filesystem path for a region minimap PNG file.
 pub fn minimap_path(base: &Path, rx: i32, rz: i32) -> PathBuf {
     let rx = wrap_region_x(rx);
+    let rz = wrap_region_z(rz);
     base.join("minimap")
         .join(format!("r{:+03}_{:+03}.png", rx, rz))
 }
@@ -132,6 +159,7 @@ pub fn minimap_path(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// quad-mesh river renderer. See `shared/src/worldgen/tile_bake/river_field.rs`.
 pub fn river_field_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     river_field_region_dir(base, rx, rz).join(format!("rf_{:+05}_{:+05}.bin", tx, tz))
 }
@@ -147,6 +175,7 @@ pub fn river_field_region_dir(base: &Path, rx: i32, rz: i32) -> PathBuf {
 /// `shared/src/worldgen/tile_bake/water_field.rs`.
 pub fn water_field_path(base: &Path, tx: i32, tz: i32) -> PathBuf {
     let tx = wrap_tile_x(tx);
+    let tz = wrap_tile_z(tz);
     let (rx, rz) = (tile_to_region(tx), tile_to_region(tz));
     water_field_region_dir(base, rx, rz).join(format!("wf_{:+05}_{:+05}.bin", tx, tz))
 }

--- a/terrain/src/tests.rs
+++ b/terrain/src/tests.rs
@@ -37,6 +37,40 @@ fn region_x_wraps_across_baked_file_range() {
 }
 
 #[test]
+fn tile_z_wraps_across_baked_file_range() {
+    assert_eq!(coords::wrap_tile_z(-256), -256);
+    assert_eq!(coords::wrap_tile_z(255), 255);
+    assert_eq!(coords::wrap_tile_z(256), -256);
+    assert_eq!(coords::wrap_tile_z(-257), 255);
+    assert_eq!(coords::wrap_tile_z(768), -256);
+}
+
+#[test]
+fn region_z_wraps_across_baked_file_range() {
+    assert_eq!(coords::wrap_region_z(-16), -16);
+    assert_eq!(coords::wrap_region_z(15), 15);
+    assert_eq!(coords::wrap_region_z(16), -16);
+    assert_eq!(coords::wrap_region_z(-17), 15);
+}
+
+#[test]
+fn tile_paths_wrap_z_to_opposite_edge() {
+    let base = std::path::Path::new("/data");
+    assert_eq!(
+        coords::heightmap_path(base, 0, 256),
+        coords::heightmap_path(base, 0, -256)
+    );
+    assert_eq!(
+        coords::zone_path(base, 3, 16),
+        coords::zone_path(base, 3, -16)
+    );
+    assert_eq!(
+        coords::object_path(base, 16, -17),
+        coords::object_path(base, -16, 15)
+    );
+}
+
+#[test]
 fn heightmap_path_positive() {
     let p = coords::heightmap_path(Path::new("terrain"), 5, 3);
     assert_eq!(

--- a/tools/terrain-gen/src/bake.rs
+++ b/tools/terrain-gen/src/bake.rs
@@ -202,8 +202,10 @@ pub fn run(
     let t = Instant::now();
     let settlement_directives =
         tile_bake::settlement_flatten::build_directives(&settlements_list, &map.config, &map, &ctx);
-    let settlement_flattens =
-        tile_bake::settlement_flatten::group_flattens_by_tile(&settlement_directives);
+    let settlement_flattens = tile_bake::settlement_flatten::group_flattens_by_tile(
+        &settlement_directives,
+        map.config.world_size_m as f32,
+    );
     eprintln!(
         "  Phase 7 pads:        {:.2}s  ({} settlements across {} tiles)",
         t.elapsed().as_secs_f32(),
@@ -226,7 +228,11 @@ pub fn run(
         &bridge_catalog,
         &settlement_directives,
     );
-    let bridge_flattens = bridges::group_flattens_by_tile(&bridge_placements, &bridge_catalog);
+    let bridge_flattens = bridges::group_flattens_by_tile(
+        &bridge_placements,
+        &bridge_catalog,
+        map.config.world_size_m as f32,
+    );
     eprintln!(
         "  Phase 7 bridges:     {:.2}s  ({} bridges across {} tiles)",
         t.elapsed().as_secs_f32(),

--- a/tools/terrain-gen/src/inspect.rs
+++ b/tools/terrain-gen/src/inspect.rs
@@ -302,6 +302,7 @@ pub fn probe(config: &WorldGenConfig, points: &[(f32, f32)]) -> Result<()> {
                 p.natural_height,
                 &pad_directives,
                 &ctx.detail_noise,
+                map.config.world_size_m as f32,
             );
             println!(
                 "  height AFTER settlement flatten (pre-carve): {:+.3}m",

--- a/tools/terrain-gen/src/preview/terrain.rs
+++ b/tools/terrain-gen/src/preview/terrain.rs
@@ -66,11 +66,11 @@ pub(super) fn write_potential_png(map: &GlobalMap, path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Horizontally-shifted version of the land/sea map: the right half of the
-/// map is moved to the left. If the X-wrap is working, the resulting image
-/// has its seam *inside* (where the original left/right edges used to be),
-/// so any discontinuity at the original wrap boundary becomes visible as a
-/// line down the middle. A clean output = seamless wrap.
+/// Half-world-shifted version of the land/sea map on both axes. If the
+/// torus wrap is working, the resulting image has both seams *inside*
+/// (where the original edges used to be), so any discontinuity at either
+/// wrap boundary becomes visible as a line through the middle — a cross
+/// of artifacts marks a broken wrap. A clean output = seamless torus.
 pub(super) fn write_land_sea_shifted_png(
     map: &GlobalMap,
     coast_dist: &[u16],
@@ -81,9 +81,10 @@ pub(super) fn write_land_sea_shifted_png(
 
     let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(n as u32, n as u32);
     for y in 0..n {
+        let src_y = (y + half) % n;
         for x in 0..n {
             let src_x = (x + half) % n;
-            let i = y * n + src_x;
+            let i = src_y * n + src_x;
             let px = shade_cell(map, coast_dist, i);
             img.put_pixel(x as u32, y as u32, px);
         }
@@ -162,7 +163,7 @@ fn land_color(height: f32) -> Rgb<u8> {
 
 /// Multi-source BFS distance field: distance (in cells) from each cell to
 /// the nearest cell of the *opposite* type (sea→land coast = distance to
-/// nearest land; land→coast = distance to nearest sea). X wraps; Y doesn't.
+/// nearest land; land→coast = distance to nearest sea). Both axes wrap.
 /// The returned Vec contains the same value for sea and land cells — for
 /// sea cells it's distance-to-nearest-land, for land it's distance-to-sea.
 /// Capped at u16 max for memory compactness.
@@ -179,22 +180,18 @@ pub(super) fn coast_distance(land_mask: &[u8], res: usize) -> Vec<u16> {
         let here = land_mask[i];
         let left = if x == 0 { res - 1 } else { x - 1 };
         let right = if x + 1 == res { 0 } else { x + 1 };
+        let up = if y == 0 { res - 1 } else { y - 1 };
+        let down = if y + 1 == res { 0 } else { y + 1 };
         let mut touches_opposite = false;
         for &n in &[
-            Some(y * res + left),
-            Some(y * res + right),
-            if y > 0 { Some((y - 1) * res + x) } else { None },
-            if y + 1 < res {
-                Some((y + 1) * res + x)
-            } else {
-                None
-            },
+            y * res + left,
+            y * res + right,
+            up * res + x,
+            down * res + x,
         ] {
-            if let Some(n) = n {
-                if land_mask[n] != here {
-                    touches_opposite = true;
-                    break;
-                }
+            if land_mask[n] != here {
+                touches_opposite = true;
+                break;
             }
         }
         if touches_opposite {
@@ -209,21 +206,17 @@ pub(super) fn coast_distance(land_mask: &[u8], res: usize) -> Vec<u16> {
         let here = land_mask[i];
         let left = if x == 0 { res - 1 } else { x - 1 };
         let right = if x + 1 == res { 0 } else { x + 1 };
+        let up = if y == 0 { res - 1 } else { y - 1 };
+        let down = if y + 1 == res { 0 } else { y + 1 };
         for &n in &[
-            Some(y * res + left),
-            Some(y * res + right),
-            if y > 0 { Some((y - 1) * res + x) } else { None },
-            if y + 1 < res {
-                Some((y + 1) * res + x)
-            } else {
-                None
-            },
+            y * res + left,
+            y * res + right,
+            up * res + x,
+            down * res + x,
         ] {
-            if let Some(n) = n {
-                if land_mask[n] == here && dist[n] > d.saturating_add(1) {
-                    dist[n] = d.saturating_add(1);
-                    queue.push_back(n);
-                }
+            if land_mask[n] == here && dist[n] > d.saturating_add(1) {
+                dist[n] = d.saturating_add(1);
+                queue.push_back(n);
             }
         }
     }


### PR DESCRIPTION
## Summary

- make world generation periodic across both world axes
- wrap player, monster, movement, passability, dungeon, item, and trading interactions across world seams
- update client rendering, coordinates, and world map labels for continuous toroidal navigation

## Testing

- `npm run format`
- `npm run lint`
- `npm run check`
- `cargo fmt`
- `cargo check`
- `git diff --check`

## Preview

Seed 42 full-world preview generated during the terrain bake (4096×4096).
<img width="4096" height="4096" alt="image" src="https://github.com/user-attachments/assets/1a0f14f4-1ded-44cd-a653-974be3200b1f" />



