### PR TITLE
Let agents trade with merchants and work dungeon props

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -63,6 +63,31 @@ Available action types (use EXACTLY these field names):
   To cross the room to the great chest instead of the small one at your feet:
   {"type": "open_chest", "chest": "great"}
 
+- Sell one bag item to a nearby merchant. You walk to them first; the
+  merchant pays their rate and your gold updates. One item per action —
+  repeat for more. Equipped gear must be taken off before selling:
+  {"type": "sell", "item": "goblin_sword", "merchant": "Rica"}
+
+- Buy one item from a merchant's catalog at base price. You walk to them
+  first; the item lands in your bag if your gold covers it. One unit per
+  action — repeat for more:
+  {"type": "buy", "item": "healing_potion", "merchant": "Rica"}
+
+- Drop one bag item on the ground where you stand (e.g. to shed weight
+  for better loot). A stacked item drops the WHOLE stack, and anyone can
+  pick it up afterwards:
+  {"type": "drop", "item": "goblin_sword"}
+
+- Buy back one item you sold to that merchant this session, for exactly
+  what they paid you (undo a mis-sell). The [Buyback] event after each
+  sale lists what they still hold:
+  {"type": "buyback", "item": "iron_sword", "merchant": "Rica"}
+
+- Smash a breakable dungeon prop (barrel or crate) listed in "Breakable
+  props on this floor". You walk to it first; smashing opens its cell for
+  movement:
+  {"type": "break_prop", "prop_id": 3}
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -106,6 +106,57 @@ pub(super) enum AgentAction {
         )]
         item: PickupRef,
     },
+    /// Sell one bag item to a nearby merchant, walking up to them first.
+    /// The server owns pricing, proximity and wallet checks.
+    #[serde(rename = "sell", alias = "sell_item")]
+    Sell {
+        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        item: String,
+        #[serde(alias = "npc", alias = "to", alias = "merchant_name", alias = "target")]
+        merchant: String,
+    },
+    /// Buy one catalog item from a nearby merchant, walking up to them
+    /// first. The server owns catalog, pricing and gold checks.
+    #[serde(rename = "buy", alias = "buy_item", alias = "purchase")]
+    Buy {
+        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        item: String,
+        #[serde(
+            alias = "npc",
+            alias = "from",
+            alias = "merchant_name",
+            alias = "target"
+        )]
+        merchant: String,
+    },
+    /// Drop one bag item on the ground where you stand. Stricter than the
+    /// web client: worn gear must be taken off first.
+    #[serde(rename = "drop", alias = "drop_item", alias = "discard")]
+    Drop {
+        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        item: String,
+    },
+    /// Repurchase an item sold to this merchant this session, at the exact
+    /// payout price. The server owns the entry list and gold checks.
+    #[serde(rename = "buyback", alias = "buy_back", alias = "repurchase")]
+    Buyback {
+        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        item: String,
+        #[serde(
+            alias = "npc",
+            alias = "from",
+            alias = "merchant_name",
+            alias = "target"
+        )]
+        merchant: String,
+    },
+    /// Smash a breakable dungeon prop (barrel/crate) on the current floor,
+    /// walking up to it first. The server validates floor and proximity.
+    #[serde(rename = "break_prop", alias = "smash", alias = "break")]
+    BreakProp {
+        #[serde(alias = "id", alias = "prop", alias = "target")]
+        prop_id: u32,
+    },
     /// Open a chest standing in the agent's own room: the nearest one, or the
     /// great chest when `chest` asks for it. The server validates floor,
     /// proximity, prop kind, boss state and the per-player cooldown, and
@@ -288,6 +339,11 @@ pub(super) fn action_to_command(
         AgentAction::OpenTrade { .. } => None,
         // Needs the bag and worn gear from SharedState; likewise handled there.
         AgentAction::Use { .. } => None,
+        AgentAction::Sell { .. } => None,
+        AgentAction::Buy { .. } => None,
+        AgentAction::Drop { .. } => None,
+        AgentAction::Buyback { .. } => None,
+        AgentAction::BreakProp { .. } => None,
         AgentAction::OpenChest { .. } => None,
         // Needs ground-item resolution and the walk-to loop; handled there too.
         AgentAction::Pickup { .. } => None,

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -68,6 +68,10 @@ pub(super) async fn handle_response(
     }
 
     let mut last_attack_target = None;
+    // Bag instances already sold/dropped this turn: the bag snapshot only
+    // refreshes on InventoryUpdated, so without this a second sell of the
+    // same non-stackable item would resend a spent instance id.
+    let mut spent_instances: Vec<u64> = Vec::new();
 
     for action in &agent_resp.actions {
         // Skip movement/attack when the NPC must stay put — resting on a
@@ -79,6 +83,10 @@ pub(super) async fn handle_response(
                     | AgentAction::Attack { .. }
                     | AgentAction::Pickup { .. }
                     | AgentAction::OpenChest { .. }
+                    | AgentAction::Sell { .. }
+                    | AgentAction::Buy { .. }
+                    | AgentAction::Buyback { .. }
+                    | AgentAction::BreakProp { .. }
             )
         {
             debug!("Skipping {:?} action — NPC is holding position", action);
@@ -213,6 +221,280 @@ pub(super) async fn handle_response(
             };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send use action: {e}");
+            }
+            continue;
+        }
+
+        // Sell a bag item: resolve the merchant, walk up to them, and send
+        // the sale. The server owns pricing, proximity and wallet checks and
+        // answers with GoldUpdate/InventoryUpdated.
+        if let AgentAction::Sell { item, merchant } = action {
+            let target = {
+                let s = state.lock().await;
+                s.resolve_nearby_player(merchant)
+            };
+            let Some((merchant_id, _)) = target else {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[SellFailed] No one named '{merchant}' is nearby to sell to."
+                ));
+                continue;
+            };
+            match approach_player(state, &merchant_id).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    let Some((def_id, placed)) = s.find_carried_bag_first(item, &spent_instances)
+                    else {
+                        s.push_agent_event(format!(
+                            "[SellFailed] Nothing called '{item}' is left in your bag."
+                        ));
+                        continue;
+                    };
+                    let Carried::InBag(instance_id) = placed else {
+                        s.push_agent_event(format!(
+                            "[SellFailed] {def_id} is equipped — worn gear is not for sale."
+                        ));
+                        continue;
+                    };
+                    let cmd = onlinerpg_shared::ClientMessage::SellItem {
+                        merchant_player_id: merchant_id,
+                        instance_id,
+                    };
+                    if let Err(e) = s.send_command(cmd).await {
+                        error!("Failed to send sell: {e}");
+                    } else {
+                        spent_instances.push(instance_id);
+                        info!("Agent selling {def_id} [id {instance_id}] to {merchant}");
+                    }
+                }
+                ChaseResult::Lost | ChaseResult::Error => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!("[SellFailed] You could not reach {merchant}."));
+                }
+            }
+            continue;
+        }
+
+        // Drop a bag item where we stand. Stricter than the web client:
+        // worn gear must be taken off first.
+        if let AgentAction::Drop { item } = action {
+            let mut s = state.lock().await;
+            let Some((def_id, placed)) = s.find_carried_bag_first(item, &spent_instances) else {
+                s.push_agent_event(format!(
+                    "[DropFailed] Nothing called '{item}' is left in your bag."
+                ));
+                continue;
+            };
+            let Carried::InBag(instance_id) = placed else {
+                s.push_agent_event(format!(
+                    "[DropFailed] {def_id} is equipped — worn gear cannot be dropped."
+                ));
+                continue;
+            };
+            let cmd = onlinerpg_shared::ClientMessage::DropItem { instance_id };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send drop: {e}");
+            } else {
+                spent_instances.push(instance_id);
+                info!("Agent dropped {def_id} [id {instance_id}]");
+            }
+            continue;
+        }
+
+        // Buy a catalog item: resolve the merchant, walk up to them, and
+        // send the purchase. The server owns catalog, pricing and gold
+        // checks and answers with GoldUpdate/InventoryUpdated or TradeError.
+        if let AgentAction::Buy { item, merchant } = action {
+            let target = {
+                let s = state.lock().await;
+                s.resolve_nearby_player(merchant)
+            };
+            let Some((merchant_id, _)) = target else {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[BuyFailed] No one named '{merchant}' is nearby to buy from."
+                ));
+                continue;
+            };
+            match approach_player(state, &merchant_id).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    // Fuzzy-resolve LLM spellings ("health potion") to a def
+                    // id; unresolved names go through for the server to judge.
+                    let ids = crate::item_defs::all_ids();
+                    let def_id = crate::item_defs::resolve_named(&ids, item)
+                        .unwrap_or_else(|| item.trim())
+                        .to_string();
+                    let cmd = onlinerpg_shared::ClientMessage::BuyItem {
+                        merchant_player_id: merchant_id,
+                        item_def_id: def_id,
+                    };
+                    if let Err(e) = s.send_command(cmd).await {
+                        error!("Failed to send buy: {e}");
+                    } else {
+                        info!("Agent buying {item} from {merchant}");
+                    }
+                }
+                ChaseResult::Lost | ChaseResult::Error => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!("[BuyFailed] You could not reach {merchant}."));
+                }
+            }
+            continue;
+        }
+
+        // Buy back a unit sold to this merchant this session, at the exact
+        // payout recorded server-side. Entry list arrives via BuybackUpdated.
+        if let AgentAction::Buyback { item, merchant } = action {
+            let target = {
+                let s = state.lock().await;
+                s.resolve_nearby_player(merchant)
+            };
+            let Some((merchant_id, _)) = target else {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[BuybackFailed] No one named '{merchant}' is nearby."
+                ));
+                continue;
+            };
+            match approach_player(state, &merchant_id).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    let entries = s
+                        .merchant_buyback
+                        .get(&merchant_id)
+                        .cloned()
+                        .unwrap_or_default();
+                    if entries.is_empty() {
+                        s.push_agent_event(format!(
+                            "[BuybackFailed] {merchant} holds nothing you sold this session."
+                        ));
+                        continue;
+                    }
+                    let ids = crate::item_defs::all_ids();
+                    let want = crate::item_defs::resolve_named(&ids, item)
+                        .unwrap_or_else(|| item.trim())
+                        .to_string();
+                    let Some(entry) = entries.iter().find(|e| e.item_def_id == want) else {
+                        let held: Vec<&str> =
+                            entries.iter().map(|e| e.item_def_id.as_str()).collect();
+                        s.push_agent_event(format!(
+                            "[BuybackFailed] {merchant}'s buyback list has no '{item}' — it \
+                             holds: {}.",
+                            held.join(", ")
+                        ));
+                        continue;
+                    };
+                    let cmd = onlinerpg_shared::ClientMessage::BuybackItem {
+                        merchant_player_id: merchant_id,
+                        entry_id: entry.entry_id,
+                    };
+                    if let Err(e) = s.send_command(cmd).await {
+                        error!("Failed to send buyback: {e}");
+                    } else {
+                        info!(
+                            "Agent buying back {want} [entry {}] from {merchant}",
+                            entry.entry_id
+                        );
+                    }
+                }
+                ChaseResult::Lost | ChaseResult::Error => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!("[BuybackFailed] You could not reach {merchant}."));
+                }
+            }
+            continue;
+        }
+
+        // Smash a breakable dungeon prop: resolve it on the current floor,
+        // walk up to its cell, and ask the server. The server owns floor,
+        // proximity and kind checks. Chest props are not handled here — they
+        // come through `open_chest` with the rest of the room's chests.
+        if let AgentAction::BreakProp { prop_id } = action {
+            use onlinerpg_shared::dungeon::PropKind;
+            let resolved = {
+                let s = state.lock().await;
+                if s.self_floor_level >= 0 {
+                    None
+                } else {
+                    let depth = s.self_floor_level.unsigned_abs();
+                    s.dungeon_here().and_then(|d| {
+                        let layout = d.layouts().get(depth as usize - 1)?;
+                        let prop = layout.props.get(*prop_id as usize)?;
+                        // The prop's own cell is sealed for passability —
+                        // aim for the closest reachable neighbor cell.
+                        let pfloor = onlinerpg_shared::dungeon::passability_floor_for_level(
+                            s.self_floor_level,
+                        );
+                        let me = s.self_player.as_ref().map(|p| p.position)?;
+                        let pos = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+                            .iter()
+                            .map(|(dx, dz)| {
+                                onlinerpg_shared::dungeon::cell_center(
+                                    &d.entrance,
+                                    depth,
+                                    (prop.x + dx, prop.z + dz),
+                                )
+                            })
+                            .filter(|c| s.find_path_to(c.x, c.z, pfloor).found)
+                            .min_by(|a, b| {
+                                let da = crate::geom::PlanarDelta::between(&me, a).dist;
+                                let db = crate::geom::PlanarDelta::between(&me, b).dist;
+                                da.total_cmp(&db)
+                            })?;
+                        let prop_pos = onlinerpg_shared::dungeon::cell_center(
+                            &d.entrance,
+                            depth,
+                            (prop.x, prop.z),
+                        );
+                        let broken = s.dungeon_broken_props(&d.id, depth);
+                        Some((d.id.clone(), depth, prop.kind, pos, prop_pos, broken))
+                    })
+                }
+            };
+            let Some((entrance_id, depth, kind, pos, prop_pos, broken)) = resolved else {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[PropFailed] Prop {prop_id} is not on your floor, or no open cell \
+                     next to it is reachable."
+                ));
+                continue;
+            };
+            if !matches!(kind, PropKind::Barrel | PropKind::Crate) {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[PropFailed] Prop {prop_id} is a {kind:?} — you cannot break it."
+                ));
+                continue;
+            }
+            if broken.contains(prop_id) {
+                let mut s = state.lock().await;
+                s.push_agent_event(format!("[PropFailed] Prop {prop_id} is already smashed."));
+                continue;
+            }
+            // The server measures its range from the prop itself, so the metre
+            // between it and the cell we can stand on comes out of ours.
+            let gap = crate::geom::PlanarDelta::between(&pos, &prop_pos).dist;
+            match walk_to_point(state, pos, -(depth as i8), chest_arrive_range(gap)).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    let cmd = onlinerpg_shared::ClientMessage::BreakDungeonProp {
+                        entrance_id,
+                        depth,
+                        prop_id: *prop_id,
+                    };
+                    if let Err(e) = s.send_command(cmd).await {
+                        error!("Failed to send break_prop: {e}");
+                    } else {
+                        info!("Agent requested break on prop {prop_id}");
+                    }
+                }
+                ChaseResult::Lost | ChaseResult::Error => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!(
+                        "[PropFailed] You could not reach prop {prop_id} — the way is blocked."
+                    ));
+                }
             }
             continue;
         }

--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -180,6 +180,34 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
                 item_def_ids.join(", ")
             ))
         }
+        ServerMessage::DungeonPropBroken { depth, prop_id, .. } => Some(format!(
+            "[Prop] Prop {prop_id} on floor {depth} was smashed — its cell is now walkable."
+        )),
+        ServerMessage::DungeonPropOpened { depth, prop_id, .. } => Some(format!(
+            "[Prop] Chest prop {prop_id} on floor {depth} swung open."
+        )),
+        ServerMessage::BuybackUpdated {
+            merchant_player_id,
+            buyback,
+        } => {
+            let who = player_name(state, merchant_player_id);
+            if buyback.is_empty() {
+                return Some(format!(
+                    "[Buyback] {who}'s buyback list is now empty (your last repurchase or \
+                     sale cleared it)."
+                ));
+            }
+            let list: Vec<String> = buyback
+                .iter()
+                .take(6)
+                .map(|e| format!("{} @{}c", e.item_def_id, e.price))
+                .collect();
+            Some(format!(
+                "[Buyback] {who} will sell back: {} — {{\"type\": \"buyback\", \"item\": ..., \
+                 \"merchant\": \"{who}\"}}.",
+                list.join(", ")
+            ))
+        }
         ServerMessage::PlayerJoined { player } => {
             if !within_event_range(state, player.position.x, player.position.z) {
                 return None;

--- a/agent-client/src/item_defs.rs
+++ b/agent-client/src/item_defs.rs
@@ -38,6 +38,10 @@ fn defs() -> &'static HashMap<String, ItemDef> {
     })
 }
 
+pub fn all_ids() -> Vec<&'static str> {
+    defs().keys().map(String::as_str).collect()
+}
+
 pub fn get(item_def_id: &str) -> Option<&'static ItemDef> {
     defs().get(item_def_id)
 }

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -210,6 +210,15 @@ impl WorldCache {
         self.dungeon_opened_props.get(&(id.to_string(), depth))
     }
 
+    /// Broken prop ids for one dungeon floor — `break_prop` checks this before
+    /// walking out to a barrel someone already smashed.
+    pub fn dungeon_broken_props(&self, id: &str, depth: u8) -> Vec<u32> {
+        self.dungeon_broken_props
+            .get(&(id.to_string(), depth))
+            .cloned()
+            .unwrap_or_default()
+    }
+
     /// Recompute one dungeon floor's cells from the live door/prop state
     /// (shared `dungeon::floor_cells`).
     fn rebuild_dungeon_floor(&mut self, id: &str, depth: u8) {
@@ -322,6 +331,9 @@ pub struct SharedState {
     pub trade_busy: bool,
     /// Known nearby players
     pub nearby_players: HashMap<PlayerId, Player>,
+    /// Per-merchant list of units we sold this session, repurchasable at the
+    /// recorded payout (fed by BuybackUpdated/ShopState).
+    pub merchant_buyback: HashMap<PlayerId, Vec<onlinerpg_shared::messages::BuybackEntry>>,
     /// Known nearby monsters
     pub nearby_monsters: HashMap<String, Monster>,
     /// Known items lying on the ground, keyed by instance id (from the join
@@ -400,6 +412,7 @@ impl SharedState {
             trade_satiated_until: None,
             trade_busy: false,
             nearby_players: HashMap::new(),
+            merchant_buyback: HashMap::new(),
             nearby_monsters: HashMap::new(),
             ground_items: HashMap::new(),
             events: Vec::new(),
@@ -1047,6 +1060,21 @@ impl SharedState {
                     *prop_id,
                 );
             }
+            ServerMessage::BuybackUpdated {
+                merchant_player_id,
+                ref buyback,
+            } => {
+                self.merchant_buyback
+                    .insert(*merchant_player_id, buyback.clone());
+            }
+            ServerMessage::ShopState {
+                merchant_player_id,
+                ref buyback,
+                ..
+            } => {
+                self.merchant_buyback
+                    .insert(*merchant_player_id, buyback.clone());
+            }
             ServerMessage::GameState {
                 players,
                 monsters,
@@ -1438,6 +1466,9 @@ impl SharedState {
                     "\nChest in this room: {looks} ({dist:.0}m away){note}"
                 ));
             }
+            if let Some(d) = &dungeon {
+                line.push_str(&self.format_floor_props(d, depth, p));
+            }
             return Some(line);
         }
         let dungeon = self
@@ -1453,6 +1484,59 @@ impl SharedState {
             dungeon.entrance.z,
             dungeon.max_depth()
         ))
+    }
+
+    /// Broken prop ids for one dungeon floor.
+    pub fn dungeon_broken_props(&self, id: &str, depth: u8) -> Vec<u32> {
+        self.world_cache
+            .read()
+            .unwrap()
+            .dungeon_broken_props(id, depth)
+    }
+
+    /// Nearest breakable clutter on the agent's dungeon floor. Chest props are
+    /// left out — they reach the agent as chests in its room, not as prop ids.
+    fn format_floor_props(&self, d: &crate::dungeon::Dungeon, depth: u8, p: &Player) -> String {
+        use onlinerpg_shared::dungeon::PropKind;
+        let Some(layout) = d.layouts().get(depth as usize - 1) else {
+            return String::new();
+        };
+        let broken = self
+            .world_cache
+            .read()
+            .unwrap()
+            .dungeon_broken_props(&d.id, depth);
+        let mut props: Vec<(f32, String)> = Vec::new();
+        for (i, prop) in layout.props.iter().enumerate() {
+            let id = i as u32;
+            if broken.contains(&id) {
+                continue;
+            }
+            let kind = match prop.kind {
+                PropKind::Barrel => "barrel",
+                PropKind::Crate => "crate",
+                PropKind::Chest | PropKind::TorchWall => continue,
+            };
+            let pos = onlinerpg_shared::dungeon::cell_center(&d.entrance, depth, (prop.x, prop.z));
+            let dist = crate::geom::PlanarDelta::between(&p.position, &pos).dist;
+            props.push((
+                dist,
+                format!(
+                    "{kind} [prop {id}] at ({:.0}, {:.0}) {dist:.0}m",
+                    pos.x, pos.z
+                ),
+            ));
+        }
+        if props.is_empty() {
+            return String::new();
+        }
+        props.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let list: Vec<String> = props.into_iter().take(6).map(|(_, s)| s).collect();
+        format!(
+            "\nBreakable props on this floor: {} — {{\"type\": \"break_prop\", \"prop_id\": N}} \
+             smashes one open.",
+            list.join("; ")
+        )
     }
 
     /// Find a smoothed path from current position to the goal.
@@ -1580,6 +1664,30 @@ impl SharedState {
     /// Find the item the agent named among the ones we carry, and where it
     /// sits. Matching is forgiving about the exact id (see
     /// `item_defs::resolve_named`) but never reaches past what we hold.
+    /// Like [`Self::find_carried`], but bag items win over worn ones —
+    /// selling should reach the spare in the bag, not the equipped copy.
+    /// `exclude` skips instances already spent earlier this turn (the bag
+    /// snapshot only refreshes when InventoryUpdated arrives).
+    pub fn find_carried_bag_first(
+        &self,
+        asked: &str,
+        exclude: &[u64],
+    ) -> Option<(String, Carried)> {
+        let (id, placed) = self.find_carried(asked)?;
+        if let Some(item) = self
+            .self_bag
+            .iter()
+            .find(|i| i.item_def_id == id && !exclude.contains(&i.instance_id))
+        {
+            return Some((id, Carried::InBag(item.instance_id)));
+        }
+        match placed {
+            Carried::Worn(_) => Some((id, placed)),
+            // Every bag copy was already spent this turn.
+            Carried::InBag(_) => None,
+        }
+    }
+
     pub fn find_carried(&self, asked: &str) -> Option<(String, Carried)> {
         let ids: Vec<&str> = self
             .self_bag


### PR DESCRIPTION
#20 · #31 의 후속으로, 에이전트와 웹 플레이어 사이의 다음 파리티 간극인 **상거래와 던전 소품**을 닫습니다.

### 새 액션

- `sell` / `buy` — 이름으로 지목한 상인에게 걸어가 1개 단위로 거래합니다. 카탈로그·가격·근접·지갑 검증은 전부 서버 권위 그대로입니다. 판매는 **착용 장비보다 가방 사본을 우선** 해석합니다 — 초기 버전에서 실패 메시지의 힌트를 따라 에이전트가 착용 중인 검을 벗어 팔아버리는 사고를 실제로 목격하고 넣은 가드입니다.
- `buyback` — 이번 세션에 그 상인에게 판 물건을, 기록된 지급가 그대로 되삽니다(실수 판매 복구). `BuybackUpdated`/`ShopState`의 엔트리를 상인별로 추적하고, 판매 직후 `[Buyback]` 이벤트로 LLM에 목록을 보여줍니다.
- `drop` — 서 있는 자리에 가방 아이템 1개를 내려놓습니다 (착용 장비는 먼저 벗어야 함).
- `break_prop` — 현재 던전 층의 배럴/크레이트를 부숩니다. 부술 수 있는 소품이 id·좌표·거리와 함께 world state에 나열됩니다. 소품이 놓인 칸 자체는 통행 차단 칸이라 걷기 목표는 가장 가까운 도달 가능한 인접 칸으로 잡고, 서버가 거리를 소품 기준으로 재므로 그 간격만큼 도착 반경을 좁힙니다 (`chest_arrive_range`).

걸어가는 액션(`sell`/`buy`/`buyback`/`break_prop`)은 모두 `skip_movement` 게이트를 따릅니다 — 휴식 중이거나 거래창이 열려 있을 때 자리를 뜨지 않습니다. `drop`은 제자리 인벤토리 조작이라 게이트 밖입니다.

### 실측 (공개 서버)

- 이전 세션에서 판매 13건 + 구매 8건 무실패. 토치 1개로 구매 → 판매 → 되사기 왕복이 골드 단위까지 정확했습니다 (+20c / −20c).
- `break_prop`: 크레이트 파괴, `DungeonPropBroken` 브로드캐스트, 해당 칸 통행 개방 확인.
- 토치 드랍/줍기 왕복 — 벽 너머 1.1m 거리에서의 픽업 포함. (이 드랍-줍기는 좌초된 캐릭터에게 다른 플레이어가 스크롤을 전달하는 구조 수단으로도 실전 사용됐습니다 — #33 참고)
