### PR TITLE
Ground monster corpses so they don't float on death

### DIFF
--- a/client/src/lib/components/Monster.svelte
+++ b/client/src/lib/components/Monster.svelte
@@ -12,6 +12,7 @@
   import type { MonsterData } from '../types/Monster'
   import { getMonsterDef } from '../data/monsterDefs'
   import { getItemDef } from '../data/itemDefs'
+  import { computeCorpseGroundOffset } from '../utils/characterAnimationUtils'
 
   interface Props {
     position: { x: number; y: number; z: number }
@@ -77,6 +78,7 @@
   let damageTextRef = $state<ReturnType<typeof DamageText>>()
   let lastAppliedOpacity = 1
   let materialsCloned = false
+  let deadGroundApplied = false
   let corpseTimer = 0
   const CORPSE_FADE_START = 25
   const CORPSE_FADE_DURATION = 5
@@ -295,6 +297,14 @@
           }
           if (finishedClipName === (def?.animDie ?? 'Die')) {
             isDeadAnimationFinished = true
+            // The death clip clamps here with the pelvis still raised, so the
+            // corpse would hover. Drop the model so its lowest point in this
+            // settled pose rests on the ground (these rigs have no foot bones,
+            // so the standing sole-offset can't be reused).
+            if (model && !deadGroundApplied) {
+              deadGroundApplied = true
+              model.position.y = computeCorpseGroundOffset(model)
+            }
           }
         })
         playAnimation()

--- a/client/src/lib/utils/characterAnimationUtils.test.ts
+++ b/client/src/lib/utils/characterAnimationUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { computeCorpseGroundOffset } from './characterAnimationUtils'
+
+// A one-bone skinned mesh whose vertices sit at the given local Ys, all fully
+// weighted to the bone. `posedBoneY` moves the bone AFTER bind, standing in for
+// a death clip that poses the skeleton away from its rest pose.
+function makeSkinned(localYs: number[], posedBoneY = 0): THREE.Group {
+  const n = localYs.length
+  const positions = new Float32Array(n * 3)
+  const skinIndex = new Uint16Array(n * 4)
+  const skinWeight = new Float32Array(n * 4)
+  for (let i = 0; i < n; i++) {
+    positions[i * 3 + 1] = localYs[i]
+    skinWeight[i * 4] = 1
+  }
+  const geom = new THREE.BufferGeometry()
+  geom.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geom.setAttribute('skinIndex', new THREE.Uint16BufferAttribute(skinIndex, 4))
+  geom.setAttribute(
+    'skinWeight',
+    new THREE.Float32BufferAttribute(skinWeight, 4)
+  )
+
+  const bone = new THREE.Bone()
+  const mesh = new THREE.SkinnedMesh(geom, new THREE.MeshBasicMaterial())
+  mesh.add(bone)
+  mesh.bind(new THREE.Skeleton([bone]))
+
+  const root = new THREE.Group()
+  root.add(mesh)
+  bone.position.y = posedBoneY
+  root.updateMatrixWorld(true)
+  return root
+}
+
+const CLEARANCE = 0.01
+
+describe('computeCorpseGroundOffset', () => {
+  it('grounds the body and ignores a few outlier vertices', () => {
+    // Body at 0.30 m; one stray vertex dangling to -0.50 m (like a tail tip).
+    // A min-based offset would LIFT the body by +0.51; the percentile must
+    // instead DROP the body ~0.29 so it rests, letting the outlier go below.
+    const body = new Array(100).fill(0.3)
+    const root = makeSkinned([-0.5, ...body])
+    const offset = computeCorpseGroundOffset(root)
+    expect(offset).toBeCloseTo(-0.3 + CLEARANCE, 5)
+  })
+
+  it('rests a uniformly-raised corpse on the floor', () => {
+    const root = makeSkinned(new Array(100).fill(0.25))
+    expect(computeCorpseGroundOffset(root)).toBeCloseTo(-0.25 + CLEARANCE, 5)
+  })
+
+  it('measures the current pose, not the bind pose', () => {
+    const flat = new Array(100).fill(0.2)
+    const rest = computeCorpseGroundOffset(makeSkinned(flat, 0))
+    const posed = computeCorpseGroundOffset(makeSkinned(flat, 0.5))
+    expect(posed).toBeCloseTo(rest - 0.5, 5)
+  })
+
+  it('returns 0 when there is no skinned geometry', () => {
+    const root = new THREE.Group()
+    root.add(
+      new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshBasicMaterial())
+    )
+    expect(computeCorpseGroundOffset(root)).toBe(0)
+  })
+})

--- a/client/src/lib/utils/characterAnimationUtils.ts
+++ b/client/src/lib/utils/characterAnimationUtils.ts
@@ -139,6 +139,58 @@ export function computeSoleGroundOffset(modelRoot: THREE.Object3D): number {
   return Number.isFinite(lowest) ? -lowest + FOOT_GROUND_CLEARANCE : 0
 }
 
+/** Tiny gap (m) kept between a settled corpse and the floor. */
+const CORPSE_GROUND_CLEARANCE = 0.01
+/**
+ * Fraction of skinned vertices allowed below the floor when grounding a corpse.
+ * The contact height is this percentile of vertex heights, not the absolute
+ * minimum. The Death01_Rig pose lands the body splayed with the limbs ~15cm up
+ * and the tail dangling well below them, so keying off the lowest vertices (the
+ * tail tip) leaves the whole body hovering. Grounding at ~8% instead rests the
+ * splayed limbs and torso on the floor; the thin tail just clips through.
+ * Verified on the kobold asset; tune if another monster over/under-sinks.
+ */
+const CORPSE_CONTACT_PERCENTILE = 0.08
+
+/**
+ * Y offset (metres) to add to `model` so the body of its CURRENT animated pose
+ * rests on the floor (y = 0 in the model's own frame).
+ *
+ * Unlike computeSoleGroundOffset this scans every skinned vertex, not just
+ * soles: a fallen corpse touches the ground with its back or flank, and the
+ * AI-generated monster rigs have no foot/toe bones to key off. Measured in the
+ * current pose, so call it once the death clip has clamped on its final frame —
+ * the shared Death01_Rig clip leaves the body raised, so without this the
+ * corpse floats. Uses a low percentile rather than the absolute lowest vertex
+ * so a few stray verts don't leave the body hovering. Returns 0 for a model
+ * with no skinned geometry.
+ */
+export function computeCorpseGroundOffset(model: THREE.Object3D): number {
+  model.updateMatrixWorld(true)
+  const heights: number[] = []
+  const v = new THREE.Vector3()
+
+  model.traverse((child) => {
+    if (!(child instanceof THREE.SkinnedMesh) || !child.skeleton) return
+    const position = child.geometry.getAttribute('position')
+    if (!position) return
+
+    for (let i = 0; i < position.count; i++) {
+      v.fromBufferAttribute(position, i)
+      child.applyBoneTransform(i, v) // skinned position in the current pose
+      child.localToWorld(v)
+      model.worldToLocal(v) // → model-local, independent of model.position
+      heights.push(v.y)
+    }
+  })
+
+  if (heights.length === 0) return 0
+  heights.sort((a, b) => a - b)
+  const contact =
+    heights[Math.floor(CORPSE_CONTACT_PERCENTILE * heights.length)]
+  return -contact + CORPSE_GROUND_CLEARANCE
+}
+
 function findPrimarySkinnedMesh(
   root: THREE.Object3D
 ): THREE.SkinnedMesh | null {


### PR DESCRIPTION
![Before/after: kobold Death01_Rig corpse — raw floats, fixed rests on the ground](https://raw.githubusercontent.com/iwaterheater/OpenMMO/pr10-media/corpse-before-after.jpg)

*Rendered from the real `kobold.glb` at the death clip's final frame. Left: raw (body hovers ~15 cm). Right: with the fix (body rests on the ground).*

## What

Monsters lie down **floating above the ground** when they die. Fixes the `doc/TODO.md` item "kobold 죽을 때 땅 위에 떠 있는 거 고치기". Closes #9.

## Cause

The shared `Death01_Rig` clip lands the body splayed with the limbs ~15 cm up, and monster models never received the grounding offset players get via `computeSoleGroundOffset` — and these AI-generated rigs have no `foot`/`toe` bones, so that sole-based helper can't be reused. The kobold's tail also dangles ~15 cm *below* the limbs, so the lowest skinned vertices are the tail tip (only 4 of 5499 verts are below 2 cm).

## Fix

Add `computeCorpseGroundOffset` (`client/src/lib/utils/characterAnimationUtils.ts`): scan every skinned vertex in the settled (clamped) death pose and drop the model so the body rests on the floor. It grounds to a low **percentile** (~8%, `CORPSE_CONTACT_PERCENTILE`) of vertex heights, **not** the absolute minimum — otherwise the dangling tail pegs the offset and the body floats. `Monster.svelte` applies it once the death clip finishes.

## Verification

- **Unit test** (`characterAnimationUtils.test.ts`): outlier rejection + current-pose measurement — `npx vitest run`, 4/4.
- `prettier` + `eslint` clean on the changed files.
- **Rendered the real kobold asset** in a harness at the `Death01_Rig` final frame (see image above): raw corpse floats; with the fix the limbs/torso rest on the ground and the thin tail clips under.

`CORPSE_CONTACT_PERCENTILE` is a single tunable constant — nudge it if another `Death01_Rig` monster (goblin/orc/…) over- or under-sinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
