### PR TITLE
Stop the health bar flickering by depth-offsetting its fill

### DIFF
--- a/client/src/lib/components/PlayerModel.svelte
+++ b/client/src/lib/components/PlayerModel.svelte
@@ -920,6 +920,7 @@
       <!-- Foreground (red) -->
       <T.Mesh
         position.x={-HEALTH_BAR_WIDTH / 2}
+        position.z={0.001}
         scale.x={Math.max(0.001, displayedHealthRatio)}
       >
         <T is={healthBarFillGeometry} />


### PR DESCRIPTION
## Summary

The current-player health bar drew the red fill and the black background overlapping at z=0, so their equal depth caused them to paint over each other while moving. Fixed by pushing the red fill forward so it always draws on top.

https://github.com/user-attachments/assets/72ea3116-076c-4c48-8843-10b12f74a97e


## Changes

the fix is just single line. 😅
- `PlayerModel.svelte`: offset the health bar fill by `+0.001` on the z-axis
so it wins the depth test against the coplanar background. 

## Testing

- Verified in-game: bar no longer flickers while moving; empty portion still renders black at every zoom distance.