### PR TITLE
agent-client: expose torch toggle and ship game-knowledge onboarding

### DIFF
--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -100,6 +100,15 @@ llm = "codex"
 # idle_interval_secs = 3600
 # activity_window_secs = 30
 
+# Stat rolling at character creation (optional, defaults shown).
+# Rerolls until primary stat >= stat_roll_primary, CON >= stat_roll_secondary
+# and guard >= 10, or until stat_rolls attempts are spent. Last roll wins,
+# same as the web client's reroll button. Raise the targets (and attempts)
+# if you want to hold out for a near-perfect sheet.
+# stat_rolls = 12
+# stat_roll_primary = 16
+# stat_roll_secondary = 12
+
 [[npcs]]
 id = "rica"
 account = "npc_merchant"

--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -33,6 +33,9 @@ Available action types (use EXACTLY these field names):
 5. Do nothing (idle/observe/skip turn):
    {"type": "wait"}
 
+6. Light or extinguish your torch (needs a torch in your bag; useful at night):
+   {"type": "torch", "enabled": true}
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.
@@ -42,3 +45,21 @@ IMPORTANT:
 - Flee when HP is low. Prioritize survival over finishing a fight.
 - Keep chat messages short and in-character.
 - Output ONLY the raw JSON object. No ``` blocks.
+
+GAME KNOWLEDGE — how this world works (from the official docs):
+- Towns are no-spawn zones: monsters never appear inside them. If you see no
+  monsters, you are probably standing in town — walk OUT to find them.
+- attack auto-chases: give the monster_id and the client walks you to the
+  monster and keeps swinging. Never use move to approach a monster; move's
+  "target" only works for players and NPCs.
+- Combat is d20 vs the target's guard. Higher-guard monsters are hard to hit
+  at low level. Rough tiers: Kobold Lv1 (guard 8, 2 XP), Goblin Lv2 (guard 9,
+  5 XP), Stalker Lv3 (guard 10, 10 XP, fast), Orc Lv4 (guard 11, 19 XP).
+- XP per kill = 1 + monster_level^2 + max(guard-10,0)*2. Cumulative XP to
+  reach level n = 20 * 2^(n-2): Lv2=20, Lv3=40, Lv4=80, Lv5=160.
+- HP regen ticks every 16 seconds, but only after 10+ seconds without
+  attacking or being hit. To heal, disengage fully and rest several turns.
+- Dying costs 15% of your current level bracket XP and sends you back to
+  spawn — flee early rather than dying to finish a fight.
+- A practical loop: leave town, grind monsters at or below your level until
+  you out-level them, then step up a tier. One monster at a time.

--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -63,3 +63,9 @@ GAME KNOWLEDGE — how this world works (from the official docs):
   spawn — flee early rather than dying to finish a fight.
 - A practical loop: leave town, grind monsters at or below your level until
   you out-level them, then step up a tier. One monster at a time.
+- Your six stats (3-18, always summing 72): STR adds to melee hit and damage,
+  DEX sets your guard (10 + (DEX-10)/2 — what monsters must beat on a d20 to
+  hit you), CON adds max HP and regen. INT/WIS/CHA do little in combat yet.
+- Hit dice by class: knight/barbarian/caveman/valkyrie d10, ranger/samurai/
+  monk/priest d8, rogue/wizard/archaeologist/healer d6. A d6 class is fragile
+  at low level — pick fights accordingly.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -74,6 +74,9 @@ pub(super) enum AgentAction {
         #[serde(alias = "target", alias = "player_name", alias = "target_player")]
         player: String,
     },
+    /// Light or extinguish the carried torch (requires one in the bag).
+    #[serde(rename = "torch", alias = "toggle_torch")]
+    Torch { enabled: bool },
     #[serde(rename = "wait", alias = "idle", alias = "observe", alias = "none")]
     Wait,
 }
@@ -182,6 +185,7 @@ pub(super) fn action_to_command(
         // `execute::handle_response`, not here.
         AgentAction::OfferDeal { .. } => None,
         AgentAction::OpenTrade { .. } => None,
+        AgentAction::Torch { enabled } => Some(ClientMessage::TorchToggle { enabled: *enabled }),
         AgentAction::Wait => None,
     }
 }

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -26,8 +26,16 @@ use crate::ws;
 use crate::LlmType;
 
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
-/// How many times to reroll character stats before settling.
-const MAX_STAT_ROLLS: u32 = 12;
+
+fn default_stat_rolls() -> u32 {
+    12
+}
+fn default_stat_roll_primary() -> u8 {
+    16
+}
+fn default_stat_roll_secondary() -> u8 {
+    12
+}
 
 /// The stat a class leans on, for judging a roll's quality.
 fn primary_stat(
@@ -168,6 +176,15 @@ pub struct NpcConfig {
     pub character_class: Option<String>,
     /// Character gender for auto-creation. Defaults to male when omitted.
     pub gender: Option<Gender>,
+    /// Stat rolls to attempt at character creation; last roll wins.
+    #[serde(default = "default_stat_rolls")]
+    pub stat_rolls: u32,
+    /// Stop rolling early once the class's primary stat reaches this…
+    #[serde(default = "default_stat_roll_primary")]
+    pub stat_roll_primary: u8,
+    /// …and CON (max HP and regen for every class) reaches this.
+    #[serde(default = "default_stat_roll_secondary")]
+    pub stat_roll_secondary: u8,
 
     // --- 3-tier prompt system ---
     /// Path to template prompt file (role-specific behavior rules).
@@ -356,9 +373,10 @@ async fn run_npc_session(
                 label, char_name, class, gender
             );
 
-            // Roll stats — reroll until the class's key stat comes up strong,
-            // like a human spamming the reroll button. Last roll wins.
-            for attempt in 1..=MAX_STAT_ROLLS {
+            // Roll stats — reroll until the roll meets the configured
+            // targets, like a human spamming the reroll button. Last roll
+            // wins, same as the web client.
+            for attempt in 1..=npc.stat_rolls {
                 ws::send(
                     &mut ws_tx,
                     &ClientMessage::RollCharacterStats {
@@ -374,7 +392,9 @@ async fn run_npc_session(
                 let ServerMessage::CharacterStatsRolled { attributes, max_hp } = rolled else {
                     continue;
                 };
-                let good = primary_stat(&class, &attributes) >= 16 && attributes.guard >= 10;
+                let good = primary_stat(&class, &attributes) >= npc.stat_roll_primary
+                    && attributes.con >= npc.stat_roll_secondary
+                    && attributes.guard >= 10;
                 info!(
                     "[{label}] Stat roll {attempt}: STR {} DEX {} CON {} INT {} WIS {} CHA {} guard {} HP {}",
                     attributes.r#str,

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -26,6 +26,23 @@ use crate::ws;
 use crate::LlmType;
 
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+/// How many times to reroll character stats before settling.
+const MAX_STAT_ROLLS: u32 = 12;
+
+/// The stat a class leans on, for judging a roll's quality.
+fn primary_stat(
+    class: &onlinerpg_shared::CharacterClass,
+    a: &onlinerpg_shared::CharacterAttributes,
+) -> u8 {
+    use onlinerpg_shared::CharacterClass::*;
+    match class {
+        Ranger | Rogue | Monk => a.dex,
+        Priest | Healer => a.wis,
+        Wizard | Archaeologist => a.int,
+        Tourist => a.cha,
+        _ => a.r#str,
+    }
+}
 
 /// Parsed schedule condition (validated at load time).
 #[derive(Debug, Clone, PartialEq)]
@@ -339,19 +356,40 @@ async fn run_npc_session(
                 label, char_name, class, gender
             );
 
-            // Roll stats
-            ws::send(
-                &mut ws_tx,
-                &ClientMessage::RollCharacterStats {
-                    character_class: class.clone(),
-                    gender,
-                },
-            )
-            .await?;
-            ws::wait_for_msg(&mut ws_rx, &label, "CharacterStatsRolled", |msg| {
-                matches!(msg, ServerMessage::CharacterStatsRolled { .. })
-            })
-            .await?;
+            // Roll stats — reroll until the class's key stat comes up strong,
+            // like a human spamming the reroll button. Last roll wins.
+            for attempt in 1..=MAX_STAT_ROLLS {
+                ws::send(
+                    &mut ws_tx,
+                    &ClientMessage::RollCharacterStats {
+                        character_class: class.clone(),
+                        gender,
+                    },
+                )
+                .await?;
+                let rolled = ws::wait_for_msg(&mut ws_rx, &label, "CharacterStatsRolled", |msg| {
+                    matches!(msg, ServerMessage::CharacterStatsRolled { .. })
+                })
+                .await?;
+                let ServerMessage::CharacterStatsRolled { attributes, max_hp } = rolled else {
+                    continue;
+                };
+                let good = primary_stat(&class, &attributes) >= 16 && attributes.guard >= 10;
+                info!(
+                    "[{label}] Stat roll {attempt}: STR {} DEX {} CON {} INT {} WIS {} CHA {} guard {} HP {}",
+                    attributes.r#str,
+                    attributes.dex,
+                    attributes.con,
+                    attributes.int,
+                    attributes.wis,
+                    attributes.cha,
+                    attributes.guard,
+                    max_hp
+                );
+                if good {
+                    break;
+                }
+            }
 
             // Create character
             ws::send(


### PR DESCRIPTION
## 요약

에이전트 클라이언트에 세 가지 개선을 제안합니다.

**1. torch 액션 노출** (`src/driver/action.rs`)
프로토콜에는 `TorchToggle`이 있지만 LLM 드라이버가 노출하지 않아, 웹 클라이언트 유저는 밤에 횃불을 켜는데 에이전트는 못 켭니다. `{"type": "torch", "enabled": true}` 액션을 추가해 다른 단순 커맨드(say/respawn)와 동일한 경로로 `ClientMessage::TorchToggle`을 보냅니다.

**2. 기본 시스템 프롬프트에 게임 지식 온보딩 동봉** (`data/system_prompt.txt`)
지금 프롬프트는 '어떻게 행동하는지'(액션 스키마)만 알려주고 '뭘 해야 하는지'는 알려주지 않습니다. 그래서 갓 접속한 에이전트들이 공통적으로:
- 마을(no-spawn 존) 안에서 몬스터를 찾아 헤매고
- `attack`이 자동 추격한다는 걸 몰라 `move`로 몬스터에게 다가가려다 실패합니다 (`move`의 `target`은 캐릭터 전용이라 "no nearby character named 'orc_...'" 워닝)

doc/COMBAT.md의 핵심 수치(XP 공식, 레벨 테이블, d20 vs guard, 스탯·히트다이스 의미, 리젠·사망 페널티)와 스폰 존 규칙을 프롬프트에 담았습니다. 서버 좌표 같은 월드 종속 정보는 넣지 않았고, 문서에 있는 메커니즘만 실었습니다.

**3. 캐릭터 생성 시 스탯 리롤 — 목표치는 config로** (`src/orchestrator.rs`)
웹 클라이언트 유저는 마음에 들 때까지 리롤 버튼을 누를 수 있는데, 에이전트는 한 번 굴리고 결과를 읽지도 않은 채 수락하고 있었습니다. 사람이 리롤 연타하듯 굴리다가 목표를 만족하면 멈춥니다 (마지막 롤 채택 — 웹 UX와 동일한 last-roll-wins). 얼마나 진심으로 굴릴지는 플레이어마다 다르니 `[[npcs]]`에서 조절 가능합니다:

```toml
# stat_rolls = 12            # 리롤 횟수
# stat_roll_primary = 16     # 클래스 주스탯 목표 (완벽주의자는 18)
# stat_roll_secondary = 12   # 부스탯(CON) 목표
```

부스탯은 모든 클래스에서 CON입니다 — 현재 전투에 영향을 주는 스탯은 STR/DEX/CON 셋뿐이고, 주스탯이 아닌 것 중 갓 만든 캐릭터를 살려주는 건 CON(HP·리젠)이라서입니다. guard ≥ 10은 고정 바닥으로 항상 요구합니다.

## 검증

openmmo.to.nexus 라이브 서버에서 claude 백엔드로 확인했습니다. 기본 프롬프트로는 마을에서 배회하던 에이전트가, 이 지식을 넣자 스스로 마을을 벗어나 저티어부터 사냥하며 접속 ~15분 만에 Lv2를 달성했습니다. torch 액션·리롤은 빌드 및 clippy 확인했습니다 (기존 `needless_borrow` 워닝 3건은 본 PR 이전과 동일).

---

## English summary

Three improvements to the agent client:

1. **Expose the torch to the LLM driver** — the protocol has `TorchToggle` but agents couldn't use it; adds a `{"type": "torch", "enabled": true}` action.
2. **Ship game-knowledge onboarding in the default system prompt** — fresh agents idle inside town (a no-spawn zone) and try to `move` toward monsters instead of `attack`-ing (which auto-chases). Folds the key mechanics from doc/COMBAT.md (XP formula, level table, d20 vs guard, stats/hit dice, regen, death penalty) and the spawn-zone rule into the prompt. No world-specific coordinates — only documented mechanics.
3. **Reroll character stats at creation, targets configurable** — the web client lets a human spam reroll; the agent rolled once and accepted blind. Now rerolls (last-roll-wins, same as the web UX) until class primary ≥ `stat_roll_primary`, CON ≥ `stat_roll_secondary` and guard ≥ 10, up to `stat_rolls` attempts (defaults 16 / 12 / 12). CON is the universal secondary: of the six stats only STR/DEX/CON matter in combat today.

Verified against the live server (claude backend): with the onboarding knowledge an agent that previously wandered in town left on its own, hunted low tiers first and hit Lv2 in ~15 minutes. Build + clippy clean (the 3 pre-existing `needless_borrow` warnings are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)