### PR TITLE
Echo own monster moves into local state

### DIFF
--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -504,6 +504,24 @@ async fn run_npc_session(
             };
 
             for cmd in commands.into_iter().chain(pending) {
+                // Self-echo: the server skips broadcasting our own monster
+                // moves back to us, so apply them locally or every owned
+                // monster stays frozen at its spawn position — and the LLM
+                // swings at coordinates the monster left long ago.
+                if let ClientMessage::MonsterMove {
+                    ref monster_id,
+                    ref position,
+                    rotation,
+                    state: monster_state,
+                    ..
+                } = cmd
+                {
+                    if let Some(m) = s.nearby_monsters.get_mut(monster_id) {
+                        m.position = *position;
+                        m.rotation = rotation;
+                        m.state = monster_state;
+                    }
+                }
                 if let Err(e) = s.send_command(cmd).await {
                     tracing::warn!("Monster AI command failed: {e}");
                     break;


### PR DESCRIPTION
Monsters owned by the agent-client (ambient spawns it hosts AI for) stay frozen at their spawn position in the client's own `nearby_monsters` map, while their real server-side position wanders off with the AI. Two facts combine into this:

1. The server deliberately skips echoing `MonsterMoved` back to the client that moved the monster (`skip_player_id` in the monster-move visibility diff).
2. The agent-client never applies its own outgoing `MonsterMove` commands to local state — `tick_all` returns commands, they get sent, and nothing writes the new position back.

So the LLM is fed phantom coordinates for every monster this client spawned: it sees "scp939 1.4m away", the chase loop agrees it is already in range (same stale position) and never walks, `PlayerAttack` goes out, and the server's range gate silently drops it because the monster's real position is elsewhere — no event, no error, and the LLM retries forever. Operator NPCs (guards/merchants with combat behaviors) are affected the same way. Observed live: an agent standing in a spawn field swung at the same monster for 5+ minutes with zero `PlayerAttacked` events, while another (human) player killed those same monsters normally — their client receives the broadcasts.

The fix mirrors what the server's skip assumes: the owner already knows where its monsters are — so apply each outgoing `MonsterMove` to `nearby_monsters` (position, rotation, state) before sending it.

Verified against prod: before, owned monsters moved **0/18** across samples 35s apart (all `idle` at spawn coordinates, indefinitely); after, **27/27** moved across 90s (up to 47m, with live idle→walk→run state transitions). `cargo test -p agent-client` 20/20, clippy clean for the change.

Found while watching an agent through the spectator panel proposed in #13 — the map made the frozen-monster pattern obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
