### PR TITLE
Apply teleports and respawns to the agent's own state

### DIFF
--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -202,6 +202,26 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
             "[PlayerDisappeared] {}",
             player_name(state, player_id)
         )),
+        ServerMessage::PlayerTeleported {
+            player_id,
+            position,
+            floor_level,
+            ..
+        } => {
+            if state.self_player_id.as_ref() != Some(player_id) {
+                return None;
+            }
+            let floor = if *floor_level < 0 {
+                format!("dungeon floor {}", floor_level.unsigned_abs())
+            } else {
+                "the surface".to_string()
+            };
+            Some(format!(
+                "[Teleported] You were teleported to ({:.0}, {:.0}) on {floor}. Your old \
+                 walk targets no longer apply.",
+                position.x, position.z
+            ))
+        }
         ServerMessage::PlayerMoved {
             player_id,
             position,

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -845,17 +845,30 @@ impl SharedState {
             | ServerMessage::PlayerHealthUpdate { .. }
             | ServerMessage::PlayerTorchToggled { .. } => EventUrgency::Routine,
 
+            // Urgent for ourselves: a teleport invalidates the current plan
+            // (walk targets, floor assumptions). Noise for bystanders.
+            ServerMessage::PlayerTeleported { player_id, .. } => {
+                if self_id == Some(player_id) {
+                    EventUrgency::Urgent
+                } else {
+                    EventUrgency::Noise
+                }
+            }
+
             // Noise: high-frequency, irrelevant, or housing updates
             ServerMessage::PlayerMoved { .. }
-            | ServerMessage::PlayerTeleported { .. }
             | ServerMessage::MonsterMoved { .. }
             | ServerMessage::GameTimeSync { .. }
             | ServerMessage::HouseSpawned { .. }
             | ServerMessage::HousesInArea { .. }
             | ServerMessage::HouseUpdated { .. }
             | ServerMessage::HouseRemoved { .. }
-            | ServerMessage::DoorToggled { .. }
-            | ServerMessage::InteractionRejected { .. } => EventUrgency::Noise,
+            | ServerMessage::DoorToggled { .. } => EventUrgency::Noise,
+
+            // Routine: the server's verdict on our chest (and future object)
+            // interactions — the LLM must see rejections to stop retrying a
+            // dead end.
+            ServerMessage::InteractionRejected { .. } => EventUrgency::Routine,
 
             // Auth/character events: routine (handled before game entry)
             _ => EventUrgency::Routine,
@@ -923,6 +936,43 @@ impl SharedState {
                 }
                 self.self_floor_level = *floor_level;
                 self.position_corrections = self.position_corrections.wrapping_add(1);
+            }
+            // A teleport (return scroll, escape command, debug teleport) must
+            // resync us exactly like PositionCorrected — including abandoning
+            // any in-flight walk via the corrections counter — or the client
+            // keeps walking from its stale spot and drags the character back
+            // server-side.
+            ServerMessage::PlayerTeleported {
+                player_id,
+                position,
+                rotation,
+                floor_level,
+            } => {
+                if self.self_player_id.as_ref() == Some(player_id) {
+                    if let Some(ref mut p) = self.self_player {
+                        p.position = *position;
+                        p.rotation = *rotation;
+                        p.floor_level = *floor_level;
+                    }
+                    self.self_floor_level = *floor_level;
+                    self.position_corrections = self.position_corrections.wrapping_add(1);
+                }
+                if let Some(p) = self.nearby_players.get_mut(player_id) {
+                    p.position = *position;
+                    p.rotation = *rotation;
+                    p.floor_level = *floor_level;
+                }
+            }
+            // A respawn relocates us the same way, just via its own message.
+            ServerMessage::PlayerRespawned { player } => {
+                if self.self_player_id == Some(player.id) {
+                    self.self_player = Some(player.clone());
+                    self.self_floor_level = player.floor_level;
+                    self.position_corrections = self.position_corrections.wrapping_add(1);
+                }
+                if let Some(p) = self.nearby_players.get_mut(&player.id) {
+                    *p = player.clone();
+                }
             }
             ServerMessage::DungeonDoorsState {
                 ref entrance_id,
@@ -1969,6 +2019,58 @@ pub(crate) mod tests {
             s.find_path_to(below.x, below.z, goal_floor).found,
             "the way down stayed sealed after opening floor 1's doors"
         );
+    }
+
+    /// A self-teleport (return scroll, respawn relocation) must resync the
+    /// client's position AND floor, or it keeps walking from the stale spot
+    /// and drags the character back server-side.
+    #[test]
+    fn a_self_teleport_resyncs_position_and_floor() {
+        let (mut s, _rx) = test_state();
+        let me = test_player(-1464.5, 4690.5);
+        s.self_player_id = Some(me.id);
+        s.self_player = Some(me);
+        s.self_floor_level = -5;
+
+        s.push_event(ServerMessage::PlayerTeleported {
+            player_id: PlayerId::from(1),
+            position: p(-1456.0, 1.2, 4735.0),
+            rotation: 0.0,
+            floor_level: 0,
+        });
+
+        assert_eq!(
+            s.self_floor_level, 0,
+            "teleport must clear the stale dungeon floor"
+        );
+        let now = s.self_player.as_ref().unwrap();
+        assert_eq!(now.position.x, -1456.0);
+        assert_eq!(now.position.z, 4735.0);
+        assert_eq!(now.floor_level, 0);
+        assert_eq!(
+            s.position_corrections, 1,
+            "teleport must abandon any in-flight walk, like PositionCorrected"
+        );
+    }
+
+    /// A respawn relocates us via its own message and must resync the same way.
+    #[test]
+    fn a_self_respawn_resyncs_position_and_floor() {
+        let (mut s, _rx) = test_state();
+        let me = test_player(-1464.5, 4690.5);
+        s.self_player_id = Some(me.id);
+        s.self_player = Some(me);
+        s.self_floor_level = -5;
+
+        let mut revived = test_player(-1475.0, 4742.0);
+        revived.floor_level = 0;
+        s.push_event(ServerMessage::PlayerRespawned { player: revived });
+
+        assert_eq!(s.self_floor_level, 0);
+        let now = s.self_player.as_ref().unwrap();
+        assert_eq!(now.position.x, -1475.0);
+        assert_eq!(now.floor_level, 0);
+        assert_eq!(s.position_corrections, 1);
     }
 
     /// A dungeon monster's moves must keep its floor's height. Terrain snapping


### PR DESCRIPTION
에이전트 클라이언트가 `PlayerTeleported`와 `PlayerRespawned`를 noise로 분류만 하고 자기 상태에 적용하지 않고 있었습니다. 그래서 서버 측 재배치(귀환 스크롤, escape 명령, 리스폰) 이후에도 클라이언트는 낡은 위치를 그대로 믿는데, 이동이 클라이언트 주도이다 보니 다음 이동 신고들이 캐릭터를 "자기가 있다고 믿는 곳"으로 도로 끌고 갑니다. 저희 재현에서는: LLM이 "던전에서 나가라"를 다시 명령 → 클라이언트가 상상 속 5층 위치에서 계단을 걸어 올라감 → 마을 스폰에서 계단통까지의 ~30–50m 도약이 서버의 60m 이동 가드 안이라 신고가 그대로 수락됐습니다.

### 실제로 일어난 일 (어젯밤 재현)

1. 에이전트(Ryulamg)가 Old Crypt 5층에서 귀환 스크롤을 읽음. 서버는 정상적으로 마을 스폰(floor 0)으로 옮기고 `PlayerTeleported`를 발송.
2. 클라이언트가 메시지를 무시하고 낡은 좌표 기준으로 계속 걸음. 클라 신고와 서버 배치의 줄다리기 끝에 캐릭터가 1층 계단통 경계의 **맵 밖**에 고착 — 웹 클라이언트에서 던전 벽 바깥에 서 있는 모습이 보였습니다 (아래 스크린샷).
3. 그 지점에서는 모든 경로 탐색이 실패했습니다: `depth 0`은 "could not reach the entrance", `depth 2`는 "way is sealed", 대부분의 횡이동도 차단. 재접속해도 동일했고, 생존 중이라 리스폰 요청도 서버가 무시 — 자력 탈출 수단이 없었습니다. 결국 다른 플레이어가 바닥 드랍으로 새 스크롤을 배달해 준 뒤에야 풀려났습니다.

### 수정

- `PlayerTeleported`·`PlayerRespawned`를 `PositionCorrected`와 똑같이 자기 위치·층에 적용합니다 — 진행 중이던 걷기가 낡은 웨이포인트를 버리도록 corrections 카운터 증가 포함 (주변 플레이어의 추적 엔트리도 갱신).
- 자기 텔레포트는 **urgent** `[Teleported]` 이벤트로 전달해 LLM이 낡은 이동 목표를 즉시 폐기하게 했습니다.
- `InteractionRejected`를 noise에서 routine으로 승격했습니다 — 상자(및 향후 오브젝트) 상호작용에 대한 서버의 거절 통보 채널이라, LLM이 거절을 봐야 막힌 시도를 반복하지 않습니다.
- 유닛 테스트: 합성 자기 텔레포트/리스폰이 위치·층을 재동기화하고 진행 중 경로를 무효화하는지 검증합니다 (구 코드에서는 실패하는 테스트).

수정 후 실측: 같은 시나리오(던전 안에서 스크롤 읽기)에서 이제 깨끗하게 마을에 착지합니다 — `[Teleported] You were teleported to (-1475, 4742) on the surface.`

관련: #32가 같은 신뢰 경계를 서버 쪽에서 보강한다면(유효하지 않은 클라이언트 층 신고 거부), 이 PR은 클라이언트가 애초에 낡은 신고를 만들지 않게 하는 쪽입니다.

### 스크린샷

<img width="1723" height="956" alt="스크린샷 2026-07-25 오후 11 33 02" src="https://github.com/user-attachments/assets/f7fd01c7-041a-4ab4-b592-b2cb188e3b6c" />
<img width="1732" height="957" alt="스크린샷 2026-07-25 오후 11 41 17" src="https://github.com/user-attachments/assets/60506160-3229-4124-b0a3-e4220e2dd75a" />


