### PR TITLE
Run tests, clippy, fmt and client checks on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust (fmt + clippy + test)
+    runs-on: ubuntu-latest
+    steps:
+      # LFS assets (models, audio) are not needed to compile or test — plain
+      # checkout keeps CI fast and off the LFS bandwidth quota.
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all --check
+      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo test --workspace
+
+  client:
+    name: Client (wasm + vitest + svelte-check + eslint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - run: npm ci
+      - run: npm run build:wasm
+      - run: npm test
+      - run: npm run check
+      - run: npm run lint

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -571,12 +571,10 @@ impl SharedState {
                 player_id,
                 health,
                 max_health,
-            } => {
-                if self.self_player_id.as_ref() == Some(player_id) {
-                    if let Some(ref mut p) = self.self_player {
-                        p.health = *health;
-                        p.max_health = *max_health;
-                    }
+            } if self.self_player_id.as_ref() == Some(player_id) => {
+                if let Some(p) = self.self_player.as_mut() {
+                    p.health = *health;
+                    p.max_health = *max_health;
                 }
             }
             // Only ever sent direct to the player who earned (or lost) the XP,


### PR DESCRIPTION
## Problem

The only workflow today is the CLA assistant. Every PR's "tests pass" claim — including my own #26 and #27 — is the author running `cargo test` at home and the reviewer taking their word for it. With external contributions picking up (#15–#27), that trust model doesn't scale.

## What this adds

One workflow, two parallel jobs, `pull_request` + push-to-master triggers:

**rust** — `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (456 tests). Game data regenerates through `build.rs`, so a plain checkout suffices. Checkout skips LFS: models/audio aren't needed to compile or test, which keeps CI fast and off the LFS bandwidth quota.

**client** — real `wasm-pack` build of the shared crate, then `vitest` (281 tests), `svelte-check` + `tsc`, `eslint`. Building the real wasm (not a stub) means a shared-crate protocol change that breaks the browser client fails CI instead of surfacing at the next deploy.

Both jobs are cache-backed (`Swatinem/rust-cache`, npm cache keyed on `client/package-lock.json`). The `pull_request` trigger exposes no secrets to fork PRs.

A small preparatory commit lifts the one existing clippy warning (`collapsible_match` in `state.rs`) into a match guard, so the `-D warnings` gate starts from a clean tree. Behavior is unchanged — a non-self `PlayerHealthUpdate` now falls through to the catch-all arm, which does nothing, same as before.

## Cost

This adds **zero cost to the repository owner**:

- Actions minutes: "GitHub Actions usage is free for self-hosted runners and for public repositories that use standard GitHub-hosted runners" ([About billing for GitHub Actions](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions)). This workflow uses only standard `ubuntu-latest` runners, and this repo is public — fork PRs run on the base repo's allowance, which is likewise free here.
- Git LFS bandwidth **is** metered even on public repos (free plans include 10 GiB/month, [About storage and bandwidth usage](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage)) — which is exactly why the checkout skips LFS; CI consumes none of that quota.
- The only practical ceiling is the free plan's concurrent-job limit ([Usage limits](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration)); bursts queue rather than bill, and the `concurrency` group cancels superseded runs on the same ref to keep the queue short.

## Verification

Validated end-to-end on my fork before opening this PR: both jobs green on a clean runner — [run 30149041370](https://github.com/jckdotim/OpenMMO/actions/runs/30149041370). Cold run ≈6 min (wasm + npm ci dominate); warm-cache runs should be well under that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)