### PR TITLE
fix(server): reject non-finite monster movement values

### DIFF
--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -167,6 +167,19 @@ impl super::GameState {
             if !monster.is_controllable_by(mover_id) {
                 return;
             }
+            if !new_position.is_finite() || !rotation.is_finite() || !target_position.is_finite() {
+                let correction = ServerMessage::MonsterMoved {
+                    monster_id,
+                    position: monster.position,
+                    rotation: monster.rotation,
+                    state: monster.state,
+                    target_position: monster.position,
+                    owner_id: monster.owner_id,
+                };
+                drop(monsters);
+                self.send_direct_message(mover_id, correction).await;
+                return;
+            }
             // Rate-limit client-reported movement with a token bucket that
             // refills at the monster's run speed. Movement is simulated by the
             // owning client, so without this an owner could teleport the monster

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -1344,6 +1344,131 @@ async fn monster_move_requires_ownership() {
     );
 }
 
+#[tokio::test]
+async fn non_finite_monster_move_is_rejected() {
+    let game_state = make_test_game_state("monster_move_non_finite");
+    let owner_id = pid("owner");
+    let observer_id = pid("observer");
+    let authoritative_position = Position {
+        x: 1.0,
+        y: 2.0,
+        z: 3.0,
+    };
+
+    game_state.add_player(make_player("owner", 1.0, 3.0)).await;
+    game_state
+        .add_player(make_player("observer", 1.0, 3.0))
+        .await;
+    let mut owner_rx = game_state.register_direct_channel(&owner_id).await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        let mut monster = make_monster("owned_monster", authoritative_position, 0);
+        monster.owner_id = Some(owner_id);
+        monster.rotation = 0.25;
+        monster.move_budget = 7.0;
+        monster.last_move_at = 42;
+        monsters.insert("owned_monster".to_string(), monster);
+    }
+
+    let with_component = |axis: usize, value: f32| {
+        let mut position = authoritative_position;
+        match axis {
+            0 => position.x = value,
+            1 => position.y = value,
+            2 => position.z = value,
+            _ => unreachable!(),
+        }
+        position
+    };
+    let mut cases = Vec::new();
+    for (axis, axis_name) in [(0, "x"), (1, "y"), (2, "z")] {
+        for (value, value_name) in [
+            (f32::NAN, "NaN"),
+            (f32::INFINITY, "+infinity"),
+            (f32::NEG_INFINITY, "-infinity"),
+        ] {
+            cases.push((
+                format!("position {axis_name} {value_name}"),
+                with_component(axis, value),
+                0.5,
+                authoritative_position,
+            ));
+            cases.push((
+                format!("target {axis_name} {value_name}"),
+                authoritative_position,
+                0.5,
+                with_component(axis, value),
+            ));
+        }
+    }
+    for (rotation, value_name) in [
+        (f32::NAN, "NaN"),
+        (f32::INFINITY, "+infinity"),
+        (f32::NEG_INFINITY, "-infinity"),
+    ] {
+        cases.push((
+            format!("rotation {value_name}"),
+            authoritative_position,
+            rotation,
+            authoritative_position,
+        ));
+    }
+
+    for (case, position, rotation, target_position) in cases {
+        let before = game_state.monsters.read().await["owned_monster"].clone();
+
+        game_state
+            .update_monster_position(
+                &owner_id,
+                "owned_monster".to_string(),
+                position,
+                rotation,
+                MonsterState::Run,
+                target_position,
+            )
+            .await;
+
+        let after = game_state.monsters.read().await["owned_monster"].clone();
+        assert_eq!(after.position.x, before.position.x, "{case}");
+        assert_eq!(after.position.y, before.position.y, "{case}");
+        assert_eq!(after.position.z, before.position.z, "{case}");
+        assert_eq!(after.rotation, before.rotation, "{case}");
+        assert_eq!(after.state, before.state, "{case}");
+        assert_eq!(after.move_budget, before.move_budget, "{case}");
+        assert_eq!(after.last_move_at, before.last_move_at, "{case}");
+        assert!(after.move_budget.is_finite(), "{case}");
+
+        match observer_rx.try_recv() {
+            Err(MpscTryRecvError::Empty) => {}
+            other => panic!("{case} must not fan out, got {other:?}"),
+        }
+        match owner_rx.try_recv() {
+            Ok(ServerMessage::MonsterMoved {
+                monster_id,
+                position,
+                rotation,
+                state,
+                target_position,
+                ..
+            }) => {
+                assert_eq!(monster_id, "owned_monster", "{case}");
+                assert_eq!(position.x, before.position.x, "{case}");
+                assert_eq!(position.y, before.position.y, "{case}");
+                assert_eq!(position.z, before.position.z, "{case}");
+                assert_eq!(rotation, before.rotation, "{case}");
+                assert_eq!(state, before.state, "{case}");
+                assert_eq!(target_position.x, before.position.x, "{case}");
+                assert_eq!(target_position.y, before.position.y, "{case}");
+                assert_eq!(target_position.z, before.position.z, "{case}");
+            }
+            other => panic!("{case} must correct the owner, got {other:?}"),
+        }
+        assert!(matches!(owner_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    }
+}
+
 /// Even the owner can't teleport a monster onto a distant victim: a move is
 /// capped to what the monster could run since its last accepted move, so an
 /// owned monster stays a melee threat only where it could actually walk.


### PR DESCRIPTION
## Overview

`update_monster_position` accepted client-reported position, rotation, and target-position values without confirming that they were finite. Ownership was checked, but an authorized owner could still submit `NaN`, positive infinity, or negative infinity.

An ordinary authenticated, in-game player can become the owner of a configured ambient monster through `RequestSpawnMonster`; no administrator privilege is required. The binary WebSocket protocol uses MessagePack, which can encode non-finite floating-point values, so a crafted client can reach this handler with such input.

I reproduced a case where `position.x = NaN` bypassed the movement speed check and reached the accepted-move path. This stored both a `NaN` position and a `NaN` movement budget. The immediately following finite move then also produced a `NaN` distance and bypassed the 12-meter movement-budget cap, allowing an arbitrary-distance reposition. Alternating a `NaN` update with a finite destination made the bypass repeatable.

## Steps to reproduce

1. Create a monster controlled by a connected player.
2. Give the monster a finite position, rotation, and movement budget.
3. Send a movement update with a finite target and rotation, but set one position component to `NaN`.
4. `update_monster_position` confirms ownership and calculates the distance from the unvalidated position.
5. The calculated distance becomes `NaN`.
6. The `dist > budget` comparison evaluates to `false`, so the update continues through the accepted-move path.
7. Send a finite position more than 12 meters from the monster's last valid position.
8. Because the stored position is now `NaN`, this distance is also `NaN`; the comparison again evaluates to `false`, and the out-of-budget move is accepted.
9. Alternate another `NaN` update with another finite destination to repeat the bypass.

The same input boundary also permits other invalid cases:

- `NaN` or infinity in rotation can be stored when the reported distance is otherwise valid.
- `NaN` or infinity in target position can be published because target position is not part of the distance calculation.
- Infinite position behavior is axis-dependent because movement distance is calculated only in the X-Z plane: an infinite Y value is ignored by the distance check and can be stored; an infinite Z value produces an infinite distance and is rejected; and world wrapping turns an infinite X delta into `NaN`, which can reach the accepted-move path. Rejected cases are still evaluated only after movement-accounting state has started to update.

## Observed behavior

Before this change:

- a `NaN` position could be stored in the authoritative monster state;
- `move_budget` could become `NaN`;
- after a `NaN` position was accepted, the next finite movement update could reposition the monster an arbitrary distance because its calculated distance was also `NaN`;
- alternating `NaN` and finite positions made the 12-meter speed-cap bypass repeatable;
- non-finite rotation or target values could be included in `MonsterMoved`;
- an invalid request could change `last_move_at` or movement budget before being rejected;
- the owner received no correction for a `NaN` move because it was incorrectly accepted and normal movement fanout skips the owner.

The regression test initially failed on the first `position.x = NaN` case:

```text
observed: NaN
expected: 1.0
```

## Expected behavior

The server should reject the complete movement update when position, rotation, or target position contains a non-finite value.

A rejected update should not change the monster or its token bucket, should not be sent to observers, and should send one authoritative correction to the owner because the owner applies movement optimistically.

## Root cause

The token-bucket speed limiter assumed that all movement inputs were finite. The player movement path already checks this invariant, but the equivalent monster movement path did not.

The validation also needs to run before token refill, distance calculation, timestamps, or stored movement fields are updated. A later check would still allow an invalid packet to change accounting state.

## Changes

- Check both reported positions with `Position::is_finite()`.
- Check rotation with `f32::is_finite()`.
- Run the validation after ownership is confirmed and before movement accounting begins.
- Build a `MonsterMoved` correction from the current authoritative state.
- Release the monster write lock before sending the correction directly to the owner.

Valid movement, ownership rules, the configured speed cap, and the wire format are unchanged. The new boundary check restores the finite-input invariant required by the existing token-bucket limiter.

## Validation

`non_finite_monster_move_is_rejected` covers 21 invalid inputs:

- `NaN`, positive infinity, and negative infinity on each x/y/z position component;
- the same three values on each x/y/z target-position component;
- the same three values for rotation.

For every case, the test confirms that position, rotation, state, `move_budget`, and `last_move_at` remain unchanged. It also confirms that observers receive no update and the owner receives exactly one correction containing the authoritative state.

Tested:

- `cargo test -p onlinerpg-server non_finite_monster_move_is_rejected` — 1/1 passed
- `cargo test -p onlinerpg-server` — 128/128 passed
- `cargo test -p agent-client` — 42/42 passed
- `cargo check --workspace` — passed
- `cargo clippy --workspace --all-targets` — passed
- `git diff --check` — passed

I also confirmed that this commit applies cleanly to the current `master` and passes the combined latest-master workspace verification.

## Scope and limitations

This change does not alter the configured speed cap or token-bucket algorithm; it prevents invalid inputs from bypassing that existing protection by rejecting them before movement accounting begins. Protocol serialization and spawn-request validation remain unchanged.
