### PR TITLE
Keep Google-account characters out of mismatch deletion

### DIFF
--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -313,7 +313,7 @@ async fn run_npc_session(
 
     let mut characters = ws::wait_for_auth(&mut ws_rx, label).await?;
 
-    // --- Delete characters whose class or name doesn't match config ---
+    // --- Resolve which of the account's characters this NPC entry owns ---
     let desired_class = npc
         .character_class
         .as_deref()
@@ -326,31 +326,50 @@ async fn run_npc_session(
     let desired_name = npc.character_name.as_deref();
     let desired_gender = npc.gender;
 
-    let should_delete = |c: &onlinerpg_shared::Character| {
+    let mismatch = |c: &onlinerpg_shared::Character| {
         desired_class.as_ref().is_some_and(|d| c.class != *d)
             || desired_name.is_some_and(|n| c.name != n)
             || desired_gender.is_some_and(|gender| c.gender != gender)
     };
 
-    for c in characters.iter().filter(|c| should_delete(c)) {
-        info!(
-            "[{}] Deleting character '{}' (id={}, {:?}, {:?}) — mismatch (want name={:?}, class={:?}, gender={:?})",
-            label, c.name, c.id, c.class, c.gender, desired_name, desired_class, desired_gender
-        );
-        ws::send(
-            &mut ws_tx,
-            &ClientMessage::DeleteCharacter { character_id: c.id },
-        )
-        .await?;
-        ws::wait_for_msg(&mut ws_rx, label, "CharacterDeleted", |msg| {
-            matches!(
-                msg,
-                ServerMessage::CharacterDeleted { .. } | ServerMessage::CharacterError { .. }
-            )
-        })
-        .await?;
+    // Mismatched characters are deleted only on dedicated npc_token accounts,
+    // where the account exists solely for this fixture. A Google account
+    // belongs to a person who may keep their own web-client characters on it
+    // (doc/REMOTE_AGENT_CLIENT.md) — those are left untouched, and the agent
+    // only picks (or creates) the character this entry describes.
+    match shared.auth {
+        AuthSource::NpcToken(_) => {
+            for c in characters.iter().filter(|c| mismatch(c)) {
+                info!(
+                    "[{}] Deleting character '{}' (id={}, {:?}, {:?}) — mismatch (want name={:?}, class={:?}, gender={:?})",
+                    label, c.name, c.id, c.class, c.gender, desired_name, desired_class, desired_gender
+                );
+                ws::send(
+                    &mut ws_tx,
+                    &ClientMessage::DeleteCharacter { character_id: c.id },
+                )
+                .await?;
+                ws::wait_for_msg(&mut ws_rx, label, "CharacterDeleted", |msg| {
+                    matches!(
+                        msg,
+                        ServerMessage::CharacterDeleted { .. }
+                            | ServerMessage::CharacterError { .. }
+                    )
+                })
+                .await?;
+            }
+        }
+        AuthSource::Google(_) => {
+            let skipped = characters.iter().filter(|c| mismatch(c)).count();
+            if skipped > 0 {
+                info!(
+                    "[{}] Leaving {} other character(s) on this Google account untouched",
+                    label, skipped
+                );
+            }
+        }
     }
-    characters.retain(|c| !should_delete(c));
+    characters.retain(|c| !mismatch(c));
 
     // --- Auto-create character if needed ---
     if characters.is_empty() {


### PR DESCRIPTION
## 문제

자동 프로비저닝이 계정의 캐릭터 중 `[[npcs]]` 항목의 name/class/gender와 하나라도 다른 캐릭터를 **경고 없이 전부 삭제**합니다 (`orchestrator.rs`의 mismatch 삭제 루프). 이 정리 동작은 해당 픽스처 전용인 npc_token 계정에는 맞지만, 인증 모드로 게이팅되지 않아 **구글 로그인 계정에도 그대로 적용**됩니다.

구글 계정은 사람의 계정입니다 — `doc/REMOTE_AGENT_CLIENT.md`대로 계정이 구글 `sub`에서 결정되므로, 웹 클라이언트로 직접 플레이하는 캐릭터와 에이전트 캐릭터가 같은 계정에 공존합니다. 그 상태에서 에이전트를 켜면 config에 적힌 캐릭터 하나만 남기고 사람 캐릭터가 영구 삭제됩니다.

실제로 당했습니다. 웹으로 키우던 캐릭터(RyuK, Lv.5)가 에이전트 첫 실행에서 삭제됐고, 다시 만든 캐릭터도 에이전트 재접속 때 또 삭제됐습니다:

```
12:37:38 [Ryulamg] Authenticated. 2 character(s):
12:37:38   [4123] Ryulamg (Lv.2 Rogue)
12:37:38   [4130] RyuK (Lv.5 Ranger)          ← 웹 클라이언트로 키우던 캐릭터
12:37:38 [Ryulamg] Deleting character 'RyuK' (id=4130, Ranger, Male) — mismatch
   ...
13:13:43   [4744] RyuK (Lv.5 Caveman)         ← 다시 만든 캐릭터
13:13:43 [Ryulamg] Deleting character 'RyuK' (id=4744, Caveman, Male) — mismatch
```

`doc/REMOTE_AGENT_CLIENT.md`가 세운 원칙 — "`mode = "google"`이 함의를 한꺼번에 묶는다. **설정 실수로 보안 결정이 뒤집히지 않도록** 개별 플래그로 쪼개지 않는다" — 에 비추면, config 오타 하나로 사람의 캐릭터가 되돌릴 수 없이 지워지는 현재 동작은 정확히 그 원칙이 막으려는 종류의 사고입니다. 같은 문서의 google 모드 함의 목록에도 "불일치 캐릭터 삭제"는 없습니다.

## 수정

삭제를 `AuthSource`로 게이팅합니다:

- **NpcToken**: 기존과 동일 — 불일치 캐릭터 삭제 (전용 계정 정리, 의도된 동작 유지)
- **Google**: 삭제하지 않음 — config와 일치하는 캐릭터를 골라 입장하고, 없으면 생성하며, 나머지 캐릭터는 몇 개를 남겨뒀는지 로그만 남김

## 검증

- `cargo test -p agent-client` 42/42 통과, clippy 경고 없음 (변경 코드 기준)
- 라이브 왕복 테스트 (공개 서버, 구글 계정):
  - config가 다른 캐릭터(RamgTest/knight)를 가리키게 한 뒤 실행 → 기존 Ryulamg(Lv.5 Rogue)을 건드리지 않고 RamgTest 생성:
    ```
    [RamgTest] Authenticated. 1 character(s):
    [RamgTest] Leaving 1 other character(s) on this Google account untouched
    [RamgTest] No characters found. Creating 'RamgTest' (Knight, Male)...
    ```
  - config를 Ryulamg으로 되돌려 실행 → 두 캐릭터 공존, 일치 캐릭터로 입장:
    ```
    [Ryulamg] Authenticated. 2 character(s):
      [4123] Ryulamg (Lv.6 Rogue)
      [4757] RamgTest (Lv.1 Knight)
    [Ryulamg] Leaving 1 other character(s) on this Google account untouched
    [Ryulamg] Entering game with character 4123...
    ```
  수정 전 코드라면 두 실행 모두에서 상대 캐릭터가 삭제됐을 상황입니다.

## 참고 (이 PR 범위 밖)

`character_name`을 지정하지 않은 항목은 삭제는 하지 않지만 `characters.first()`를 그대로 잡기 때문에, 구글 계정에서는 사람 캐릭터로 입장해버릴 수 있습니다. 성격이 다른 문제라(파괴가 아닌 오선택) 별도로 다루는 게 좋겠습니다.
