### PR TITLE
Add a local spectator panel to the agent client

### DIFF
--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -25,6 +25,9 @@ account = "npc_example"
 # MCP HTTP server port (default: 8808)
 # mcp_port = 8808
 
+# Spectator web panel on 127.0.0.1 (0 disables)
+# watch_port = 8808
+
 # LLM backend to use: "none", "claude", "openrouter", "codex"
 # - none: no LLM driver (MCP or direct mode)
 # - claude: Claude CLI (stdio subprocess)

--- a/agent-client/src/driver/mod.rs
+++ b/agent-client/src/driver/mod.rs
@@ -21,6 +21,8 @@ mod execute;
 mod movement;
 mod prompt;
 
+pub(crate) use prompt::format_event;
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -104,7 +104,7 @@ pub(super) fn build_prompt(
 
 /// Format a server event as a human-readable line for LLM prompts.
 /// Returns `None` for events that should not be forwarded to the LLM.
-fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<String> {
+pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<String> {
     match msg {
         ServerMessage::JoinSuccess { player, .. } => Some(format!(
             "[Join] You joined as {} at ({:.1}, {:.1}, {:.1})",

--- a/agent-client/src/llm_scheduler.rs
+++ b/agent-client/src/llm_scheduler.rs
@@ -75,17 +75,18 @@ impl PartialOrd for LlmRequest {
 #[derive(Clone)]
 pub struct LlmScheduler {
     request_tx: mpsc::UnboundedSender<LlmRequest>,
+    watch: Option<Arc<crate::watch::WatchHub>>,
 }
 
 impl LlmScheduler {
     /// Create a new scheduler and spawn its background task.
     ///
     /// `max_concurrent`: maximum number of simultaneous LLM calls across all NPCs.
-    pub fn new(max_concurrent: usize) -> Self {
+    pub fn new(max_concurrent: usize, watch: Option<Arc<crate::watch::WatchHub>>) -> Self {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
         tokio::spawn(scheduler_loop(request_rx, max_concurrent));
         info!("LLM scheduler started (max_concurrent={})", max_concurrent);
-        Self { request_tx }
+        Self { request_tx, watch }
     }
 
     /// Submit an LLM request and wait for the response.
@@ -99,6 +100,12 @@ impl LlmScheduler {
         prompt: String,
         invoker: Arc<dyn LlmBackend>,
     ) -> anyhow::Result<String> {
+        let watch = self
+            .watch
+            .as_ref()
+            .and_then(|hub| hub.llm_prompt(label, &prompt));
+        let started = Instant::now();
+
         let (response_tx, response_rx) = oneshot::channel();
         let request = LlmRequest {
             priority,
@@ -111,9 +118,18 @@ impl LlmScheduler {
         self.request_tx
             .send(request)
             .map_err(|_| anyhow::anyhow!("LLM scheduler shut down"))?;
-        response_rx
+        let result = response_rx
             .await
-            .map_err(|_| anyhow::anyhow!("LLM scheduler dropped request"))?
+            .map_err(|_| anyhow::anyhow!("LLM scheduler dropped request"))?;
+
+        if let Some(w) = watch {
+            let elapsed = started.elapsed().as_millis() as u64;
+            match &result {
+                Ok(text) => w.push_timed("llm-response", text.clone(), Some(elapsed)),
+                Err(e) => w.push_timed("llm-error", e.to_string(), Some(elapsed)),
+            }
+        }
+        result
     }
 }
 

--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -10,6 +10,7 @@ mod orchestrator;
 mod shop_info;
 mod state;
 mod terrain_http;
+mod watch;
 mod ws;
 
 use std::sync::Arc;
@@ -62,6 +63,10 @@ struct Config {
     /// Maximum number of concurrent LLM calls across all NPCs (default: 2)
     #[serde(default = "default_max_concurrent")]
     max_concurrent: usize,
+
+    /// Spectator panel port on 127.0.0.1 (default: 8808, 0 disables)
+    #[serde(default = "default_watch_port")]
+    watch_port: u16,
 
     /// Claude CLI integration config (shared across NPCs that don't override)
     #[serde(default)]
@@ -125,6 +130,10 @@ pub fn default_activity_window_secs() -> u64 {
 
 fn default_max_concurrent() -> usize {
     2
+}
+
+fn default_watch_port() -> u16 {
+    8808
 }
 
 const CONFIG_PATH: &str = "data/config.toml";
@@ -193,22 +202,40 @@ async fn main() -> anyhow::Result<()> {
     let (type_mapping, movement_speeds) =
         monster_ai::MonsterAiManager::load_monster_data(include_str!("../../data/monsters.json"));
 
+    let watch_hub = Arc::new(watch::WatchHub::new(
+        npcs.iter().map(|n| n.label().to_string()).collect(),
+    ));
+    let height_sampler = Arc::new(create_height_sampler(
+        &config.terrain,
+        &config.terrain_cache,
+    ));
+
+    // Start the panel before sign-in so it is reachable while waiting
+    if config.watch_port != 0 {
+        tokio::spawn(watch::serve(
+            Arc::clone(&watch_hub),
+            Arc::clone(&height_sampler),
+            config.watch_port,
+        ));
+    }
+
     let shared = Arc::new(SharedResources {
-        height_sampler: Arc::new(create_height_sampler(
-            &config.terrain,
-            &config.terrain_cache,
-        )),
+        height_sampler,
         world_cache: Arc::new(std::sync::RwLock::new(state::WorldCache::new())),
         behavior_trees: Arc::new(behavior_trees),
         type_mapping: Arc::new(type_mapping),
         movement_speeds: Arc::new(movement_speeds),
-        scheduler: llm_scheduler::LlmScheduler::new(config.max_concurrent),
+        scheduler: llm_scheduler::LlmScheduler::new(
+            config.max_concurrent,
+            Some(Arc::clone(&watch_hub)),
+        ),
         auth: match config.auth.mode {
             AuthMode::NpcToken => AuthSource::NpcToken(resolve_npc_token(config.npc_token)?),
             AuthMode::Google => {
                 AuthSource::Google(google_auth::GoogleAuth::sign_in(config.auth.google).await?)
             }
         },
+        watch: watch_hub,
     });
 
     orchestrator::run_orchestrator(config.server, npcs, shared).await

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -166,7 +166,7 @@ pub struct NpcConfig {
 
 impl NpcConfig {
     /// Log label: the account when there is one, else the character it plays.
-    fn label(&self) -> &str {
+    pub fn label(&self) -> &str {
         self.account
             .as_deref()
             .or(self.character_name.as_deref())
@@ -183,6 +183,7 @@ pub struct SharedResources {
     pub movement_speeds: Arc<HashMap<String, crate::monster_ai::MonsterMovement>>,
     pub scheduler: LlmScheduler,
     pub auth: AuthSource,
+    pub watch: Arc<crate::watch::WatchHub>,
 }
 
 /// How sessions prove who they are. Operator NPCs share one secret; a
@@ -405,12 +406,18 @@ async fn run_npc_session(
     }
 
     let (cmd_tx, mut cmd_rx) = mpsc::channel::<ClientMessage>(32);
+    let watch = shared.watch.handle(label);
     let state = Arc::new(Mutex::new(SharedState::new(
         characters,
         cmd_tx,
         Arc::clone(&shared.height_sampler),
         Arc::clone(&shared.world_cache),
+        watch.clone(),
     )));
+    if let Some(w) = &watch {
+        w.set_state(Arc::clone(&state));
+        w.push("system", "Session connected".to_string());
+    }
 
     let account_for_tx = label.to_string();
     let tx_task = tokio::spawn(async move {
@@ -525,6 +532,16 @@ async fn run_npc_session(
     ai_task.abort();
     if let Some(t) = llm_task {
         t.abort();
+    }
+    if let Some(w) = &watch {
+        w.set_disconnected();
+        w.push(
+            "system",
+            format!(
+                "Connection lost — reconnecting in {}s",
+                RECONNECT_DELAY.as_secs()
+            ),
+        );
     }
 
     Ok(())

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -535,6 +535,25 @@ impl SharedState {
                     }
                 }
             }
+            ServerMessage::XpGained {
+                player_id,
+                new_level,
+                max_hp,
+                current_hp,
+                ..
+            } => {
+                if self.self_player_id.as_ref() == Some(player_id) {
+                    if let Some(ref mut p) = self.self_player {
+                        p.level = *new_level;
+                        p.health = *current_hp;
+                        p.max_health = *max_hp;
+                    }
+                } else if let Some(p) = self.nearby_players.get_mut(player_id) {
+                    p.level = *new_level;
+                    p.health = *current_hp;
+                    p.max_health = *max_hp;
+                }
+            }
             ServerMessage::PlayerJoined { player } | ServerMessage::PlayerAppeared { player } => {
                 self.nearby_players.insert(player.id, player.clone());
             }

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -52,6 +52,10 @@ impl WorldCache {
         &self.passability_cache
     }
 
+    pub fn houses(&self) -> &HashMap<String, HouseData> {
+        &self.houses
+    }
+
     pub fn add_house(&mut self, house: HouseData) {
         let rp = pathfinding::build_runtime_passability(&house);
         self.passability_cache.insert(house.id.clone(), rp);
@@ -161,6 +165,8 @@ pub struct SharedState {
     pending_commands: Vec<ClientMessage>,
     /// No-spawn zones received from server on join
     no_spawn_zones: Vec<NoSpawnZone>,
+    /// Spectator panel handle; feeds it chat/combat/system lines
+    watch: Option<Arc<crate::watch::NpcWatch>>,
 }
 
 impl SharedState {
@@ -169,6 +175,7 @@ impl SharedState {
         cmd_tx: mpsc::Sender<ClientMessage>,
         height_sampler: Arc<HeightSampler>,
         world_cache: Arc<std::sync::RwLock<WorldCache>>,
+        watch: Option<Arc<crate::watch::NpcWatch>>,
     ) -> Self {
         Self {
             characters,
@@ -198,6 +205,7 @@ impl SharedState {
             monster_ai: MonsterAiManager::new(),
             pending_commands: Vec::new(),
             no_spawn_zones: Vec::new(),
+            watch,
         }
     }
 
@@ -485,6 +493,17 @@ impl SharedState {
 
     /// Push an event and update tracked state. Returns the urgency of the event.
     pub fn push_event(&mut self, msg: ServerMessage) -> EventUrgency {
+        // Feed the spectator panel before mutating, while names still resolve
+        if let Some(watch) = self.watch.clone() {
+            if let Some(kind) = crate::watch::feed_kind(&msg) {
+                let line = crate::watch::feed_fallback(&msg)
+                    .or_else(|| crate::driver::format_event(self, &msg));
+                if let Some(line) = line {
+                    watch.push(kind, line);
+                }
+            }
+        }
+
         // Update tracked state from certain messages
         match &msg {
             ServerMessage::JoinSuccess { player, .. } => {
@@ -852,6 +871,9 @@ impl SharedState {
 
     /// Push a synthetic agent event visible to the LLM.
     pub fn push_agent_event(&mut self, event: String) {
+        if let Some(watch) = &self.watch {
+            watch.push("agent", event.clone());
+        }
         self.agent_events.push(event);
     }
 

--- a/agent-client/src/watch.html
+++ b/agent-client/src/watch.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenMMO Agent Watch</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font: 13px/1.45 -apple-system, "Segoe UI", "Noto Sans KR", sans-serif;
+    background: #0e1116; color: #d8dee6; display: flex; flex-direction: column;
+  }
+  header {
+    display: flex; align-items: center; gap: 14px; padding: 8px 14px;
+    background: #161b22; border-bottom: 1px solid #262d38; flex-wrap: wrap;
+  }
+  header .dot { width: 9px; height: 9px; border-radius: 50%; background: #e05252; }
+  header .dot.on { background: #4fc36b; box-shadow: 0 0 6px #4fc36b; }
+  header .name { font-weight: 700; font-size: 15px; color: #fff; }
+  header .sub { color: #8b98a8; }
+  .hpwrap { width: 130px; height: 12px; background: #2a1518; border-radius: 6px; overflow: hidden; }
+  .hpbar { height: 100%; background: linear-gradient(90deg, #d94f4f, #e6704f); transition: width .4s; }
+  .stat { color: #b8c2cf; }
+  .stat b { color: #ffd76a; }
+  select {
+    background: #1d242e; color: #d8dee6; border: 1px solid #313a47;
+    border-radius: 6px; padding: 3px 8px; font-size: 13px;
+  }
+  main { flex: 1; display: flex; min-height: 0; }
+  #mapbox { flex: 1.4; position: relative; min-width: 0; }
+  canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
+  #zoombox {
+    position: absolute; right: 10px; top: 10px; display: flex; flex-direction: column; gap: 4px;
+  }
+  #zoombox button {
+    width: 30px; height: 30px; border-radius: 8px; border: 1px solid #37414f;
+    background: rgba(22,27,34,.85); color: #d8dee6; font-size: 16px; cursor: pointer;
+  }
+  #legend {
+    position: absolute; left: 10px; bottom: 10px; background: rgba(14,17,22,.78);
+    border: 1px solid #262d38; border-radius: 8px; padding: 6px 10px; color: #9daab8; font-size: 12px;
+  }
+  #legend span { margin-right: 10px; }
+  #legend i { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; }
+  aside {
+    flex: 1; display: flex; flex-direction: column; min-width: 340px; max-width: 480px;
+    border-left: 1px solid #262d38; background: #12161c;
+  }
+  #filters { display: flex; gap: 6px; padding: 8px 10px; border-bottom: 1px solid #232a35; flex-wrap: wrap; }
+  #filters button {
+    border: 1px solid #313a47; background: #1a212b; color: #94a1b0;
+    border-radius: 20px; padding: 2px 11px; font-size: 12px; cursor: pointer;
+  }
+  #filters button.on { background: #2b3d55; color: #cfe3ff; border-color: #3d5878; }
+  #feed { flex: 1; overflow-y: auto; padding: 8px 10px; display: flex; flex-direction: column; gap: 6px; }
+  .item { border-radius: 8px; padding: 6px 9px; background: #1a202a; border-left: 3px solid #3a4657; word-break: break-word; }
+  .item .t { color: #6b7789; font-size: 11px; margin-right: 6px; }
+  .item.chat { border-left-color: #4fc36b; background: #16241b; }
+  .item.combat { border-left-color: #e0684f; background: #261a18; }
+  .item.trade { border-left-color: #ffd76a; background: #262115; }
+  .item.system { border-left-color: #5d8fd1; }
+  .item.agent { border-left-color: #9a7fd1; background: #1e1a28; }
+  .item.llm-prompt, .item.llm-response, .item.llm-error { border-left-color: #c07fd1; background: #221a26; }
+  .item.llm-error { border-left-color: #e05252; }
+  details summary { cursor: pointer; color: #cfa9de; }
+  details pre {
+    margin-top: 6px; padding: 8px; background: #14181f; border-radius: 6px;
+    font-size: 11.5px; white-space: pre-wrap; word-break: break-word; color: #b9c4d2; max-height: 320px; overflow-y: auto;
+  }
+  .say { color: #7fd19a; font-weight: 600; }
+</style>
+</head>
+<body>
+<header>
+  <select id="npcsel"></select>
+  <span class="dot" id="conn"></span>
+  <span class="name" id="selfname">—</span>
+  <span class="sub" id="selfsub"></span>
+  <div class="hpwrap"><div class="hpbar" id="hp" style="width:0%"></div></div>
+  <span class="stat" id="hptext"></span>
+  <span class="stat">💰 <b id="gold">—</b></span>
+  <span class="stat" id="clock">—</span>
+  <span class="stat" id="floor"></span>
+  <span class="stat" id="bag"></span>
+</header>
+<main>
+  <div id="mapbox">
+    <canvas id="map"></canvas>
+    <div id="zoombox">
+      <button id="zin">+</button>
+      <button id="zout">−</button>
+    </div>
+    <div id="legend">
+      <span><i style="background:#ffd76a"></i>에이전트</span>
+      <span><i style="background:#59c2e6"></i>플레이어</span>
+      <span><i style="background:#b48ae0"></i>NPC</span>
+      <span><i style="background:#e05252"></i>몬스터</span>
+    </div>
+  </div>
+  <aside>
+    <div id="filters"></div>
+    <div id="feed"></div>
+  </aside>
+</main>
+<script>
+"use strict";
+const $ = id => document.getElementById(id);
+const mapC = $("map"), ctx = mapC.getContext("2d");
+
+let npc = null;
+let snap = null;
+let cam = { x: 0, z: 0, ready: false };
+let scale = 4.5;
+let terrain = null;   // {x0, z0, step, res, canvas}
+let terrainReq = null;
+let lastKey = "";
+const KINDS = [
+  ["chat", "채팅"], ["combat", "전투"], ["trade", "거래"],
+  ["llm", "LLM"], ["agent", "감지"], ["system", "시스템"],
+];
+const active = new Set(KINDS.map(k => k[0]));
+
+function heightColor(h) {
+  const lerp = (a, b, t) => a.map((v, i) => v + (b[i] - v) * t);
+  let c;
+  if (h < 0)        c = lerp([20, 56, 79], [74, 144, 184], Math.max(0, 1 + h / 8));
+  else if (h < 0.8) c = lerp([194, 178, 128], [168, 153, 110], h / 0.8);
+  else if (h < 15)  c = lerp([90, 132, 66], [63, 99, 48], (h - 0.8) / 14.2);
+  else if (h < 40)  c = lerp([94, 105, 78], [138, 138, 128], (h - 15) / 25);
+  else              c = [153, 153, 153];
+  return c;
+}
+
+async function fetchTerrain(cx, cz, half) {
+  const key = `${Math.round(cx / 20)}:${Math.round(cz / 20)}:${Math.round(half)}`;
+  if (key === lastKey || terrainReq) return;
+  terrainReq = key;
+  try {
+    const r = await fetch(`/api/height?cx=${cx}&cz=${cz}&half=${half}&res=112`);
+    const d = await r.json();
+    const off = document.createElement("canvas");
+    off.width = d.res; off.height = d.res;
+    const octx = off.getContext("2d");
+    const img = octx.createImageData(d.res, d.res);
+    for (let i = 0; i < d.heights.length; i++) {
+      const [r0, g0, b0] = heightColor(d.heights[i]);
+      img.data[i * 4] = r0; img.data[i * 4 + 1] = g0; img.data[i * 4 + 2] = b0; img.data[i * 4 + 3] = 255;
+    }
+    octx.putImageData(img, 0, 0);
+    terrain = { ...d, canvas: off };
+    lastKey = key;
+  } catch (e) { /* retry next poll */ }
+  terrainReq = null;
+}
+
+function resize() {
+  const r = mapC.getBoundingClientRect();
+  mapC.width = r.width * devicePixelRatio;
+  mapC.height = r.height * devicePixelRatio;
+}
+addEventListener("resize", resize);
+
+function w2s(wx, wz) {
+  return [
+    (wx - cam.x) * scale * devicePixelRatio + mapC.width / 2,
+    (wz - cam.z) * scale * devicePixelRatio + mapC.height / 2,
+  ];
+}
+
+function draw() {
+  requestAnimationFrame(draw);
+  if (!mapC.width) resize();
+  ctx.fillStyle = "#0c1219";
+  ctx.fillRect(0, 0, mapC.width, mapC.height);
+  if (!snap) return;
+
+  const self = snap.self;
+  if (self && cam.ready) {
+    cam.x += (self.position.x - cam.x) * 0.12;
+    cam.z += (self.position.z - cam.z) * 0.12;
+  } else if (self) {
+    cam.x = self.position.x; cam.z = self.position.z; cam.ready = true;
+  }
+
+  const px = scale * devicePixelRatio;
+
+  if (terrain) {
+    const [sx, sy] = w2s(terrain.x0, terrain.z0);
+    const size = terrain.res * terrain.step * px;
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(terrain.canvas, sx, sy, size, size);
+  }
+
+  for (const h of snap.houses || []) {
+    for (const r of h.rooms) {
+      if (r.floor > 0) continue;
+      const [sx, sy] = w2s(r.x, r.z);
+      ctx.fillStyle = "rgba(150,100,52,.6)";
+      ctx.strokeStyle = "rgba(220,170,110,.8)";
+      ctx.lineWidth = 1.2 * devicePixelRatio;
+      ctx.fillRect(sx, sy, r.w * px, r.d * px);
+      ctx.strokeRect(sx, sy, r.w * px, r.d * px);
+    }
+  }
+
+  const label = (sx, sy, text, color) => {
+    ctx.font = `${11 * devicePixelRatio}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.fillStyle = "rgba(0,0,0,.55)";
+    const w = ctx.measureText(text).width;
+    ctx.fillRect(sx - w / 2 - 3, sy - 23 * devicePixelRatio, w + 6, 13 * devicePixelRatio);
+    ctx.fillStyle = color;
+    ctx.fillText(text, sx, sy - 13 * devicePixelRatio);
+  };
+  const hpbar = (sx, sy, frac) => {
+    const w = 24 * devicePixelRatio;
+    ctx.fillStyle = "rgba(0,0,0,.6)";
+    ctx.fillRect(sx - w / 2, sy - 10 * devicePixelRatio, w, 3 * devicePixelRatio);
+    ctx.fillStyle = frac > 0.5 ? "#4fc36b" : frac > 0.25 ? "#ffd76a" : "#e05252";
+    ctx.fillRect(sx - w / 2, sy - 10 * devicePixelRatio, w * Math.max(0, frac), 3 * devicePixelRatio);
+  };
+
+  for (const m of snap.monsters || []) {
+    const [sx, sy] = w2s(m.position.x, m.position.z);
+    const dead = m.state === "dead";
+    ctx.beginPath();
+    ctx.arc(sx, sy, 4.5 * devicePixelRatio, 0, 7);
+    ctx.fillStyle = dead ? "#555" : (m.aggressive ? "#e05252" : "#d98a8a");
+    ctx.fill();
+    if (m.state === "attack" && !dead) {
+      ctx.strokeStyle = "#ff9d4f"; ctx.lineWidth = 2 * devicePixelRatio;
+      ctx.beginPath(); ctx.arc(sx, sy, 7.5 * devicePixelRatio, 0, 7); ctx.stroke();
+    }
+    if (!dead) {
+      hpbar(sx, sy, m.health / m.max_health);
+      label(sx, sy, m.monster_type, "#f0b9b9");
+    }
+  }
+
+  const selfId = self ? self.id : null;
+  for (const p of snap.players || []) {
+    if (selfId !== null && p.id === selfId) continue;
+    const [sx, sy] = w2s(p.position.x, p.position.z);
+    ctx.beginPath();
+    ctx.arc(sx, sy, 5 * devicePixelRatio, 0, 7);
+    ctx.fillStyle = p.is_official_npc ? "#b48ae0" : "#59c2e6";
+    ctx.fill();
+    hpbar(sx, sy, p.health / p.max_health);
+    label(sx, sy, p.name, p.is_official_npc ? "#d7c3f2" : "#bde6f5");
+  }
+
+  if (self) {
+    const [sx, sy] = w2s(self.position.x, self.position.z);
+    ctx.beginPath();
+    ctx.arc(sx, sy, 9 * devicePixelRatio, 0, 7);
+    ctx.strokeStyle = "rgba(255,215,106,.5)"; ctx.lineWidth = 2 * devicePixelRatio;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(sx, sy, 5.5 * devicePixelRatio, 0, 7);
+    ctx.fillStyle = "#ffd76a"; ctx.fill();
+    const a = self.rotation;
+    ctx.beginPath();
+    ctx.moveTo(sx, sy);
+    ctx.lineTo(sx + Math.sin(a) * 14 * devicePixelRatio, sy + Math.cos(a) * 14 * devicePixelRatio);
+    ctx.strokeStyle = "#ffd76a"; ctx.lineWidth = 2.5 * devicePixelRatio; ctx.stroke();
+    hpbar(sx, sy, self.health / self.max_health);
+    label(sx, sy, self.name, "#ffe9ad");
+  }
+
+  if (snap.time && snap.time.night) {
+    ctx.fillStyle = "rgba(20,24,70,.28)";
+    ctx.fillRect(0, 0, mapC.width, mapC.height);
+  }
+
+  if (cam.ready) {
+    const half = Math.max(mapC.width, mapC.height) / (2 * px) * 1.25;
+    fetchTerrain(cam.x, cam.z, Math.min(600, Math.max(60, half)));
+  }
+}
+
+function fmtTime(t) {
+  return new Date(t).toLocaleTimeString("ko-KR", { hour12: false });
+}
+
+function renderHeader() {
+  $("conn").className = "dot" + (snap.connected ? " on" : "");
+  const s = snap.self;
+  if (s) {
+    $("selfname").textContent = s.name;
+    $("selfsub").textContent = `Lv.${s.level} ${s.class}`;
+    $("hp").style.width = (100 * s.health / s.max_health) + "%";
+    $("hptext").textContent = `${s.health}/${s.max_health}`;
+  }
+  $("gold").textContent = snap.gold ?? "—";
+  const t = snap.time || {};
+  $("clock").textContent = t.hour != null
+    ? `${t.night ? "🌙" : "☀️"} ${String(t.hour).padStart(2, "0")}:${String(t.minute).padStart(2, "0")}` : "—";
+  $("floor").textContent = snap.floor > 0 ? `${snap.floor + 1}층` : "";
+  $("bag").textContent = snap.bag ? `🎒 ${snap.bag.length}` : "";
+}
+
+function feedKindGroup(k) { return k.startsWith("llm") ? "llm" : k; }
+
+let renderedCount = 0;
+let renderedFirstT = null;
+function renderFeed() {
+  const feed = snap.feed || [];
+  const box = $("feed");
+  const atBottom = box.scrollHeight - box.scrollTop - box.clientHeight < 60;
+  const firstT = feed.length ? feed[0].t : null;
+  if (firstT !== renderedFirstT) { box.innerHTML = ""; renderedCount = 0; renderedFirstT = firstT; }
+
+  for (let i = renderedCount; i < feed.length; i++) {
+    const it = feed[i];
+    const div = document.createElement("div");
+    div.className = "item " + it.k;
+    div.dataset.group = feedKindGroup(it.k);
+    const time = `<span class="t">${fmtTime(it.t)}</span>`;
+    if (it.k === "llm-prompt") {
+      div.innerHTML = `${time}<details><summary>📋 프롬프트 (${it.m.length}자)</summary><pre></pre></details>`;
+      div.querySelector("pre").textContent = it.m;
+    } else if (it.k === "llm-response") {
+      const dur = it.d != null ? ` · ${(it.d / 1000).toFixed(1)}s` : "";
+      div.innerHTML = `${time}<details open><summary>💭 LLM 응답${dur}</summary><pre></pre></details>`;
+      let text = it.m;
+      try { text = JSON.stringify(JSON.parse(it.m), null, 2); } catch (e) {}
+      div.querySelector("pre").textContent = text;
+    } else if (it.k === "llm-error") {
+      div.innerHTML = `${time}⚠️ LLM 오류: `;
+      div.append(it.m);
+    } else if (it.k === "chat") {
+      div.innerHTML = time;
+      const span = document.createElement("span");
+      span.className = "say";
+      span.textContent = it.m.replace(/^\[Chat\]\s*/, "💬 ");
+      div.append(span);
+    } else {
+      div.innerHTML = time;
+      div.append(it.m);
+    }
+    div.style.display = active.has(feedKindGroup(it.k)) ? "" : "none";
+    box.append(div);
+  }
+  renderedCount = feed.length;
+  if (atBottom) box.scrollTop = box.scrollHeight;
+}
+
+function buildFilters() {
+  const box = $("filters");
+  for (const [key, name] of KINDS) {
+    const b = document.createElement("button");
+    b.textContent = name;
+    b.className = "on";
+    b.onclick = () => {
+      if (active.has(key)) { active.delete(key); b.classList.remove("on"); }
+      else { active.add(key); b.classList.add("on"); }
+      for (const el of $("feed").children) {
+        el.style.display = active.has(el.dataset.group) ? "" : "none";
+      }
+    };
+    box.append(b);
+  }
+}
+
+async function poll() {
+  try {
+    const r = await fetch(`/api/state${npc ? "?npc=" + encodeURIComponent(npc) : ""}`);
+    snap = await r.json();
+    renderHeader();
+    renderFeed();
+  } catch (e) {
+    $("conn").className = "dot";
+  }
+  setTimeout(poll, 1000);
+}
+
+async function init() {
+  buildFilters();
+  try {
+    const r = await fetch("/api/npcs");
+    const d = await r.json();
+    const sel = $("npcsel");
+    for (const l of d.npcs) {
+      const o = document.createElement("option");
+      o.value = o.textContent = l;
+      sel.append(o);
+    }
+    npc = d.npcs[0] || null;
+    sel.onchange = () => {
+      npc = sel.value; snap = null; cam.ready = false;
+      terrain = null; lastKey = ""; renderedFirstT = -1;
+      $("feed").innerHTML = ""; renderedCount = 0;
+    };
+    if (d.npcs.length < 2) sel.style.display = "none";
+  } catch (e) {}
+  resize();
+  poll();
+  draw();
+}
+
+$("zin").onclick = () => { scale = Math.min(20, scale * 1.35); lastKey = ""; };
+$("zout").onclick = () => { scale = Math.max(1.2, scale / 1.35); lastKey = ""; };
+mapC.addEventListener("wheel", e => {
+  e.preventDefault();
+  scale = Math.min(20, Math.max(1.2, scale * (e.deltaY < 0 ? 1.15 : 0.87)));
+  lastKey = "";
+}, { passive: false });
+
+init();
+</script>
+</body>
+</html>

--- a/agent-client/src/watch.rs
+++ b/agent-client/src/watch.rs
@@ -1,0 +1,312 @@
+//! Local spectator panel: a small HTTP server that exposes each NPC's live
+//! game state (map, entities, chat/combat feed, LLM turns) to a browser page.
+//! Read-only and bound to 127.0.0.1 — it observes the agent, never drives it.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use axum::extract::{Query, State};
+use axum::response::{Html, IntoResponse, Json};
+use axum::routing::get;
+use axum::Router;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::state::SharedState;
+use onlinerpg_terrain::height::HeightSampler;
+
+const FEED_CAP: usize = 300;
+const FEED_SNAPSHOT: usize = 200;
+const PROMPT_TEXT_CAP: usize = 6000;
+
+#[derive(Clone, serde::Serialize)]
+pub struct FeedItem {
+    /// Unix ms.
+    pub t: u64,
+    /// Kind: chat | combat | trade | system | agent | llm-prompt | llm-response | llm-error.
+    pub k: &'static str,
+    pub m: String,
+    /// Duration ms (LLM responses only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub d: Option<u64>,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Per-NPC watch handle. Outlives sessions, so the feed survives reconnects.
+pub struct NpcWatch {
+    feed: StdMutex<VecDeque<FeedItem>>,
+    state: StdMutex<Option<Arc<Mutex<SharedState>>>>,
+    connected: AtomicBool,
+}
+
+impl NpcWatch {
+    fn new() -> Self {
+        Self {
+            feed: StdMutex::new(VecDeque::new()),
+            state: StdMutex::new(None),
+            connected: AtomicBool::new(false),
+        }
+    }
+
+    pub fn push(&self, kind: &'static str, text: String) {
+        self.push_timed(kind, text, None)
+    }
+
+    pub fn push_timed(&self, kind: &'static str, text: String, duration_ms: Option<u64>) {
+        let mut feed = self.feed.lock().unwrap();
+        feed.push_back(FeedItem {
+            t: now_ms(),
+            k: kind,
+            m: text,
+            d: duration_ms,
+        });
+        while feed.len() > FEED_CAP {
+            feed.pop_front();
+        }
+    }
+
+    pub fn set_state(&self, state: Arc<Mutex<SharedState>>) {
+        *self.state.lock().unwrap() = Some(state);
+        self.connected.store(true, Ordering::Relaxed);
+    }
+
+    pub fn set_disconnected(&self) {
+        self.connected.store(false, Ordering::Relaxed);
+    }
+
+    fn current_state(&self) -> Option<Arc<Mutex<SharedState>>> {
+        self.state.lock().unwrap().clone()
+    }
+
+    fn feed_snapshot(&self) -> Vec<FeedItem> {
+        let feed = self.feed.lock().unwrap();
+        feed.iter()
+            .skip(feed.len().saturating_sub(FEED_SNAPSHOT))
+            .cloned()
+            .collect()
+    }
+}
+
+/// All NPC watch handles, keyed by orchestrator label. Fixed at startup.
+pub struct WatchHub {
+    npcs: Vec<(String, Arc<NpcWatch>)>,
+}
+
+impl WatchHub {
+    pub fn new(labels: Vec<String>) -> Self {
+        Self {
+            npcs: labels
+                .into_iter()
+                .map(|l| (l, Arc::new(NpcWatch::new())))
+                .collect(),
+        }
+    }
+
+    pub fn handle(&self, label: &str) -> Option<Arc<NpcWatch>> {
+        self.npcs
+            .iter()
+            .find(|(l, _)| l == label)
+            .map(|(_, w)| Arc::clone(w))
+    }
+
+    /// Record an LLM turn start; returns the handle for the response push.
+    pub fn llm_prompt(&self, label: &str, prompt: &str) -> Option<Arc<NpcWatch>> {
+        let w = self.handle(label)?;
+        let mut text = prompt.chars().take(PROMPT_TEXT_CAP).collect::<String>();
+        if prompt.len() > text.len() {
+            text.push_str("\n… (truncated)");
+        }
+        w.push("llm-prompt", text);
+        Some(w)
+    }
+}
+
+struct AppState {
+    hub: Arc<WatchHub>,
+    height: Arc<HeightSampler>,
+}
+
+#[derive(Deserialize)]
+struct NpcQuery {
+    npc: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct HeightQuery {
+    cx: f32,
+    cz: f32,
+    #[serde(default = "default_half")]
+    half: f32,
+    #[serde(default = "default_res")]
+    res: usize,
+}
+
+fn default_half() -> f32 {
+    100.0
+}
+
+fn default_res() -> usize {
+    96
+}
+
+pub async fn serve(hub: Arc<WatchHub>, height: Arc<HeightSampler>, port: u16) {
+    let app_state = Arc::new(AppState { hub, height });
+    let app = Router::new()
+        .route("/", get(page))
+        .route("/api/npcs", get(npcs))
+        .route("/api/state", get(state_snapshot))
+        .route("/api/height", get(height_grid))
+        .with_state(app_state);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            warn!("Watch panel failed to bind {addr}: {e}");
+            return;
+        }
+    };
+    info!("Watch panel: http://{addr}/");
+    if let Err(e) = axum::serve(listener, app).await {
+        warn!("Watch panel server stopped: {e}");
+    }
+}
+
+async fn page() -> Html<&'static str> {
+    Html(include_str!("watch.html"))
+}
+
+async fn npcs(State(app): State<Arc<AppState>>) -> Json<serde_json::Value> {
+    let labels: Vec<&str> = app.hub.npcs.iter().map(|(l, _)| l.as_str()).collect();
+    Json(json!({ "npcs": labels }))
+}
+
+async fn state_snapshot(
+    State(app): State<Arc<AppState>>,
+    Query(q): Query<NpcQuery>,
+) -> impl IntoResponse {
+    let entry = match &q.npc {
+        Some(label) => app.hub.npcs.iter().find(|(l, _)| l == label),
+        None => app.hub.npcs.first(),
+    };
+    let Some((label, watch)) = entry else {
+        return Json(json!({ "error": "unknown npc" }));
+    };
+
+    let feed = watch.feed_snapshot();
+    let connected = watch.connected.load(Ordering::Relaxed);
+
+    let Some(state_arc) = watch.current_state() else {
+        return Json(json!({
+            "npc": label, "connected": false, "feed": feed,
+        }));
+    };
+
+    let s = state_arc.lock().await;
+    let houses: Vec<serde_json::Value> = {
+        let wc = s.world_cache.read().unwrap();
+        wc.houses()
+            .values()
+            .map(|h| {
+                let rooms: Vec<serde_json::Value> = h
+                    .rooms
+                    .iter()
+                    .map(|r| {
+                        json!({
+                            "x": h.origin.x + r.local_x as f32,
+                            "z": h.origin.z + r.local_z as f32,
+                            "w": r.size_x, "d": r.size_z, "floor": r.floor_level,
+                        })
+                    })
+                    .collect();
+                json!({ "id": h.id, "rooms": rooms })
+            })
+            .collect()
+    };
+
+    Json(json!({
+        "npc": label,
+        "connected": connected && s.in_game,
+        "self": s.self_player,
+        "gold": s.self_gold,
+        "floor": s.self_floor_level,
+        "bag": s.self_bag,
+        "time": { "hour": s.game_hour, "minute": s.game_minute, "night": s.is_night },
+        "players": s.nearby_players.values().collect::<Vec<_>>(),
+        "monsters": s.nearby_monsters.values().collect::<Vec<_>>(),
+        "houses": houses,
+        "feed": feed,
+    }))
+}
+
+async fn height_grid(
+    State(app): State<Arc<AppState>>,
+    Query(q): Query<HeightQuery>,
+) -> Json<serde_json::Value> {
+    let res = q.res.clamp(8, 160);
+    let half = q.half.clamp(10.0, 600.0);
+    let step = (half * 2.0) / res as f32;
+    let x0 = q.cx - half;
+    let z0 = q.cz - half;
+
+    let mut heights = Vec::with_capacity(res * res);
+    for iz in 0..res {
+        for ix in 0..res {
+            let x = x0 + (ix as f32 + 0.5) * step;
+            let z = z0 + (iz as f32 + 0.5) * step;
+            let h = app.height.sample_height(x, z).await.unwrap_or(0.0);
+            heights.push((h * 100.0).round() / 100.0);
+        }
+    }
+
+    Json(json!({
+        "x0": x0, "z0": z0, "step": step, "res": res, "heights": heights,
+    }))
+}
+
+/// Feed category for a server message; `None` keeps it off the panel
+/// (movement/time spam is visible on the map already).
+pub fn feed_kind(msg: &onlinerpg_shared::ServerMessage) -> Option<&'static str> {
+    use onlinerpg_shared::ServerMessage as M;
+    Some(match msg {
+        M::ChatMessage { .. } => "chat",
+        M::PlayerAttacked { .. }
+        | M::MonsterAttackedPlayer { .. }
+        | M::MonsterDead { .. }
+        | M::PlayerDead { .. }
+        | M::PlayerRespawned { .. }
+        | M::XpGained { .. } => "combat",
+        M::DealResult { .. } | M::TradeNotice { .. } | M::TradeError { .. } => "trade",
+        M::JoinSuccess { .. }
+        | M::Kicked { .. }
+        | M::ServerNotice { .. }
+        | M::PlayerJoined { .. }
+        | M::PlayerLeft { .. }
+        | M::PlayerAppeared { .. }
+        | M::PlayerDisappeared { .. }
+        | M::CharacterCreated { .. }
+        | M::CharacterError { .. } => "system",
+        _ => return None,
+    })
+}
+
+/// Message text for feed kinds `format_event` does not cover.
+pub fn feed_fallback(msg: &onlinerpg_shared::ServerMessage) -> Option<String> {
+    use onlinerpg_shared::ServerMessage as M;
+    match msg {
+        M::ServerNotice { message } => Some(format!(
+            "[Notice] {}",
+            message.as_deref().unwrap_or("(cleared)")
+        )),
+        _ => None,
+    }
+}


### PR DESCRIPTION
The agent plays headless — the only way to watch it was logging a second character in next to it. This adds a read-only web panel served by the agent-client itself on `127.0.0.1:8808` (`watch_port` in config, `0` disables):

- **Live top-down map** rendered from real height tiles — terrain colors by elevation (sea/sand/grass/rock), house footprints, players / official NPCs / monsters with name labels and HP bars, aggressive/attack states, self marker with facing arrow, night tint, wheel zoom
- **Status header**: HP bar, gold, game clock (day/night), floor, bag count
- **Categorized event feed**: chat / combat / trade / system / agent events, plus **every LLM turn** — the prompt sent (collapsed), the response received (pretty-printed JSON with duration), and errors — captured in `LlmScheduler::submit` so every backend (claude / codex / openrouter) is covered at one choke point
- Per-NPC tabs when several NPCs run on one instance; feed ring buffers live outside the session so they survive reconnects; the panel starts before Google sign-in completes, so the page is reachable while the device flow waits

Implementation notes:

- Game events are captured in `SharedState::push_event` *before* the message mutates state, while player names still resolve, reusing `driver::prompt::format_event` so the panel shows exactly the lines the LLM reads. Movement/time-sync spam stays off the feed (the map shows it live instead).
- `/api/height` samples the shared `HeightSampler` server-side, so the browser needs no tile protocol and the tile cache is reused.
- No new dependencies — axum and serde_json were already in the tree. Bound to `127.0.0.1`, strictly read-only (no command path from the panel to the agent).

Tested: `cargo test -p agent-client` 20/20 passing, clippy clean for the new code (the 3 pre-existing `needless_borrow` warnings in orchestrator.rs are untouched), plus a live smoke test — panel served real prod height tiles around (5000, −4000) with a stubbed session snapshot to verify map, feed, filters, and LLM-turn rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
