### PR TITLE
Reject player floors above the housing limit

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -2,7 +2,7 @@ use crate::auth::AuthService;
 use crate::conn_limit::{resolve_client_ip, ConnectLimiter};
 use crate::game::character_attributes::roll_character_attributes;
 use crate::game::character_hp::{level_one_max_hp, DEFAULT_CHARACTER_RACE};
-use crate::game_state::{parse_notice_command, GameState};
+use crate::game_state::{parse_notice_command, restored_floor_level, GameState};
 use crate::google_auth::GoogleAuthVerifier;
 use crate::types::{
     new_player, Character, CharacterAttributes, CharacterClass, ClientKind, ClientMessage,
@@ -890,7 +890,17 @@ async fn handle_client_message(
             if let Some(saved_health) = selected_character.health {
                 player.health = saved_health.min(max_hp);
             }
-            player.floor_level = selected_character.floor_level;
+            let saved_floor = selected_character.floor_level;
+            player.floor_level = restored_floor_level(saved_floor);
+            if player.floor_level != saved_floor {
+                let spawn = &crate::world_config::world_config().spawn_position;
+                player.position = spawn.position();
+                player.rotation = spawn.rotation;
+                warn!(
+                    "Reset out-of-range stored floor {} to the world spawn for character '{}'",
+                    saved_floor, selected_character.name
+                );
+            }
             // A negative floor means the player logged out inside a
             // dungeon: re-prime that dungeon's runtime, or fall back to
             // the world spawn if the entrance no longer exists.

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -66,7 +66,7 @@ mod inventory;
 mod monster;
 mod passability;
 mod player;
-pub(crate) use player::MoveCommand;
+pub(crate) use player::{restored_floor_level, MoveCommand};
 mod salary;
 mod time;
 mod trading;

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -1,6 +1,7 @@
 use crate::auth::{AuthError, AuthService, CharacterSaveData, ItemRow};
 use crate::types::{CharacterAttributes, Player, PlayerId, Position, ServerMessage};
 use crate::world_config::world_config;
+use onlinerpg_shared::housing::MAX_FLOOR_LEVEL;
 use onlinerpg_shared::{shortest_world_delta_x, wrap_world_x, PLAYER_MOVE_SPEED};
 use std::collections::{HashMap, HashSet, VecDeque};
 use tokio::sync::mpsc;
@@ -13,6 +14,22 @@ const MAX_MOVE_TARGET_DISTANCE: f32 = 60.0;
 
 /// Most queued waypoints per player; legit smoothed paths stay well under.
 const MAX_QUEUED_WAYPOINTS: usize = 32;
+
+/// Keep the shared housing limit representable on the signed wire.
+const _: () = assert!(MAX_FLOOR_LEVEL <= i8::MAX as u8);
+
+fn exceeds_positive_floor_limit(floor_level: i8) -> bool {
+    floor_level > MAX_FLOOR_LEVEL as i8
+}
+
+/// Keep legacy out-of-range rows from re-entering live state.
+pub(crate) fn restored_floor_level(saved: i8) -> i8 {
+    if exceeds_positive_floor_limit(saved) {
+        0
+    } else {
+        saved
+    }
+}
 
 /// Least time between `PositionCorrected` snaps for one player. Long enough
 /// that a client which cannot act on them is not yanked repeatedly, short
@@ -540,6 +557,13 @@ impl super::GameState {
             floor_level,
             append,
         } = cmd;
+        if exceeds_positive_floor_limit(floor_level) {
+            warn!(
+                "Rejected move carrying floor {} from player {}",
+                floor_level, player_id
+            );
+            return;
+        }
         if !(new_position.is_finite() && new_rotation.is_finite()) {
             warn!(
                 "Rejected non-finite move from player {}",
@@ -903,6 +927,13 @@ impl super::GameState {
     /// alone. Keeps AOI membership tracking where the player visually is while
     /// they walk a stairwell, which is one uninterrupted leg.
     pub async fn update_player_floor(&self, player_id: &PlayerId, floor_level: i8) {
+        if exceeds_positive_floor_limit(floor_level) {
+            warn!(
+                "Rejected floor change to {} from player {}",
+                floor_level, player_id
+            );
+            return;
+        }
         let (current_floor, position) = {
             let players = self.players.read().await;
             match players.get(player_id) {

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -1195,6 +1195,123 @@ async fn non_finite_move_is_rejected() {
 }
 
 #[tokio::test]
+async fn positive_floor_above_limit_is_rejected() {
+    let game_state = make_test_game_state("positive_floor_limit");
+    let player_id = pid("ghost");
+    let observer_id = pid("observer");
+    let max_floor = onlinerpg_shared::housing::MAX_FLOOR_LEVEL as i8;
+    game_state.add_player(make_player("ghost", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("observer", 1.0, 0.0))
+        .await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+
+    for invalid_floor in [max_floor + 1, 120] {
+        game_state
+            .update_player_floor(&player_id, invalid_floor)
+            .await;
+        assert_eq!(
+            game_state.players.read().await[&player_id].floor_level,
+            0,
+            "floor {invalid_floor} must be rejected"
+        );
+        assert!(matches!(
+            observer_rx.try_recv(),
+            Err(MpscTryRecvError::Empty)
+        ));
+    }
+
+    game_state.update_player_floor(&player_id, max_floor).await;
+    assert_eq!(
+        game_state.players.read().await[&player_id].floor_level,
+        max_floor
+    );
+}
+
+#[tokio::test]
+async fn player_move_cannot_bypass_positive_floor_limit() {
+    let game_state = make_test_game_state("positive_floor_move_limit");
+    let player_id = pid("ghost");
+    let observer_id = pid("observer");
+    let max_floor = onlinerpg_shared::housing::MAX_FLOOR_LEVEL as i8;
+    game_state.add_player(make_player("ghost", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("observer", 1.0, 0.0))
+        .await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+
+    game_state
+        .update_player_position(
+            &player_id,
+            MoveCommand {
+                position: pos(1.0),
+                rotation: 0.0,
+                floor_level: max_floor + 1,
+                append: false,
+            },
+            false,
+            false,
+        )
+        .await;
+
+    assert!(
+        !game_state
+            .movement_intents
+            .read()
+            .await
+            .contains_key(&player_id),
+        "an invalid floor move must not enqueue an intent"
+    );
+    let player = game_state.players.read().await[&player_id].clone();
+    assert_eq!(player.position.x, 0.0);
+    assert_eq!(player.floor_level, 0);
+    assert!(matches!(
+        observer_rx.try_recv(),
+        Err(MpscTryRecvError::Empty)
+    ));
+
+    game_state
+        .update_player_position(
+            &player_id,
+            MoveCommand {
+                position: pos(1.0),
+                rotation: 0.0,
+                floor_level: max_floor,
+                append: false,
+            },
+            false,
+            false,
+        )
+        .await;
+    game_state.tick_player_movement(1.0).await;
+    let player = game_state.players.read().await[&player_id].clone();
+    assert_eq!(player.position.x, 1.0);
+    assert_eq!(player.floor_level, max_floor);
+}
+
+#[test]
+fn restored_floor_falls_back_to_surface() {
+    let max_floor = onlinerpg_shared::housing::MAX_FLOOR_LEVEL as i8;
+
+    for saved in [max_floor + 1, 120, i8::MAX] {
+        assert_eq!(
+            super::restored_floor_level(saved),
+            0,
+            "floor {saved} must fall back to the surface"
+        );
+    }
+
+    // Negative floors use the existing dungeon rehydration path.
+    for saved in [i8::MIN, -1, 0, max_floor] {
+        assert_eq!(
+            super::restored_floor_level(saved),
+            saved,
+            "floor {saved} must be restored as-is"
+        );
+    }
+}
+
+#[tokio::test]
 async fn far_move_target_is_rejected() {
     let game_state = make_test_game_state("movement_far_reject");
     let player_id = pid("warper");


### PR DESCRIPTION
## Overview

The server accepted positive `floor_level` values above the housing maximum through floor-change messages, movement commands, and character rows saved before those guards existed.

Those values violate the floor-key separation documented by the shared dungeon model. Housing occupies `0..=MAX_FLOOR_LEVEL`, while dungeon passability starts at `MAX_FLOOR_LEVEL + 1`. With the current maximum of `3`, positive floor `4` uses the same passability index as dungeon depth `1`.

This change restores that invariant at all three trust boundaries.

## Steps to reproduce

1. Create a player on floor `0`.
2. Send `PlayerFloorChanged` with `MAX_FLOOR_LEVEL + 1`, currently floor `4`.
3. Observe that `update_player_floor` stores the client-reported value.
4. Reset the player and send a finite `PlayerMove` carrying floor `4`.
5. Observe that `update_player_position` queues the value in a `MoveIntent` and a movement tick applies it.
6. Save the character while the invalid floor is active. `write_character_states` persists the `i8` floor as an integer without applying the housing limit.
7. Reconnect and enter the character. The previous `EnterGame` path restored the saved floor directly into live player state.

The resulting value also crosses the documented passability boundary:

- `passability_floor_for_level(4)` and `passability_floor_for_depth(1)` both return `4`;
- converting passability index `4` back to a wire floor returns `-1`.

## Observed behavior

An explicit floor update with floor `4` was accepted even though the housing maximum is `3`. `PlayerMove` provided a separate bypass because it carries its own `floor_level` into the movement queue.

AOI delivery compares the raw signed floor, so a player on positive floor `4` becomes isolated from players on valid housing and negative dungeon floors. Passability uses a different representation: positive floor `4` collides with dungeon depth `1`. The configured dungeon range occupies indices `4..=23`, and any positive index at or above `4` is converted back as a negative dungeon-style wire floor.

The invalid value could also survive a reconnect after it had been written to the character row. Fixing only future client messages would therefore leave previously affected characters able to re-enter live state on the invalid floor.

## Expected behavior

- Positive floors through `MAX_FLOOR_LEVEL` remain valid.
- Larger positive floors are rejected before player state, movement queues, or AOI delivery changes.
- A stored floor above the limit falls back to the world spawn on surface floor `0` before the player enters live state.
- Valid surface floors and negative dungeon floors retain their existing behavior.
- Housing and dungeon passability keys cannot collide through player-controlled or restored floor values.

## Root cause

`housing::MAX_FLOOR_LEVEL` and `DUNGEON_FLOOR_INDEX_BASE` already define non-overlapping housing and dungeon passability ranges. The player state boundaries did not enforce that shared invariant.

The explicit floor-change message, the movement command, and the stored character row reach live state through separate paths. The restore path handled negative floors through dungeon rehydration but had no corresponding positive upper-bound check.

## Changes

- Add `exceeds_positive_floor_limit`, backed by `housing::MAX_FLOOR_LEVEL`.
- Reject an out-of-range floor at the start of `update_player_floor`.
- Reject the same value in `update_player_position` before a movement intent can be queued.
- Sanitize stored floors through `restored_floor_level` before `EnterGame` installs them in live state.
- Move a falling-back character to the world spawn, matching the existing dungeon-restore fallback, and warn.
- Add a compile-time assertion that keeps the housing maximum representable as the protocol's signed `i8` floor.
- Use distinct warnings for movement and explicit floor-change rejection.
- Add regressions for both client paths and the storage-restore boundary.

## Validation

The regressions verify that:

- `MAX_FLOOR_LEVEL + 1`, floor `120`, and `i8::MAX` cannot enter live state;
- rejected floor changes leave authoritative floor and observer delivery unchanged;
- rejected movement changes neither position nor floor and creates no movement intent;
- stored out-of-range floors fall back to `0`;
- valid surface floors, the exact housing maximum, and negative dungeon floors remain valid.

Implemented and validated on a branch based on `master`:

- `cargo test -p onlinerpg-server positive_floor -- --nocapture` — 2 passed
- `cargo test -p onlinerpg-server restored_floor -- --nocapture` — 1 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked` — 498 passed, including 137 server tests
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

The restore regression directly tests the sanitizer's boundary values. The save-to-`EnterGame` persistence path is established by the call path rather than a database-backed integration test.

## Scope and limitations

This PR does not migrate stored rows in place. It sanitizes an out-of-range floor to the world spawn when the character is read into live state; the stored row remains until the next save.

It does not change the shared housing/dungeon index mapping; it prevents player input and restored state from reaching the overlapping range. It also does not verify that a particular house contains an otherwise valid floor or define combat-time floor-transition policy.
