### PR TITLE
docs: add Simplified Chinese and Japanese READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,250 @@
+# オープン MMORPG
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+AI エージェントと人間のプレイヤーを対等に扱う MMORPG です。
+
+エージェントと人間は同じ世界に接続し、同じルールに従って行動し、区別なく互いに交流します。エージェント専用の特権 API はなく、人間のプレイヤーと同じインターフェースを通じて参加します。
+
+**今すぐプレイ：[openmmo.to.nexus](https://openmmo.to.nexus)** — Google でログインすれば、すぐにゲームへ参加できます。
+
+> 個人開発・Vibe Coding によるプロジェクトです。アセットには、AI 生成、手続き型・プログラムによる生成、インターネットから入手したものが混在しています。PR を歓迎します！
+
+## 機能
+
+- **エージェントと人間の対等性**：エージェントと人間のプレイヤーはまったく同じ WebSocket プロトコルを使用します。特権 API も個別のエンドポイントもありません。サーバーは両者を区別できないため、人間にできることはエージェントにもでき、その逆も同様です。
+- **リアルタイムマルチプレイ**：WebSocket によるリアルタイムのプレイヤー同期
+- **3D 環境**：Three.js を基盤としたクォータービューの 3D ゲーム世界
+- **点光源の松明**：距離減衰と影を備えたリアルタイムの点光源を松明が投射
+
+![松明で照らされた夜の風景](doc/images/gameplay-night.png)
+
+- **建築とハウジング**：部屋単位のオクルージョンと L 字型の屋根接続に対応した、モジュール式の木骨建築
+  - 2、3、4 階建てに対応
+  - 開閉できるインタラクティブなドアと窓
+  - 壁、屋根、床のテクスチャやマテリアルをカスタマイズ可能
+  - ベッドなどの家具を配置し、ゲーム世界内で操作（睡眠／使用）可能
+
+![ベッドを備えたプレイヤー建築の木骨住宅](doc/images/gameplay-housing.png)
+- **昼夜サイクル**：太陽、空、環境光が変化する時刻シミュレーション
+  - 昼夜の長さは惑星の公転位置に応じて変化（季節による長い昼と長い夜）
+- **双子の月**：独立した軌道と満ち欠けを持つ 2 つの月をシミュレーション
+
+![太陽、惑星、2 つの月を示す天体軌道パネル](doc/images/gameplay-orbits.png)
+- **手続き型の世界**：地形、河川、海岸線、バイオームを完全に手続き型で生成
+  - 32 km × 32 km の広大な世界
+  - 浸食された流路と網状分流を備えた河川を手続き型で生成
+  - 各地の集落を結ぶ道路網を手続き型で生成
+  - 道路と河川が交差する場所に橋を自動配置
+  - 突風に合わせて揺れる草や植物
+  - アニメーションする海の波（Gerstner）と流れる川面のさざ波
+  - 淡水と海水が混ざる河口に、分岐した分流と遷移表現を備えた三角州を形成
+
+![手続き型で生成されたワールドマップ](doc/images/gameplay-worldmap.png)
+
+![手続き型の河川に自動配置された木橋](doc/images/gameplay-bridge.png)
+
+![網状分流と砂州が海へ続く河川デルタ](doc/images/gameplay-delta.png)
+
+- **内蔵マップエディター**：ゲーム世界を形作るためのゲーム内ツール
+  - 道路、平坦化、高さペイントなどの地形ブラシによるリアルタイム編集
+  - 建物、小物、植物などをプレビューしながら配置
+  - 矩形領域を描画し、町（スポーン禁止）やリージョンごとのモンスター出現区域を設定
+
+![高さブラシを有効にしたゲーム内マップエディター](doc/images/gameplay-map-editor.png)
+
+- **能力値ベースの戦闘**：NetHack／D&D 風のサーバー権威型戦闘
+  - 6 つの標準能力値（STR、DEX、CON、INT、WIS、CHA）、範囲は 3～18
+  - キャラクター作成では 4d6 の最低値を除外するロール、クラス補正、72 ポイントの再調整を使用
+  - ダメージ、命中、結果判定はすべてサーバーで処理
+
+![能力値、ペーパードール式装備、インベントリを備えたキャラクターシート](doc/images/gameplay-character-sheet.png)
+
+- **インベントリと装備**：重量制限付きインベントリと完全なペーパードール式装備システム
+  - 11 の装備スロット：頭、メインハンド、オフハンド、胴、耳、首、ベルト、脚、ブーツ、指輪 2 枠
+  - 拾得時にアイテムごとの重量が適用されるため、重い装備構成には実際の選択が必要
+- **ドロップアイテム**：アイテムを世界に落とし、誰でも拾得可能
+  - 地面のアイテムは落とした位置に残り、モデルが描画される
+  - フロアを認識し、家の 2 階で落としたアイテムはその階からのみ拾得可能（多階層住宅に対応）
+  - 複製を防ぐため、距離を検証したうえでサーバー上のアトミックな処理として拾得
+- **AI 生成 BGM**：約 50 曲の BGM を [Suno](https://suno.com) と [Google Flow Music](https://labs.google/fx/tools/music-fx) で生成
+  - リュート、リコーダー、ハープ、弦楽器、打楽器、金管楽器を使った、Ultima に着想を得た中世ファンタジー調
+  - 環境音楽と戦闘音楽を別々に用意。戦闘開始時にクロスフェードで戦闘曲へ移り、しばらく再生してから環境曲へフェードバック
+- **チャットシステム**：リアルタイムのチャット機能
+- **プレイヤー移動**：マウス／キーボードによるキャラクター操作
+
+## ドキュメント
+
+- [開発ログ](doc/devlog/README.md)
+
+**世界と地形**
+- [ワールド構築](doc/WORLD_BUILDING.md)
+- [マップと地形の設計](doc/MAP_DESIGN.md)
+- [地形生成](doc/TERRAIN_GENERATION.md)
+- [河川システム](doc/RIVER_SYSTEM.md)
+- [水システム](doc/WATER_SYSTEM.md)
+- [植生システム](doc/VEGETATION_SYSTEM.md)
+- [ゾーンシステム](doc/ZONE_SYSTEM.md)
+- [Splatmap v2](doc/SPLATMAP_V2.md)
+
+**ゲームプレイシステム**
+- [ハウジングシステム](doc/HOUSING_SYSTEM.md)
+- [戦闘](doc/COMBAT.md)
+- [NPC とモンスター AI](doc/NPC_MONSTER_AI.md)
+- [アニメーション](doc/ANIMATION.md)
+
+**エンジンとパフォーマンス**
+- [実行時パフォーマンス](doc/RUNTIME_PERFORMANCE.md)
+- [読み込みの最適化](doc/LOADING_OPTIMIZATION.md)
+
+**アセットとエージェント**
+- [アセット](doc/ASSETS.md)
+- [エージェントクライアント](doc/AGENT_CLIENT.md)
+
+## アーキテクチャ
+
+- **クライアント**：Svelte のコンポーネントベース UI + Threlte を介した Three.js 統合
+- **サーバー**：ブロードキャストチャンネルでゲーム状態を管理する Rust 非同期サーバー
+- **通信**：WebSocket によるリアルタイム双方向通信
+
+## 技術スタック
+
+**クライアント：**
+- Svelte + TypeScript
+- Three.js (Threlte) + WebGPU
+- Vite
+
+**エージェントクライアント：**
+- Rust
+- MCP サーバー（rmcp）
+- Tokio + tokio-tungstenite（WebSocket）
+
+**サーバー：**
+- Rust
+- Tokio（非同期ランタイム）
+- tokio-tungstenite（WebSocket）
+- Axum（地形 REST API）
+- serde（JSON シリアライズ）
+
+## 開発環境のセットアップ
+
+### 1. 前提条件
+
+- **Rust と Cargo**：[Rust をインストール](https://rustup.rs/)
+- **Node.js と npm**：[Node.js をインストール](https://nodejs.org/)
+- **（推奨）cargo-watch**：サーバーを自動で再起動します。
+  ```bash
+  cargo install cargo-watch
+  ```
+
+### 2. ポートの割り当て
+
+| ポート | サービス |
+|-------|----------------------------------|
+| 10004 | クライアント（Vite 開発サーバー） |
+| 10005 | GLB エディター |
+| 10006 | サーバー WebSocket（127.0.0.1 にバインド。開発時は Vite プロキシ、本番では nginx 経由） |
+| 10007 | サーバーの地形／ハウジング／NPC API（127.0.0.1 にバインド。書き込みには認証が必要） |
+
+> 両方のサーバーポートは、既定でループバックのみにバインドされます（`--bind` / `--api-bind`）。他のマシン上のクライアントへ直接配信する場合にのみ `--bind 0.0.0.0` を指定してください。この経路には TLS も前段のプロキシもありません。
+
+> **プロキシルール：**Vite 開発サーバーは `/ws` を `ws://localhost:10006` へ、`/api`（すべての REST エンドポイント）を `http://localhost:10007` へ自動的にプロキシします（`client/vite.config.ts` を参照）。
+
+### 3. サーバーの実行
+
+このプロジェクトは **Cargo ワークスペース**として構成されています。共有 Rust クレート（`shared/`）は、サーバー、WASM 経由のクライアント、エージェントクライアントで使用されます。ゲームのソースデータは `data-src/` にあり、Cargo ビルド中に `data/` 内の生成済み JSON へ変換されます。サーバークレート（`server/`）、共有クレート、ソースデータの変更時だけサーバーを再ビルドするには、**ルートディレクトリ**で次の監視コマンドを実行します。
+
+```bash
+cargo watch -w server -w shared -w data-src -x "run -p onlinerpg-server"
+```
+
+サーバーは既定でポート 10006 をリッスンします。地形／ハウジング／NPC REST API は、127.0.0.1 にバインドされたポート 10007（ゲームポート + 1）で自動的に起動します（`--api-bind` で変更可能）。読み取りは公開されています。書き込み（PUT/POST/DELETE）には bearer token が必要です。ローカルスクリプト用の NPC token、またはメールアドレスが `ADMIN_EMAILS` / `--admin-emails`（カンマ区切り）に含まれる Google ID token を利用できます。マップエディターはログイン中のユーザーの token を自動的に送信します。
+
+WebSocket と地形 API のプロキシは Vite 開発サーバーが処理するため（`client/vite.config.ts` を参照）、別途 socat や SSL プロキシを用意する必要はありません。
+
+**Google ログイン**：ブラウザでのログインには Google OAuth を使用します。同じ Web クライアント ID をサーバー（`GOOGLE_CLIENT_ID` 環境変数 / `--google-client-id`）とクライアント（`VITE_GOOGLE_CLIENT_ID`、手順 4 を参照）の両方へ渡してください。指定しなくてもサーバーは動作しますが、ブラウザからのログインを拒否します。NPC／ボット用 token は初回実行時に `data/npc_token` へ自動生成されます。`NPC_AUTH_TOKEN` / `--npc-token` で上書きできます（16 文字以上）。
+
+別の人のマシンで動作するエージェントクライアントは、自身の Google アカウントでデバイスフローを使ってログインします。そのため、「TV and Limited Input」種類の 2 つ目の OAuth クライアントが必要です（ヘッドレスクライアントでは Web 用のものを使用できません）。そのクライアント ID を `GOOGLE_CLI_CLIENT_ID` / `--google-cli-client-id` で渡してください。サーバーはどちらのクライアントからの token も受け入れます。[doc/REMOTE_AGENT_CLIENT.md](doc/REMOTE_AGENT_CLIENT.md) を参照してください。
+
+
+### 4. クライアントの実行
+
+```bash
+cd client
+cp .env.example .env.local   # then set VITE_GOOGLE_CLIENT_ID (required for login)
+npm install
+npm run dev -- --port 10004
+```
+
+### 5. エージェントクライアントの実行
+
+`agent-client/data/config.toml` を編集して正しいポート番号を設定し、次を実行します。
+
+```bash
+cd agent-client
+cargo watch -i "data/prompts/memory/" -x run
+```
+
+### 6. 共有コード変更時の WASM 自動再ビルド（推奨）
+`shared` ライブラリ内の Rust コード変更をすぐにブラウザへ反映するには、別のターミナルで次のコマンドを実行します。
+
+```bash
+# Run from the root directory
+cargo watch -w shared -s "npm run build:wasm --prefix client"
+```
+
+### 7. GLB エディターの実行
+
+```bash
+cd tools/glb-editor
+npm install
+npm run dev -- --port 10005
+```
+
+## 本番環境へのデプロイ
+
+本番環境では 2 つのバイナリを systemd ユニットとして実行し、クライアントのビルド成果物を `/var/www/openmmo` から静的配信します。
+
+| ユニット | バイナリ | Syslog 識別子 |
+|------|--------|-------------------|
+| `openmmo-server` | `onlinerpg-server` | `openmmo` |
+| `openmmo-agent-client` | `agent-client` | `openmmo-agent` |
+
+本番ホスト上で `tools/deploy-prod.sh` を実行してデプロイします。このスクリプトは master をプルし、両方のバイナリとクライアントバンドルをビルドし、静的ファイルを公開してから両方のユニットを再起動します。
+
+サーバーは systemd の `SIGTERM` を適切に処理します。接続中のプレイヤーへ再起動通知を表示し、リスナーと定期タスクを停止し、進行中の一括保存を待機して、接続中の全キャラクター、インベントリ、ワールド時計を永続化してから終了します。`systemctl restart` はこの終了処理を待ってから新しいバイナリを起動します。
+
+管理者キャラクターは `/notice <message>` で同じバナーを手動表示できます（これはゲーム内のライブバナーであり、`data/announcements/` が提供するログイン画面のお知らせではありません）。メッセージなしの `/notice` でバナーを消去できます。バナーが有効な間に参加したプレイヤーにも、参加時に通知されます。
+
+SSH 経由では、接続の切断によってビルドが途中で終了しないよう、セッションから切り離して実行します。
+
+```bash
+ssh prod 'setsid nohup bash ~/work/OnlineRPG/tools/deploy-prod.sh > ~/deploy-latest.log 2>&1 < /dev/null &'
+ssh prod 'tail -f ~/deploy-latest.log'   # follow; ends at "==> deployed <commit>"
+```
+
+フォアグラウンド実行中に接続が切れるとビルド全体が無駄になりますが、不完全なデプロイ状態にはなりません。スクリプトは最初にすべてをビルドし、最後にだけ稼働中のファイルを更新するためです（`rsync` で Web ルートへ同期してから再起動）。それ以前に中断した場合は、対応の取れた古いバンドルと古いサーバープロセスがそのまま残ります。
+
+### ログ
+
+両方のユニットは journald（`StandardOutput=journal`）へ出力し、個別のログファイルはありません。
+
+```bash
+journalctl -u openmmo-server -f              # follow the game server
+journalctl -u openmmo-agent-client -f        # follow the NPC agent client
+journalctl -u openmmo-server -n 200 --no-pager   # recent history
+journalctl -u openmmo-server --since "1 hour ago" -p err   # errors only
+```
+
+両方のバイナリは `RUST_LOG` から subscriber を構成し、未設定または解析できない場合は `info` が既定値です。モンスターの出現／消滅、戦闘のダイス／HP／XP 判定など、操作ごとの詳細は、高負荷時のログ量を抑えるため `debug` になっています。確認するにはログレベルを上げてください。
+
+```bash
+sudo systemctl edit openmmo-server   # or write /etc/openmmo/server.env
+# [Service]
+# Environment=RUST_LOG=debug
+sudo systemctl restart openmmo-server
+```
+
+各ユニットは `EnvironmentFile=-/etc/openmmo/{server,agent-client}.env` を読み取るため、そこに `RUST_LOG` を設定できます。systemd ユニットはシェル環境を継承しない点に注意してください。ターミナルで `RUST_LOG` を export しても、そのターミナルから直接起動したバイナリにしか影響しません。
+
+移動に関する警告（移動先の拒否、ウェイポイントキューの上限、移動の阻害）は意図的に `warn` のままです。これらはサーバーとクライアントのステップ検証が一致しないときに発生するため、通常動作ではなくバグの兆候です。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open MMORPG
 
+[简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
 An MMORPG where AI agents and human players are treated as equals.
 
 Agents and humans connect to the same world, act under the same rules, and interact with each other without distinction. No privileged API is given to agents — they participate through the same interface as human players.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,250 @@
+# 开放式 MMORPG
+
+[English](README.md) | [日本語](README.ja.md)
+
+一个平等对待 AI 智能体和人类玩家的 MMORPG。
+
+智能体与人类连接到同一个世界，遵循相同规则行动，并且彼此互动时不作区分。智能体不会获得特权 API，而是通过与人类玩家相同的接口参与游戏。
+
+**立即游玩：[openmmo.to.nexus](https://openmmo.to.nexus)** — 使用 Google 登录，即刻进入游戏。
+
+> 本项目由个人独立开发，并采用氛围编程（vibe coding）。素材由 AI 生成、程序化创建和从互联网获取的内容混合组成。欢迎提交 PR！
+
+## 功能
+
+- **智能体与人类平等**：智能体和人类玩家使用完全相同的 WebSocket 协议，不存在特权 API 或独立端点。服务器无法区分二者，因此人类能做的任何行为，智能体也能做（反之亦然）。
+- **实时多人游戏**：通过 WebSocket 实时同步玩家
+- **3D 环境**：基于 Three.js 的斜俯视 3D 游戏世界
+- **点光源火把**：火把投射具有衰减效果和阴影的实时点光源
+
+![带有火把照明的夜间场景](doc/images/gameplay-night.png)
+
+- **建筑与住宅**：模块化木框架建筑，支持逐房间遮挡和 L 形屋顶连接
+  - 支持 2 层、3 层和 4 层的多层建筑
+  - 可交互开关的门窗
+  - 可自定义墙壁、屋顶和地板的纹理/材质
+  - 可摆放家具（例如床），并可在游戏世界中互动（睡觉/使用）
+
+![带床的玩家自建木框架房屋](doc/images/gameplay-housing.png)
+- **昼夜循环**：模拟日照时间变化，包括太阳、天空和环境光照的动态变化
+  - 昼夜长度随行星轨道位置变化（季节性的长昼与长夜）
+- **双月系统**：两个卫星拥有各自独立的轨道和月相模拟
+
+![展示太阳、行星和双月的天体轨道面板](doc/images/gameplay-orbits.png)
+- **程序化世界**：地形、河流、海岸线和生物群系均完全由程序生成
+  - 广阔的 32 公里 × 32 公里世界
+  - 程序化生成河流，包含冲刷形成的河道与辫状分流
+  - 连接各地聚落的程序化道路网络
+  - 道路跨越河流时自动放置桥梁
+  - 随阵风摇曳的动态草地和植被
+  - 带动画效果的海浪（Gerstner）与流动河面波纹
+  - 河流入海处形成具有分支分流和河口淡咸水交融效果的三角洲
+
+![程序化生成的世界地图](doc/images/gameplay-worldmap.png)
+
+![自动放置在程序化河流上的木桥](doc/images/gameplay-bridge.png)
+
+![带有辫状分流和沙洲的入海河流三角洲](doc/images/gameplay-delta.png)
+
+- **内置地图编辑器**：用于塑造游戏世界的内置工具
+  - 地形笔刷（道路、平整、高度绘制），支持实时编辑
+  - 放置建筑、道具和植被等对象，并提供预览
+  - 通过矩形区域绘制城镇（禁止生成）和每个区域的怪物生成区
+
+![启用高度笔刷的游戏内地图编辑器](doc/images/gameplay-map-editor.png)
+
+- **基于属性的战斗系统**：采用 NetHack/D&D 风格，由服务器权威判定战斗结果
+  - 六项经典属性（STR、DEX、CON、INT、WIS、CHA），取值范围为 3–18
+  - 创建角色时采用 4d6 去掉最低值的掷骰方式，并包含职业修正和 72 点重新分配
+  - 所有伤害、命中和结果判定均由服务器处理
+
+![包含属性、纸娃娃式装备和物品栏的角色面板](doc/images/gameplay-character-sheet.png)
+
+- **物品栏与装备**：受负重限制的物品栏，以及完整的纸娃娃式装备系统
+  - 十一个装备槽：头部、主手、副手、胸部、耳部、颈部、腰带、裤子、靴子和两个戒指槽
+  - 拾取物品时会检查单件重量，因此沉重配装需要真正作出取舍
+- **掉落物品**：物品可以丢到游戏世界中，并由任何人拾取
+  - 地面物品会保留在掉落位置，并显示对应模型
+  - 感知楼层：掉在房屋二楼的物品只能从该楼层拾取（支持多层住宅）
+  - 拾取操作会检查距离并在服务器端以原子方式执行，以防止物品复制
+- **AI 生成的背景音乐**：约 50 首背景音乐由 [Suno](https://suno.com) 和 [Google Flow Music](https://labs.google/fx/tools/music-fx) 生成
+  - 采用受 Ultima 启发的中世纪奇幻配器，包括鲁特琴、竖笛、竖琴、弦乐、打击乐和铜管乐
+  - 环境音乐与战斗音乐分别组成曲库；进入战斗时交叉淡入战斗音乐，短暂延续后再淡回环境音乐
+- **聊天系统**：实时聊天功能
+- **玩家移动**：使用鼠标/键盘控制角色
+
+## 文档
+
+- [开发日志](doc/devlog/README.md)
+
+**世界与地形**
+- [世界构建](doc/WORLD_BUILDING.md)
+- [地图与地形设计](doc/MAP_DESIGN.md)
+- [地形生成](doc/TERRAIN_GENERATION.md)
+- [河流系统](doc/RIVER_SYSTEM.md)
+- [水体系统](doc/WATER_SYSTEM.md)
+- [植被系统](doc/VEGETATION_SYSTEM.md)
+- [区域系统](doc/ZONE_SYSTEM.md)
+- [Splatmap v2](doc/SPLATMAP_V2.md)
+
+**游戏系统**
+- [住宅系统](doc/HOUSING_SYSTEM.md)
+- [战斗](doc/COMBAT.md)
+- [NPC 与怪物 AI](doc/NPC_MONSTER_AI.md)
+- [动画](doc/ANIMATION.md)
+
+**引擎与性能**
+- [运行时性能](doc/RUNTIME_PERFORMANCE.md)
+- [加载优化](doc/LOADING_OPTIMIZATION.md)
+
+**素材与智能体**
+- [素材](doc/ASSETS.md)
+- [智能体客户端](doc/AGENT_CLIENT.md)
+
+## 架构
+
+- **客户端**：Svelte 组件化 UI + 通过 Threlte 集成 Three.js
+- **服务器**：使用广播通道管理游戏状态的 Rust 异步服务器
+- **通信**：通过 WebSocket 进行实时双向通信
+
+## 技术栈
+
+**客户端：**
+- Svelte + TypeScript
+- Three.js (Threlte) + WebGPU
+- Vite
+
+**智能体客户端：**
+- Rust
+- MCP 服务器（rmcp）
+- Tokio + tokio-tungstenite（WebSocket）
+
+**服务器：**
+- Rust
+- Tokio（异步运行时）
+- tokio-tungstenite（WebSocket）
+- Axum（地形 REST API）
+- serde（JSON 序列化）
+
+## 开发环境设置
+
+### 1. 前置要求
+
+- **Rust 与 Cargo**：[安装 Rust](https://rustup.rs/)
+- **Node.js 与 npm**：[安装 Node.js](https://nodejs.org/)
+- **（推荐）cargo-watch**：用于在服务器代码变化时自动重启。
+  ```bash
+  cargo install cargo-watch
+  ```
+
+### 2. 端口分配
+
+| 端口  | 服务                          |
+|-------|----------------------------------|
+| 10004 | 客户端（Vite 开发服务器）                |
+| 10005 | GLB 编辑器                       |
+| 10006 | 服务器 WebSocket（绑定到 127.0.0.1；开发环境通过 Vite 代理访问，生产环境通过 nginx 访问） |
+| 10007 | 服务器地形/住宅/NPC API（绑定到 127.0.0.1；写入操作需要身份验证） |
+
+> 两个服务器端口默认只监听回环地址（`--bind` / `--api-bind`）。只有在需要直接为其他机器上的客户端提供服务时，才应传入 `--bind 0.0.0.0`；该方式没有 TLS，也没有前置代理。
+
+> **代理规则：**Vite 开发服务器会自动将 `/ws` 代理到 `ws://localhost:10006`，并将 `/api`（所有 REST 端点）代理到 `http://localhost:10007`（参见 `client/vite.config.ts`）。
+
+### 3. 运行服务器
+
+本项目组织为 **Cargo 工作区**。共享 Rust crate（`shared/`）供服务器、通过 WASM 运行的客户端以及智能体客户端共同使用。游戏源数据位于 `data-src/`，并会在 Cargo 构建期间转换为 `data/` 中生成的 JSON。若只想在服务器 crate（`server/`）、共享 crate 或源数据变化时重新构建服务器，请在**根目录**运行以下监视命令。
+
+```bash
+cargo watch -w server -w shared -w data-src -x "run -p onlinerpg-server"
+```
+
+服务器默认监听 10006 端口。地形/住宅/NPC REST API 会自动在 10007 端口（游戏端口 + 1）启动，并绑定到 127.0.0.1（可用 `--api-bind` 覆盖）。读取操作公开；写入操作（PUT/POST/DELETE）需要 bearer token：可以是 NPC token（用于本地脚本），也可以是电子邮件已列入 `ADMIN_EMAILS` / `--admin-emails`（逗号分隔）的 Google ID token；地图编辑器会自动发送已登录用户的 token。
+
+WebSocket 和地形 API 的代理由 Vite 开发服务器处理（参见 `client/vite.config.ts`），因此不需要单独运行 socat 或 SSL 代理。
+
+**Google 登录**：浏览器登录使用 Google OAuth。请将同一个 Web 客户端 ID 传给服务器（`GOOGLE_CLIENT_ID` 环境变量 / `--google-client-id`）和客户端（`VITE_GOOGLE_CLIENT_ID`，参见第 4 步）。若不提供，服务器仍可运行，但会拒绝浏览器登录。NPC/机器人 token 会在首次运行时自动生成到 `data/npc_token`；可通过 `NPC_AUTH_TOKEN` / `--npc-token` 覆盖（至少 16 个字符）。
+
+在他人机器上运行的智能体客户端会使用自己的 Google 账号通过设备流程登录，这需要第二个类型为“TV and Limited Input”的 OAuth 客户端（无头客户端不能使用 Web 客户端）。请通过 `GOOGLE_CLI_CLIENT_ID` / `--google-cli-client-id` 传入该客户端 ID；服务器会接受来自任一客户端的 token。参见 [doc/REMOTE_AGENT_CLIENT.md](doc/REMOTE_AGENT_CLIENT.md)。
+
+
+### 4. 运行客户端
+
+```bash
+cd client
+cp .env.example .env.local   # then set VITE_GOOGLE_CLIENT_ID (required for login)
+npm install
+npm run dev -- --port 10004
+```
+
+### 5. 运行智能体客户端
+
+编辑 `agent-client/data/config.toml`，设置正确的端口号，然后运行：
+
+```bash
+cd agent-client
+cargo watch -i "data/prompts/memory/" -x run
+```
+
+### 6. 共享代码变化时自动重新构建 WASM（推荐）
+若希望 `shared` 库中的 Rust 代码变化立即反映到浏览器中，请在单独的终端运行以下命令：
+
+```bash
+# Run from the root directory
+cargo watch -w shared -s "npm run build:wasm --prefix client"
+```
+
+### 7. 运行 GLB 编辑器
+
+```bash
+cd tools/glb-editor
+npm install
+npm run dev -- --port 10005
+```
+
+## 生产环境部署
+
+生产环境使用 systemd 单元运行两个二进制文件，并由 `/var/www/openmmo` 静态提供客户端构建产物。
+
+| 单元 | 二进制文件 | Syslog 标识符 |
+|------|--------|-------------------|
+| `openmmo-server` | `onlinerpg-server` | `openmmo` |
+| `openmmo-agent-client` | `agent-client` | `openmmo-agent` |
+
+请在生产主机上运行 `tools/deploy-prod.sh` 进行部署。该脚本会拉取 master、构建两个二进制文件和客户端包、发布静态文件，然后重启两个单元。
+
+服务器会优雅处理 systemd 的 `SIGTERM`：它会向已连接的玩家显示重启通知，关闭监听器和周期性任务，等待正在进行的批量保存完成，持久化所有已连接角色、物品栏和世界时钟，然后退出。`systemctl restart` 会等待该排空过程完成，再启动新的二进制文件。
+
+管理员角色可以使用 `/notice <message>` 手动显示相同的横幅（这是游戏内实时横幅，并非由 `data/announcements/` 提供的登录界面公告）。不带消息的 `/notice` 会清除横幅；横幅生效期间进入游戏的玩家会在加入时收到它。
+
+通过 SSH 运行时，请将进程与会话分离，避免连接断开导致构建在中途终止：
+
+```bash
+ssh prod 'setsid nohup bash ~/work/OnlineRPG/tools/deploy-prod.sh > ~/deploy-latest.log 2>&1 < /dev/null &'
+ssh prod 'tail -f ~/deploy-latest.log'   # follow; ends at "==> deployed <commit>"
+```
+
+前台运行时若连接丢失，会浪费整个构建过程，但绝不会造成部署一半的状态：脚本会先完成全部构建，仅在最后才更新在线文件（使用 `rsync` 同步到 Web 根目录，然后重启服务），因此在此之前中断会保留相互匹配的旧客户端包和旧服务器进程。
+
+### 日志
+
+两个单元都将日志写入 journald（`StandardOutput=journal`），不会生成单独的日志文件。
+
+```bash
+journalctl -u openmmo-server -f              # follow the game server
+journalctl -u openmmo-agent-client -f        # follow the NPC agent client
+journalctl -u openmmo-server -n 200 --no-pager   # recent history
+journalctl -u openmmo-server --since "1 hour ago" -p err   # errors only
+```
+
+两个二进制文件都使用 `RUST_LOG` 配置日志订阅器；当该值未设置或无法解析时，默认使用 `info`。各项操作的详细信息（怪物生成/消失、战斗掷骰/生命值/经验值计算）使用 `debug` 级别，以避免高负载时产生过多日志；如需查看，请提高日志级别：
+
+```bash
+sudo systemctl edit openmmo-server   # or write /etc/openmmo/server.env
+# [Service]
+# Environment=RUST_LOG=debug
+sudo systemctl restart openmmo-server
+```
+
+每个单元都会读取 `EnvironmentFile=-/etc/openmmo/{server,agent-client}.env`，因此可以在该文件中设置 `RUST_LOG`。请注意，systemd 单元不会继承 shell 环境；在终端中导出 `RUST_LOG` 只会影响由该终端直接启动的二进制文件。
+
+移动警告（目标移动被拒绝、路径点队列已满、移动受阻）会特意保持在 `warn` 级别：它们在服务器和客户端的步进检查不一致时触发，因此代表错误信号，而不是正常游戏过程。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese translations of the README and links them from the English README.

The translations preserve links, images, tables, and command examples.