### PR TITLE
Detect half-open connections with a read-idle timeout

### DIFF
--- a/agent-client/src/ws.rs
+++ b/agent-client/src/ws.rs
@@ -144,9 +144,24 @@ pub async fn send(tx: &mut WsTx, msg: &ClientMessage) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The server broadcasts GameTimeSync to every client every 8s, so a healthy
+/// connection is never quiet for long. A socket silent past this window is a
+/// half-open corpse (server restarted without a RST, NAT dropped the path):
+/// reads would otherwise block on it forever. Detection is read-side only —
+/// no client pings, so a fleet of idle agents adds zero server traffic — and
+/// the session loop's jittered backoff already spreads out the reconnects.
+const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub async fn recv(rx: &mut WsRx) -> anyhow::Result<ServerMessage> {
     loop {
-        match rx.next().await {
+        match tokio::time::timeout(READ_IDLE_TIMEOUT, rx.next())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "No server traffic for {}s — connection presumed dead",
+                    READ_IDLE_TIMEOUT.as_secs()
+                )
+            })? {
             Some(Ok(Message::Binary(bytes))) => {
                 return Ok(deserialize_server_msg(&bytes)?);
             }


### PR DESCRIPTION
## Problem

`ws::recv()` waits on the socket with no upper bound. When the server goes away without a RST reaching the client — pod restart behind the proxy, NAT table expiry, network path change — the TCP connection stays `ESTABLISHED` on the client side, reads block forever, and the agent plays dead indefinitely.

Observed live: an agent-client ran for 30+ minutes with a healthy-looking process and an `ESTABLISHED` socket to the server, while being invisible in the game the whole time. The log simply stops:

```
06:26:34 <<< FROM CLAUDE (548 bytes): ... (last line — then 30+ minutes of silence)
```

Process supervision (launchd/systemd) can't catch this — the process itself is fine. Only a manual restart brought the agent back.

## Fix

The server already broadcasts `GameTimeSync` to every connected client every 8 seconds (`main.rs`, time sync tick), so a healthy connection is never quiet for long. Wrap `recv()` in a 60-second read timeout — seven missed GameTimeSyncs — and bail out, which lands in the session loop's existing reconnect path.

Written to stay polite to the server as agent fleets grow:

- **Read-side only** — no client pings, no new frames: a fleet of idle agents adds exactly zero traffic
- **Reconnects use the existing full-jitter backoff** (`retry_delay`), so agents that all lose the same server come back spread out, not as one synchronized wave — the property that function's comment already promises
- 60s is deliberately conservative (7+ missed broadcasts) to avoid false-positive reconnect churn on brief stalls

## Verification

- `cargo test -p agent-client` 42/42 passing; clippy clean for the changed code
- Running on the live server since the patch: reconnects normally after `launchctl kickstart`, no spurious timeout disconnects under normal traffic (GameTimeSync cadence keeps the window fed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)