### PR TITLE
Let agents see and pick up ground items

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -43,6 +43,11 @@ Available action types (use EXACTLY these field names):
   takes it off; wearing a torch is how you light your way at night:
   {"type": "use", "item": "worn_torch"}
 
+- Pick up an item lying on the ground into your bag. You walk over to it
+  first, like a web player clicking it. Give the id shown in the world
+  state ("Item on ground: ... [id 6043]"), or its name:
+  {"type": "pickup", "item": 6043}
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -86,12 +86,46 @@ pub(super) enum AgentAction {
         )]
         item: String,
     },
+    /// Walk to an item on the ground and pick it up into the bag. Mirrors
+    /// the web client's click-to-pick-up. `item` is the instance id shown
+    /// in the world state, or an item name (nearest match).
+    #[serde(rename = "pickup", alias = "pick_up", alias = "loot", alias = "take")]
+    Pickup {
+        #[serde(
+            alias = "item_def_id",
+            alias = "item_id",
+            alias = "instance_id",
+            alias = "id",
+            alias = "name",
+            alias = "target"
+        )]
+        item: PickupRef,
+    },
     /// Reroll starting stats. Only meaningful during character creation,
     /// where it is the agent's version of the web client's reroll button.
     #[serde(rename = "reroll", alias = "reroll_stats", alias = "roll_again")]
     Reroll,
     #[serde(rename = "wait", alias = "idle", alias = "observe", alias = "none")]
     Wait,
+}
+
+/// How a pickup names its target: the instance id from the world state
+/// ("[id 6043]"), or an item name resolved to the nearest match. LLMs send
+/// either, and the id may arrive as a number or a numeric string.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum PickupRef {
+    Id(u64),
+    Name(String),
+}
+
+impl std::fmt::Display for PickupRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Id(id) => write!(f, "id {id}"),
+            Self::Name(name) => f.write_str(name),
+        }
+    }
 }
 
 /// Whether the agent asked to roll its starting stats again. Read from the
@@ -218,6 +252,8 @@ pub(super) fn action_to_command(
         AgentAction::OpenTrade { .. } => None,
         // Needs the bag and worn gear from SharedState; likewise handled there.
         AgentAction::Use { .. } => None,
+        // Needs ground-item resolution and the walk-to loop; handled there too.
+        AgentAction::Pickup { .. } => None,
         // Only reaches the server as a pre-creation RollCharacterStats; in
         // game there is nothing left to reroll.
         AgentAction::Reroll => None,
@@ -294,6 +330,36 @@ mod tests {
                 panic!("expected Use for {json}");
             };
             assert_eq!(item, "torch");
+        }
+    }
+
+    #[test]
+    fn pickup_parses_instance_id_as_number() {
+        for json in [
+            r#"{"actions": [{"type": "pickup", "item": 6043}]}"#,
+            r#"{"actions": [{"type": "loot", "instance_id": 6043}]}"#,
+            r#"{"actions": [{"type": "pick_up", "id": 6043}]}"#,
+        ] {
+            let AgentAction::Pickup { item } = parse_single_action(json) else {
+                panic!("expected Pickup for {json}");
+            };
+            assert!(matches!(item, PickupRef::Id(6043)), "for {json}");
+        }
+    }
+
+    #[test]
+    fn pickup_parses_item_name() {
+        for json in [
+            r#"{"actions": [{"type": "pickup", "item": "small_sword"}]}"#,
+            r#"{"actions": [{"type": "take", "name": "small_sword"}]}"#,
+        ] {
+            let AgentAction::Pickup { item } = parse_single_action(json) else {
+                panic!("expected Pickup for {json}");
+            };
+            let PickupRef::Name(name) = item else {
+                panic!("expected a name ref for {json}");
+            };
+            assert_eq!(name, "small_sword");
         }
     }
 

--- a/agent-client/src/driver/combat.rs
+++ b/agent-client/src/driver/combat.rs
@@ -42,6 +42,13 @@ const APPROACH_RANGE: f32 = 1.0;
 /// Maximum approach duration before giving up (seconds). Longer than the
 /// combat chase: an approach target can be anywhere inside the sight radius.
 const MAX_APPROACH_SECS: f32 = 30.0;
+/// Stop distance for ground items, inside the server's 2.5 m pickup gate
+/// (`MAX_PICKUP_DISTANCE`) so overshoot and float error can't push the
+/// PickupItem send back out of range.
+const PICKUP_ARRIVE_RANGE: f32 = 2.0;
+/// Maximum walk-to-item duration before giving up (seconds). Shorter than
+/// an approach: the target never moves away.
+const MAX_PICKUP_WALK_SECS: f32 = 12.0;
 
 /// Load the attack (slash1) animation duration from the shared JSON file.
 /// Returns the duration as milliseconds, or the default if loading fails.
@@ -114,12 +121,13 @@ pub(super) enum ChaseResult {
     Error,
 }
 
-/// What a chase walks toward: a monster (stop at attack range) or another
+/// What a chase walks toward: a monster (stop at attack range), another
 /// character (stop at a polite conversational distance instead of standing
-/// on top of them).
+/// on top of them), or a ground item (stop inside pickup range).
 pub(super) enum ChaseTarget<'a> {
     Monster(&'a str),
     Player(&'a PlayerId),
+    GroundItem(u64),
 }
 
 impl ChaseTarget<'_> {
@@ -127,6 +135,7 @@ impl ChaseTarget<'_> {
         match self {
             Self::Monster(id) => s.nearby_monsters.get(*id).map(|m| m.position),
             Self::Player(id) => s.nearby_players.get(*id).map(|p| p.position),
+            Self::GroundItem(id) => s.ground_items.get(id).map(|i| i.position),
         }
     }
 
@@ -136,6 +145,7 @@ impl ChaseTarget<'_> {
         let level = match self {
             Self::Monster(id) => s.nearby_monsters.get(*id).map(|m| m.floor_level),
             Self::Player(id) => s.nearby_players.get(*id).map(|p| p.floor_level),
+            Self::GroundItem(id) => s.ground_items.get(id).map(|i| i.floor_level),
         };
         onlinerpg_shared::dungeon::passability_floor_for_level(level.unwrap_or(0))
     }
@@ -147,15 +157,16 @@ impl ChaseTarget<'_> {
         match self {
             Self::Monster(_) => ATTACK_RANGE,
             Self::Player(_) => APPROACH_RANGE + 0.2,
+            Self::GroundItem(_) => PICKUP_ARRIVE_RANGE,
         }
     }
 
-    /// How far short of the target the path goal stops. Monsters are
-    /// pathed to directly (the arrive check stops us first); characters
+    /// How far short of the target the path goal stops. Monsters and items
+    /// are pathed to directly (the arrive check stops us first); characters
     /// get a pulled-back goal so a step can never land on top of them.
     fn path_pullback(&self) -> f32 {
         match self {
-            Self::Monster(_) => 0.0,
+            Self::Monster(_) | Self::GroundItem(_) => 0.0,
             Self::Player(_) => APPROACH_RANGE,
         }
     }
@@ -163,7 +174,7 @@ impl ChaseTarget<'_> {
     fn max_distance(&self) -> f32 {
         match self {
             Self::Monster(_) => MAX_CHASE_DISTANCE,
-            Self::Player(_) => crate::state::NPC_SIGHT_RADIUS,
+            Self::Player(_) | Self::GroundItem(_) => crate::state::NPC_SIGHT_RADIUS,
         }
     }
 
@@ -171,6 +182,7 @@ impl ChaseTarget<'_> {
         match self {
             Self::Monster(_) => MAX_CHASE_SECS,
             Self::Player(_) => MAX_APPROACH_SECS,
+            Self::GroundItem(_) => MAX_PICKUP_WALK_SECS,
         }
     }
 }
@@ -182,6 +194,7 @@ impl std::fmt::Display for ChaseTarget<'_> {
         match self {
             Self::Monster(id) => f.write_str(id),
             Self::Player(id) => write!(f, "{id}"),
+            Self::GroundItem(id) => write!(f, "item {id}"),
         }
     }
 }
@@ -201,6 +214,16 @@ pub(super) async fn approach_player(
     player_id: &PlayerId,
 ) -> ChaseResult {
     chase_target(state, &ChaseTarget::Player(player_id)).await
+}
+
+/// Walk to a ground item and stop inside pickup range. Same loop as the
+/// combat chase; the target vanishing (picked up or despawned) ends it
+/// as `Lost`.
+pub(super) async fn walk_to_ground_item(
+    state: &Arc<Mutex<SharedState>>,
+    instance_id: u64,
+) -> ChaseResult {
+    chase_target(state, &ChaseTarget::GroundItem(instance_id)).await
 }
 
 /// Chase the target until we're within its arrive range, using A*
@@ -363,6 +386,7 @@ fn compute_step_toward(state: &SharedState, target: &ChaseTarget) -> Option<(Cli
     let stop_dist = match target {
         ChaseTarget::Monster(_) => ATTACK_RANGE - 0.5,
         ChaseTarget::Player(_) => APPROACH_RANGE,
+        ChaseTarget::GroundItem(_) => PICKUP_ARRIVE_RANGE - 0.5,
     };
     if to_target.dist <= stop_dist {
         return None;

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -10,9 +10,15 @@ use tracing::{debug, error, info, warn};
 
 use crate::state::{Carried, SharedState};
 
-use super::action::{action_to_command, parse_agent_response, resolve_move_goal, AgentAction};
-use super::combat::{approach_player, chase_monster, ChaseResult};
+use super::action::{
+    action_to_command, parse_agent_response, resolve_move_goal, AgentAction, PickupRef,
+};
+use super::combat::{approach_player, chase_monster, walk_to_ground_item, ChaseResult};
 use super::movement::{execute_move, MoveResult};
+
+/// Pause between the crouch broadcast and the actual pickup, approximating
+/// the web client's grab moment partway into its pickup animation.
+const PICKUP_GRAB_DELAY_MS: u64 = 700;
 
 /// Parse and execute the agent's response.
 /// Returns the monster_id if the last action was an attack (for combat loop).
@@ -64,7 +70,7 @@ pub(super) async fn handle_response(
         if skip_movement
             && matches!(
                 action,
-                AgentAction::Move { .. } | AgentAction::Attack { .. }
+                AgentAction::Move { .. } | AgentAction::Attack { .. } | AgentAction::Pickup { .. }
             )
         {
             debug!("Skipping {:?} action — NPC is holding position", action);
@@ -203,6 +209,60 @@ pub(super) async fn handle_response(
             continue;
         }
 
+        // Pick up a ground item: resolve the reference, walk into pickup
+        // range, and send the pickup. The server owns the range, floor and
+        // weight checks and answers with InventoryUpdated or a SystemMessage.
+        if let AgentAction::Pickup { item } = action {
+            let resolved = {
+                let s = state.lock().await;
+                resolve_ground_item(&s, item)
+            };
+            let Some((instance_id, def_id)) = resolved else {
+                warn!("pickup: no ground item matching '{item}'");
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[PickupFailed] No item matching '{item}' is on the ground nearby."
+                ));
+                continue;
+            };
+            match walk_to_ground_item(state, instance_id).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    // The crouch nearby players see from a web client.
+                    if let Err(e) = s
+                        .send_command(onlinerpg_shared::ClientMessage::PickupStarted)
+                        .await
+                    {
+                        error!("Failed to send pickup animation: {e}");
+                    }
+                    drop(s);
+                    tokio::time::sleep(std::time::Duration::from_millis(PICKUP_GRAB_DELAY_MS))
+                        .await;
+                    let mut s = state.lock().await;
+                    if let Err(e) = s
+                        .send_command(onlinerpg_shared::ClientMessage::PickupItem { instance_id })
+                        .await
+                    {
+                        error!("Failed to send pickup: {e}");
+                    } else {
+                        info!("Agent picked up {def_id} [id {instance_id}]");
+                    }
+                }
+                ChaseResult::Lost => {
+                    warn!("pickup: could not reach {def_id} [id {instance_id}]");
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!(
+                        "[PickupFailed] You could not reach the {def_id} — it was taken \
+                         or despawned before you got there."
+                    ));
+                }
+                ChaseResult::Error => {
+                    error!("pickup: error while walking to {def_id} [id {instance_id}]");
+                }
+            }
+            continue;
+        }
+
         // Handle move actions with pathfinding
         if let AgentAction::Move {
             target,
@@ -301,4 +361,35 @@ pub(super) async fn handle_response(
     }
 
     last_attack_target
+}
+
+/// Resolve a pickup reference to a known ground item on the agent's floor:
+/// by instance id (also when the LLM quotes it as a string), or by name to
+/// the nearest item whose def id contains it.
+fn resolve_ground_item(s: &SharedState, r: &PickupRef) -> Option<(u64, String)> {
+    let by_id = |id: u64| {
+        s.ground_items
+            .get(&id)
+            .map(|i| (i.instance_id, i.item_def_id.clone()))
+    };
+    match r {
+        PickupRef::Id(id) => by_id(*id),
+        PickupRef::Name(name) => {
+            let name = name.trim();
+            if let Ok(id) = name.parse::<u64>() {
+                return by_id(id);
+            }
+            let sp = s.self_player.as_ref()?;
+            let name_lc = name.to_lowercase();
+            s.ground_items
+                .values()
+                .filter(|i| {
+                    i.floor_level == s.self_floor_level as i8
+                        && i.item_def_id.to_lowercase().contains(&name_lc)
+                })
+                .map(|i| (i.position.dist_xz_sq(&sp.position), i))
+                .min_by(|a, b| a.0.total_cmp(&b.0))
+                .map(|(_, i)| (i.instance_id, i.item_def_id.clone()))
+        }
+    }
 }

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -144,6 +144,9 @@ pub struct SharedState {
     pub nearby_players: HashMap<PlayerId, Player>,
     /// Known nearby monsters
     pub nearby_monsters: HashMap<String, Monster>,
+    /// Known items lying on the ground, keyed by instance id (from the join
+    /// snapshot plus GroundItemSpawned/Appeared/Removed).
+    pub ground_items: HashMap<u64, onlinerpg_shared::inventory::GroundItem>,
     events: Vec<ServerMessage>,
     /// Latest position per monster -- deduplicates high-frequency MonsterMoved events
     latest_monster_moves: HashMap<String, ServerMessage>,
@@ -200,6 +203,7 @@ impl SharedState {
             trade_busy: false,
             nearby_players: HashMap::new(),
             nearby_monsters: HashMap::new(),
+            ground_items: HashMap::new(),
             events: Vec::new(),
             latest_monster_moves: HashMap::new(),
             latest_player_moves: HashMap::new(),
@@ -466,6 +470,9 @@ impl SharedState {
             | ServerMessage::GoldGained { .. }
             | ServerMessage::InventoryState { .. }
             | ServerMessage::InventoryUpdated { .. }
+            | ServerMessage::GroundItemSpawned { .. }
+            | ServerMessage::GroundItemAppeared { .. }
+            | ServerMessage::GroundItemRemoved { .. }
             | ServerMessage::TradeBusy { .. } => EventUrgency::Noise,
 
             // Urgent: another player attacks a monster (so we can join in)
@@ -556,10 +563,16 @@ impl SharedState {
                 self.self_player = Some(player.clone());
             }
             ServerMessage::GameState {
-                players, monsters, ..
+                players,
+                monsters,
+                ground_items,
             } => {
                 self.nearby_players = players.iter().map(|p| (p.id, p.clone())).collect();
                 self.nearby_monsters = monsters.clone();
+                self.ground_items = ground_items
+                    .iter()
+                    .map(|i| (i.instance_id, i.clone()))
+                    .collect();
                 // Update self_player from game state
                 if let Some(self_id) = self.self_player_id {
                     if let Some(p) = self.nearby_players.get(&self_id).cloned() {
@@ -633,6 +646,13 @@ impl SharedState {
             ServerMessage::MonsterRemoved { monster_id } => {
                 self.nearby_monsters.remove(monster_id);
                 self.monster_ai.remove_monster(monster_id);
+            }
+            ServerMessage::GroundItemSpawned { item, .. }
+            | ServerMessage::GroundItemAppeared { item } => {
+                self.ground_items.insert(item.instance_id, item.clone());
+            }
+            ServerMessage::GroundItemRemoved { instance_id } => {
+                self.ground_items.remove(instance_id);
             }
             ServerMessage::CharacterCreated { ref character } => {
                 self.characters.push(character.clone());
@@ -767,6 +787,11 @@ impl SharedState {
             // A pure state flag; it changes movement gating but is not an LLM
             // event in its own right.
             ServerMessage::TradeBusy { .. } => return urgency,
+            // Ground items churn in and out of the AOI as everyone moves;
+            // the world state lists what is nearby each turn instead.
+            ServerMessage::GroundItemSpawned { .. }
+            | ServerMessage::GroundItemAppeared { .. }
+            | ServerMessage::GroundItemRemoved { .. } => return urgency,
             ServerMessage::GameTimeSync { datetime, is_night } => {
                 let prev_night = self.is_night;
                 let prev_hour = self.game_hour;
@@ -1066,6 +1091,29 @@ impl SharedState {
             ));
         }
 
+        // Items on the ground, closest first. Same floor only — pickup is
+        // floor-gated server-side.
+        if let Some(sp) = sp {
+            let mut ground: Vec<_> = self
+                .ground_items
+                .values()
+                .filter(|i| i.floor_level == self.self_floor_level as i8)
+                .filter_map(|i| {
+                    let d_sq = i.position.dist_xz_sq(&sp.position);
+                    (d_sq <= sight_sq).then_some((d_sq, i))
+                })
+                .collect();
+            ground.sort_by(|a, b| a.0.total_cmp(&b.0));
+            for (d_sq, i) in ground {
+                lines.push(format!(
+                    "Item on ground: {} ({:.1}m away) [id {}]",
+                    i.item_def_id,
+                    d_sq.sqrt(),
+                    i.instance_id
+                ));
+            }
+        }
+
         if lines.is_empty() {
             "No state available yet.".to_string()
         } else {
@@ -1120,6 +1168,68 @@ mod tests {
             last_move_at: 0,
             move_budget: 0.0,
         }
+    }
+
+    use onlinerpg_shared::inventory::GroundItem;
+
+    fn ground_item(id: u64, def: &str, x: f32, z: f32, floor: i8) -> GroundItem {
+        GroundItem {
+            instance_id: id,
+            item_def_id: def.to_string(),
+            position: p(x, 0.0, z),
+            floor_level: floor,
+            enchant: 0,
+        }
+    }
+
+    /// The world state lists reachable ground items closest first, and
+    /// leaves out other floors and anything out of sight.
+    #[test]
+    fn world_state_lists_nearby_ground_items() {
+        let (mut s, _rx) = test_state();
+        s.self_player = Some(Player {
+            id: PlayerId::from(1),
+            name: "Me".to_string(),
+            position: p(0.0, 0.0, 0.0),
+            rotation: 0.0,
+            level: 1,
+            health: 10,
+            max_health: 10,
+            class: onlinerpg_shared::CharacterClass::Rogue,
+            gender: Default::default(),
+            is_official_npc: false,
+            torch_on: false,
+            floor_level: 0,
+            object_type: None,
+            object_id: None,
+            last_combat_at: 0,
+            client_kind: Default::default(),
+        });
+        for item in [
+            ground_item(1, "small_sword", 5.0, 0.0, 0),
+            ground_item(2, "wooden_shield", 2.0, 0.0, 0),
+            ground_item(3, "coin_pile", 1.0, 0.0, 0),
+            ground_item(4, "iron_sword", 0.0, NPC_SIGHT_RADIUS + 5.0, 0),
+            ground_item(5, "healing_potion", 3.0, 0.0, 1),
+        ] {
+            s.ground_items.insert(item.instance_id, item);
+        }
+
+        let lines: Vec<String> = s
+            .format_world_state()
+            .lines()
+            .filter(|l| l.starts_with("Item on ground:"))
+            .map(str::to_string)
+            .collect();
+
+        assert_eq!(
+            lines,
+            vec![
+                "Item on ground: coin_pile (1.0m away) [id 3]",
+                "Item on ground: wooden_shield (2.0m away) [id 2]",
+                "Item on ground: small_sword (5.0m away) [id 1]",
+            ]
+        );
     }
 
     /// The server never echoes our own monster moves back (the owner is


### PR DESCRIPTION
## 문제

에이전트에게 바닥 아이템이 완전히 보이지 않습니다. 서버는 조인 스냅샷의 `ground_items`와 `GroundItemSpawned/Appeared/Removed` 스트림을 이미 보내주고 있지만, agent-client는 전부 버립니다 — `SharedState`가 바닥 아이템을 추적하지 않고, world state에도 나열되지 않으며, `PickupItem`을 보낼 액션도 없습니다. 웹 플레이어는 클릭 한 번으로 줍는 것을, 에이전트는 자기가 잡은 몬스터의 드랍 위에 서 있으면서도 존재조차 모릅니다.

관전 패널로 라이브 관찰한 수치입니다 (공개 서버, 수정 전 35분): 에이전트 킬 25, 클라이언트가 수신한 드랍 32개(small_sword 16, goblin_sword 8, 물약 3, 방패 3, iron_sword 1, coin_pile 1), **드랍이 LLM 프롬프트에 언급된 횟수 0, 줍기 0** — 32개 전부 다른 플레이어가 가져가거나 5분 뒤 사라졌습니다. 어제 추가된 가죽 갑옷 확정 드랍(ee657f8)을 포함해, 아이템 루프 전체가 에이전트에게 닫혀 있습니다.

## 수정

**인지** — `SharedState`에 `ground_items` 맵을 추가하고 스냅샷 + 증분 메시지 3종으로 유지합니다. 셋 다 상태 전용 처리라서(이벤트 큐에 넣지 않음) 시야 경계에서 아이템이 드나들어도 프롬프트가 부풀지 않습니다. world state가 같은 층·시야 반경 내 아이템을 가까운 순으로 나열합니다:

```
Item on ground: goblin_sword (2.0m away) [id 9215]
```

**액션** — 웹 클라이언트의 클릭-줍기를 그대로 미러링한 `pickup` 액션을 추가합니다. 기존 추격 루프를 재사용해 아이템까지 걸어가고(`ChaseTarget::GroundItem`, 서버의 2.5m 판정 안쪽에서 정지), 주변 플레이어에게 웅크림 모션을 보여준 뒤 `PickupItem`을 보냅니다. 검증은 전부 서버 소유 그대로입니다 — 거리·층·무게 체크, 코인 더미의 지갑 입금 처리 모두 서버가 하고, 실패는 SystemMessage로 돌아와 기존 경로로 LLM에 전달됩니다.

행동 지침은 넣지 않았습니다. 공유 프롬프트에는 액션 형식 설명만 추가했고, 무엇을 주울지는 LLM(과 역할 프롬프트 계층)의 판단입니다.

## 검증

- `cargo test -p agent-client` 45/45 (신규 3: 액션 파싱 2, world state 필터링 1), clippy 경고 없음
- 라이브 검증은 공개 서버에서 두 번, **둘 다 루팅 관련 지침이 한 줄도 없는 역할 프롬프트로** 진행했습니다 — 줍기는 전부 LLM의 자발적 선택입니다.

**1차 (24분, claude sonnet)**: 킬 32, 시야에 잡힌 드랍 9종(프롬프트 23건 중 10건에 표시), 자발적 pickup 2회, 실패 0. 첫 획득 장면:

```
LLM: {"thought": "근처에 goblin_sword 아이템이 2m 거리에 있어 먼저 습득. 이후 가까운
      orc_female(m208_129)을 공격 대상으로 삼는다.",
      "actions": [{"type": "pickup", "item_id": 9215}, {"type": "attack", "monster_id": "m208_129"}]}
INFO  Agent picked up goblin_sword [id 9215]
→ InventoryUpdated: bag = [worn_torch, goblin_sword]
```

**2차 (28분, claude haiku — 더 촘촘한 턴)**: 킬 64, 시야에 든 드랍 7개(small_sword 4, goblin_sword 2, coin_pile 1)를 **7개 전부 걸어가서 획득, 실패 0** — coin_pile은 서버가 지갑에 입금(가방 무변화, 골드 +5c)하는 것까지 그대로 동작했습니다. 획득한 무기(1d4)는 장착하지 않고 들고 있던 worn_iron_sword(1d8)를 유지했는데, 이 판단 역시 프롬프트 지시 없이 나온 것입니다.

수정 전 0/32였던 아이템 루프가, 지시 없이도 에이전트 스스로 여닫는 루프가 됐습니다.

## 범위 밖 (후속 여지)

- `OpenDungeonChest`는 별개 메커니즘(근접·상태 검증이 다름)이라 제외했습니다. 바닥 줍기가 자리 잡으면 따로 제안하겠습니다.
- 에이전트의 거리 계산(`PlanarDelta`)은 월드 X-이음새 랩을 고려하지 않는데, 이는 기존 전투 추격·접근에도 동일한 선재 한계라 이 PR에서는 건드리지 않았습니다. 이음새 인근 오차는 2.0m 정지 마진이 실질 흡수합니다.
