### PR TITLE
Run LLM turns when monsters are nearby, not only humans

### DIFF
--- a/agent-client/src/driver/mod.rs
+++ b/agent-client/src/driver/mod.rs
@@ -150,7 +150,7 @@ pub async fn llm_driver(
             check_schedule_transition(&state, &schedule, active_schedule, &label).await;
     }
 
-    // Send initial world state only if human players are nearby and NPC is not sleeping
+    // Send initial world state only if company (humans or monsters) is nearby and NPC is not sleeping
     let is_sleeping = active_schedule.0.is_some_and(|i| schedule[i].is_sleeping());
     {
         let mut s = state.lock().await;
@@ -158,7 +158,7 @@ pub async fn llm_driver(
             s.drain_events();
             s.drain_agent_events();
             info!("[{label}] LLM driver: NPC is sleeping, skipping initial prompt");
-        } else if s.has_nearby_human_players() {
+        } else if s.has_nearby_human_players() || s.has_nearby_monsters() {
             let agent_events = s.drain_agent_events();
             let initial_prompt = build_prompt(&s, &[], &agent_events, &schedule, active_schedule.0);
             drop(s);
@@ -284,9 +284,10 @@ pub async fn llm_driver(
         let (prompt, has_events, priority) = {
             let mut s = state.lock().await;
 
-            // Skip LLM when NPC is sleeping or no human players are nearby —
-            // drain events to avoid unbounded accumulation but don't build a prompt.
-            if is_sleeping || !s.has_nearby_human_players() {
+            // Skip LLM when NPC is sleeping or nothing is around to act on
+            // (no humans, no monsters) — drain events to avoid unbounded
+            // accumulation but don't build a prompt.
+            if is_sleeping || (!s.has_nearby_human_players() && !s.has_nearby_monsters()) {
                 s.drain_events();
                 s.drain_agent_events();
                 pending_urgency = LlmPriority::Idle;

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -237,6 +237,17 @@ impl SharedState {
         })
     }
 
+    /// Returns true if any monster is within NPC sight radius.
+    pub fn has_nearby_monsters(&self) -> bool {
+        let Some(self_player) = self.self_player.as_ref() else {
+            return false;
+        };
+        let radius_sq = NPC_SIGHT_RADIUS * NPC_SIGHT_RADIUS;
+        self.nearby_monsters
+            .values()
+            .any(|m| m.position.dist_xz_sq(&self_player.position) <= radius_sq)
+    }
+
     /// Check all nearby players and emit an agent event for any player
     /// that just entered NEARBY_PLAYER_RADIUS for the first time.
     fn check_nearby_player_proximity(&mut self) {


### PR DESCRIPTION
## Problem

The driver skips LLM turns entirely when no human player is in sight (the `has_nearby_human_players()` gate, at both the initial prompt and the main loop). When that gate was added in 0f473d16 the agent-client was operator-NPC-only (Rica, Karl), so "nobody watching, nothing to think about" was pure cost saving. With remote user agents in the picture, it now **turns off the brain of any agent that goes hunting alone.**

Observed live (Google-mode agent, sent to the spawn flats outside town by its schedule):

```
06:34:57 [Archy] Schedule transition: moving to field hours: hunt monsters ...
06:35:47 Monster AI: managing m389_17 (type=kobold, aggressive=false)
06:35:47 Monster AI: managing m389_18 (type=goblin, aggressive=false)
   ...   (monsters keep spawning around the agent)
06:36:29 [Archy] LLM driver: no human players nearby, skipping initial prompt
   ...   (5+ minutes: zero LLM calls, zero attacks — standing sword in hand next to a kobold)
```

`doc/REMOTE_AGENT_CLIENT.md` states the primary goal as "the LLM plays the game as an ordinary player — roams, **fights**, talks, grows", and its decision table keeps agents eligible for ambient spawns precisely because they "must receive the same rules as humans to **grow through hunting**". A brain that only boots for a human audience cannot do that.

## Fix

Add `has_nearby_monsters()` to `SharedState` (same `NPC_SIGHT_RADIUS` as the human check) and relax both skip sites from "no humans" to "**no humans and no monsters**".

- Towns are no-spawn zones, so NPCs parked in town still idle for free
- The `is_sleeping` skip is untouched
- Operator NPCs only change behavior when a monster strays into sight with no players around — arguably exactly when a guard should react

## Verification

- `cargo test -p agent-client` 42/42 passing; clippy clean for the changed code (the pre-existing `collapsible_match` warning at state.rs:586 is unrelated, left untouched)
- Confirmed on prod: before the patch, a full hunting schedule produced zero attacks; after, the very first turn picks a target, closes in, attacks, and kills (+2 XP):

```
<<< FROM CLAUDE: {"thought": "It's field hours ... The nearest kobold is m398_17 at
roughly 22 units away. I'll move to it and attack.", "actions": [
  {"type": "move", "x": -1508.7, "y": 0.7, "z": 4444.6},
  {"type": "attack", "monster_id": "m398_17"}]}
[MonsterDead] m398_17
[XP] +2 (total: 2, level: 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)