### PR TITLE
Let agents find and open the dungeon treasure chest

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -55,6 +55,12 @@ Available action types (use EXACTLY these field names):
   state ("Item on ground: ... [id 6043]"), or its name:
   {"type": "pickup", "item": 6043}
 
+- Open the treasure chest on a dungeon's deepest floor. You walk to it
+  first, then the server decides: it opens only after that floor's boss is
+  dead, and refills per player once an hour. Loot lands straight in your
+  bag; a rejection tells you why it stayed shut:
+  {"type": "open_chest"}
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -106,6 +106,11 @@ pub(super) enum AgentAction {
         )]
         item: PickupRef,
     },
+    /// Open the treasure chest on the current dungeon's deepest floor.
+    /// The server validates floor, proximity, boss state and the per-player
+    /// cooldown, and answers with loot or a rejection explaining why.
+    #[serde(rename = "open_chest", alias = "open_dungeon_chest")]
+    OpenChest,
     /// Reroll starting stats. Only meaningful during character creation,
     /// where it is the agent's version of the web client's reroll button.
     #[serde(rename = "reroll", alias = "reroll_stats", alias = "roll_again")]
@@ -268,6 +273,7 @@ pub(super) fn action_to_command(
         AgentAction::OpenTrade { .. } => None,
         // Needs the bag and worn gear from SharedState; likewise handled there.
         AgentAction::Use { .. } => None,
+        AgentAction::OpenChest => None,
         // Needs ground-item resolution and the walk-to loop; handled there too.
         AgentAction::Pickup { .. } => None,
         // Only reaches the server as a pre-creation RollCharacterStats; in

--- a/agent-client/src/driver/combat.rs
+++ b/agent-client/src/driver/combat.rs
@@ -131,6 +131,11 @@ pub(super) enum ChaseTarget<'a> {
     Monster(&'a str),
     Player(&'a PlayerId),
     GroundItem(u64),
+    /// A fixed world position on a known floor (e.g. the dungeon chest).
+    Point {
+        pos: onlinerpg_shared::Position,
+        floor_level: i8,
+    },
 }
 
 impl ChaseTarget<'_> {
@@ -139,6 +144,7 @@ impl ChaseTarget<'_> {
             Self::Monster(id) => s.nearby_monsters.get(*id).map(|m| m.position),
             Self::Player(id) => s.nearby_players.get(*id).map(|p| p.position),
             Self::GroundItem(id) => s.visible_ground_item(*id).map(|i| i.position),
+            Self::Point { pos, .. } => Some(*pos),
         }
     }
 
@@ -149,6 +155,7 @@ impl ChaseTarget<'_> {
             Self::Monster(id) => s.nearby_monsters.get(*id).map(|m| m.floor_level),
             Self::Player(id) => s.nearby_players.get(*id).map(|p| p.floor_level),
             Self::GroundItem(id) => s.visible_ground_item(*id).map(|i| i.floor_level),
+            Self::Point { floor_level, .. } => Some(*floor_level),
         };
         onlinerpg_shared::dungeon::passability_floor_for_level(level.unwrap_or(0))
     }
@@ -180,6 +187,15 @@ impl ChaseTarget<'_> {
                 max_distance: crate::state::NPC_SIGHT_RADIUS,
                 max_secs: MAX_PICKUP_WALK_SECS,
             },
+            // Fixed points sit anywhere on the floor (the chest can be a
+            // whole dungeon floor away), so no sight-radius cap.
+            Self::Point { .. } => ChaseTuning {
+                arrive_range: 2.0,
+                path_pullback: 0.0,
+                step_stop_dist: 1.5,
+                max_distance: f32::MAX,
+                max_secs: 60.0,
+            },
         }
     }
 }
@@ -207,6 +223,7 @@ impl std::fmt::Display for ChaseTarget<'_> {
             Self::Monster(id) => f.write_str(id),
             Self::Player(id) => write!(f, "{id}"),
             Self::GroundItem(id) => write!(f, "item {id}"),
+            Self::Point { pos, .. } => write!(f, "point ({:.1}, {:.1})", pos.x, pos.z),
         }
     }
 }
@@ -236,6 +253,15 @@ pub(super) async fn walk_to_ground_item(
     instance_id: u64,
 ) -> ChaseResult {
     chase_target(state, &ChaseTarget::GroundItem(instance_id)).await
+}
+
+/// Walk to a fixed position on a floor (e.g. the dungeon treasure chest).
+pub(super) async fn walk_to_point(
+    state: &Arc<Mutex<SharedState>>,
+    pos: onlinerpg_shared::Position,
+    floor_level: i8,
+) -> ChaseResult {
+    chase_target(state, &ChaseTarget::Point { pos, floor_level }).await
 }
 
 /// Chase the target until we're within its arrive range, using A*

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -13,7 +13,9 @@ use crate::state::{Carried, SharedState};
 use super::action::{
     action_to_command, parse_agent_response, resolve_move_goal, AgentAction, PickupRef,
 };
-use super::combat::{approach_player, chase_monster, walk_to_ground_item, ChaseResult};
+use super::combat::{
+    approach_player, chase_monster, walk_to_ground_item, walk_to_point, ChaseResult,
+};
 use super::movement::{execute_move, MoveResult};
 
 /// Pause between the crouch broadcast and the actual pickup, approximating
@@ -205,6 +207,60 @@ pub(super) async fn handle_response(
             };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send use action: {e}");
+            }
+            continue;
+        }
+
+        // Open the dungeon treasure chest: walk up to it on the deepest
+        // floor and ask the server. The server owns proximity, boss-state
+        // and cooldown checks and answers with DungeonChestOpened or an
+        // InteractionRejected explaining why.
+        if matches!(action, AgentAction::OpenChest) {
+            let chest = {
+                let s = state.lock().await;
+                s.dungeon_here().and_then(|d| {
+                    let depth = d.max_depth();
+                    let cell = d.layouts().last().and_then(|l| l.chest)?;
+                    let pos = onlinerpg_shared::dungeon::cell_center(&d.entrance, depth, cell);
+                    Some((d.id.clone(), pos, -(depth as i8), s.self_floor_level))
+                })
+            };
+            let Some((entrance_id, chest_pos, chest_floor, player_floor)) = chest else {
+                let mut s = state.lock().await;
+                s.push_agent_event(
+                    "[ChestFailed] There is no treasure chest here — it sits on a dungeon's deepest floor.".to_string(),
+                );
+                continue;
+            };
+            if player_floor != chest_floor {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[ChestFailed] The chest is on floor {} — descend there first.",
+                    chest_floor.unsigned_abs()
+                ));
+                continue;
+            }
+            match walk_to_point(state, chest_pos, chest_floor).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    if let Err(e) = s
+                        .send_command(onlinerpg_shared::ClientMessage::OpenDungeonChest {
+                            entrance_id,
+                        })
+                        .await
+                    {
+                        error!("Failed to send open_chest: {e}");
+                    } else {
+                        info!("Agent requested dungeon chest open");
+                    }
+                }
+                ChaseResult::Lost | ChaseResult::Error => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(
+                        "[ChestFailed] You could not reach the chest — the way is blocked."
+                            .to_string(),
+                    );
+                }
             }
             continue;
         }

--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -161,6 +161,25 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
             Some(format!("[Whisper] {from}: {message}"))
         }
         ServerMessage::SystemMessage { message } => Some(format!("[System] {message}")),
+        ServerMessage::InteractionRejected { reason } => {
+            Some(format!("[InteractionRejected] {reason}"))
+        }
+        ServerMessage::DungeonChestOpened {
+            player_id,
+            item_def_ids,
+            gold,
+            ..
+        } => {
+            let who = if state.self_player_id.as_ref() == Some(player_id) {
+                "You".to_string()
+            } else {
+                player_name(state, player_id)
+            };
+            Some(format!(
+                "[Chest] {who} opened the treasure chest: {} + {gold} gold.",
+                item_def_ids.join(", ")
+            ))
+        }
         ServerMessage::PlayerJoined { player } => {
             if !within_event_range(state, player.position.x, player.position.z) {
                 return None;

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -1285,14 +1285,36 @@ impl SharedState {
         let p = self.self_player.as_ref()?;
         if self.self_floor_level < 0 {
             let depth = self.self_floor_level.unsigned_abs();
-            let name = self
-                .dungeon_here()
+            let dungeon = self.dungeon_here();
+            let name = dungeon
+                .as_ref()
                 .map(|d| format!("{} ", d.name))
                 .unwrap_or_default();
-            return Some(format!(
+            let mut line = format!(
                 "You are underground: {name}floor {depth} (deeper floors hold stronger \
                  monsters; move with \"depth\" to change floors, 0 to leave)"
-            ));
+            );
+            // The deepest floor holds the treasure chest — surface it so the
+            // LLM knows it exists and how to claim it.
+            if let Some(d) = dungeon {
+                if depth == d.max_depth() {
+                    if let Some(cell) = d.layouts().last().and_then(|l| l.chest) {
+                        let pos = onlinerpg_shared::dungeon::cell_center(
+                            &d.entrance,
+                            d.max_depth(),
+                            cell,
+                        );
+                        let dist = crate::geom::PlanarDelta::between(&p.position, &pos).dist;
+                        line.push_str(&format!(
+                            "\nTreasure chest on this floor at ({:.0}, {:.0}), {dist:.0}m away \
+                             — {{\"type\": \"open_chest\"}} walks there and opens it. It only \
+                             opens once this floor's boss is dead (refills per player hourly).",
+                            pos.x, pos.z
+                        ));
+                    }
+                }
+            }
+            return Some(line);
         }
         let dungeon = self
             .world_cache


### PR DESCRIPTION
#21의 후속입니다. 던전 진입·탐험을 구현해주신 덕분에 에이전트가 최심층까지 내려가게 됐는데, 마지막 한 칸 — 보물상자 — 가 에이전트에게는 아직 없어서 붙였습니다.

## 무엇이 없었나

- 서버(`open_dungeon_chest`)와 프로토콜(`OpenDungeonChest`)은 완비되어 있고 웹 클라이언트는 근접 시 자동 개봉하지만, agent-client에는 ① 상자의 존재를 인지할 경로와 ② 개봉 메시지를 보낼 액션이 둘 다 없었습니다.
- 부수적으로, 서버의 `InteractionRejected`(거절 사유)와 `DungeonChestOpened`(개봉 결과)가 이벤트 렌더링에서 누락되어 LLM에게 보이지 않았습니다 — 상자와 무관하게도 에이전트가 상호작용 거절 사유를 알 수 없는 상태였습니다.

## 무엇을 했나 (agent-client만, 6파일 +140/−5)

1. **인지**: 최심층에 있을 때 상태 프롬프트에 상자 좌표·거리·개봉 조건 한 줄을 추가했습니다. 레이아웃은 결정론 생성이라 클라이언트가 이미 갖고 있는 정보를 노출만 한 것입니다 (`format_dungeon_state`).
2. **액션**: `{"type": "open_chest"}` — 상자까지 A* 보행 후 `OpenDungeonChest` 전송. 층·근접·보스·쿨다운 검증은 전부 서버 판정에 맡깁니다 (클라이언트에는 헛걸음을 아끼는 층 가드 하나만).
3. **이동**: 고정 좌표 타겟 `ChaseTarget::Point` 추가 — 기존 Monster/Player/GroundItem 추적과 같은 경로를 타되, 상자는 층 반대편일 수 있어 시야 반경 제한 없이 60초 상한으로 걷습니다.
4. **가시성**: `InteractionRejected` → `[InteractionRejected] {reason}`, `DungeonChestOpened` → `[Chest] {who} opened ...` 이벤트 렌더링 추가.

설계 선택 하나: 웹은 근접 자동 개봉이지만 에이전트는 명시 액션으로 했습니다. 에이전트는 전투·루팅 중 상자 셀을 자연히 스쳐 지나가는데, 근접 자동이면 의도치 않게 시간당 1회 쿨다운을 소모합니다. 명시 액션이면 행동-결과가 짝지어져 거절 사유가 다음 판단의 입력이 되기도 하고요. 자동 개봉이 파리티상 맞다고 보시면 근접 트리거로 바꾸겠습니다.

## 실측 (공개 서버, Ryulamg)

한 세션에서 음성·양성 경로를 모두 확인했습니다:

1. 보스 생존 중 `open_chest` → 35m를 걸어 상자 앞 2m 도착 → `[InteractionRejected] The guardian still lives` 수신 (거절 사유가 LLM 이벤트로 전달됨)
2. 에이전트가 거절 사유를 읽고 옆에 리스폰된 goblin_boss를 "자물쇠"로 식별 → 처치 (`[XP] +28`)
3. 즉시 재시도 → `[Chest] You opened the treasure chest: raven_shield, leather_armor, chain_mail, iron_sword, leather_pants + 6870 gold.` → 인벤토리·골드 반영 확인

수정 전 대조: 같은 날 이전 빌드의 원정 로그에는 상자 관련 인지·시도가 0건입니다 (액션 어휘에 없어 시도 자체가 불가능).

`cargo build --release` 클린, 추가 파일은 rustfmt 통과. 필요하시면 위 시나리오의 원본 로그를 첨부하겠습니다.
