### PR TITLE
Validate the player floor before toggling dungeon doors

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1171,7 +1171,7 @@ async fn handle_client_message(
         } => {
             if let Some(id) = &state.player_id {
                 if let Some(is_open) = game_state
-                    .toggle_dungeon_door(&entrance_id, depth, door_id)
+                    .toggle_dungeon_door(id, &entrance_id, depth, door_id)
                     .await
                 {
                     game_state

--- a/server/src/game_state/dungeon.rs
+++ b/server/src/game_state/dungeon.rs
@@ -131,11 +131,17 @@ impl GameState {
     /// cosmetic.
     pub async fn toggle_dungeon_door(
         &self,
+        player_id: &PlayerId,
         entrance_id: &str,
         depth: u8,
         door_id: u32,
     ) -> Option<bool> {
         self.dungeon_defs.get(entrance_id)?;
+        let expected_floor = -i8::try_from(depth).ok()?;
+        let player_floor = self.players.read().await.get(player_id)?.floor_level;
+        if player_floor != expected_floor {
+            return None;
+        }
         self.ensure_dungeon_runtime(entrance_id).await;
         let is_open = {
             let mut dungeons = self.dungeons.write().await;

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -3423,6 +3423,116 @@ fn first_dungeon_door(
 }
 
 #[tokio::test]
+async fn cross_floor_dungeon_door_toggle_is_rejected() {
+    let game_state = make_test_game_state("dungeon_door_cross_floor");
+    let (entrance, depth, door) = first_dungeon_door(&game_state);
+    game_state.init_passability("nonexistent_terrain_dir").await;
+    let griefer_id = pid("surface_griefer");
+    game_state
+        .add_player(make_player("surface_griefer", entrance.x, entrance.z))
+        .await;
+    let mut observer = make_player("floor_observer", entrance.x, entrance.z);
+    observer.floor_level = -(depth as i8);
+    game_state.add_player(observer).await;
+    let mut observer_rx = game_state
+        .register_direct_channel(&pid("floor_observer"))
+        .await;
+
+    assert!(
+        !game_state.dungeons.read().await.contains_key(&entrance.id),
+        "the test requires an uninitialized dungeon runtime"
+    );
+    let before = game_state.dungeon_open_doors(&entrance.id).await;
+    let result = game_state
+        .toggle_dungeon_door(&griefer_id, &entrance.id, depth, door.door_id)
+        .await;
+    if let Some(is_open) = result {
+        game_state
+            .publish_dungeon_door_toggle(
+                &griefer_id,
+                entrance.id.clone(),
+                depth,
+                door.door_id,
+                is_open,
+            )
+            .await;
+    }
+
+    assert_eq!(result, None, "a player on another floor must be rejected");
+    assert_eq!(
+        game_state.dungeon_open_doors(&entrance.id).await,
+        before,
+        "a rejected toggle must not change door state"
+    );
+    assert!(
+        !game_state.dungeons.read().await.contains_key(&entrance.id),
+        "a rejected toggle must not create dungeon runtime state"
+    );
+    assert!(matches!(
+        observer_rx.try_recv(),
+        Err(MpscTryRecvError::Empty)
+    ));
+
+    let [ax, az, _, _] = door.seg();
+    let (outside, inside) = if door.spans_x() {
+        ((ax, az - 1), (ax, az))
+    } else {
+        ((ax - 1, az), (ax, az))
+    };
+    let from = cell_center(&entrance.position(), depth, outside);
+    let to = cell_center(&entrance.position(), depth, inside);
+    let delver_id = pid("delver");
+    let mut delver = make_player("delver", from.x, from.z);
+    delver.position.y = from.y;
+    delver.floor_level = -(depth as i8);
+    game_state.add_player(delver).await;
+    game_state
+        .update_player_position(
+            &delver_id,
+            MoveCommand {
+                floor_level: -(depth as i8),
+                ..move_cmd(to, false)
+            },
+            false,
+            false,
+        )
+        .await;
+    game_state.tick_player_movement(60.0).await;
+    assert_eq!(
+        player_xz(&game_state, &delver_id).await,
+        (from.x, from.z),
+        "a rejected toggle must leave the door impassable"
+    );
+}
+
+#[tokio::test]
+async fn same_floor_dungeon_door_toggle_still_updates_state() {
+    let game_state = make_test_game_state("dungeon_door_same_floor");
+    let (entrance, depth, door) = first_dungeon_door(&game_state);
+    let player_id = pid("delver");
+    let mut player = make_player("delver", entrance.x, entrance.z);
+    player.floor_level = -(depth as i8);
+    game_state.add_player(player).await;
+
+    assert_eq!(
+        game_state
+            .toggle_dungeon_door(&player_id, &entrance.id, depth, door.door_id)
+            .await,
+        Some(true)
+    );
+    assert!(game_state
+        .dungeon_open_doors(&entrance.id)
+        .await
+        .contains(&(depth, door.door_id)));
+    assert_eq!(
+        game_state
+            .toggle_dungeon_door(&player_id, &entrance.id, depth, door.door_id)
+            .await,
+        Some(false)
+    );
+}
+
+#[tokio::test]
 async fn dungeon_door_toggle_delivery_gates_radius_and_floor() {
     let game_state = make_test_game_state("dungeon_door_delivery");
     let entrance = game_state
@@ -3540,8 +3650,12 @@ async fn dungeon_door_blocks_movement_until_opened() {
     let player_id = pid("delver");
     let mut player = make_player("delver", from.x, from.z);
     player.position.y = from.y;
+    player.floor_level = -(depth as i8);
     game_state.add_player(player).await;
-    let go = |p: Position| move_cmd(p, false);
+    let go = |p: Position| MoveCommand {
+        floor_level: -(depth as i8),
+        ..move_cmd(p, false)
+    };
 
     // Shut (boot default): the crossing is sealed.
     game_state
@@ -3553,7 +3667,7 @@ async fn dungeon_door_blocks_movement_until_opened() {
     // Open: same move goes through.
     assert_eq!(
         game_state
-            .toggle_dungeon_door(&entrance.id, depth, door.door_id)
+            .toggle_dungeon_door(&player_id, &entrance.id, depth, door.door_id)
             .await,
         Some(true)
     );
@@ -3566,7 +3680,7 @@ async fn dungeon_door_blocks_movement_until_opened() {
     // Shut again: the way back is sealed.
     assert_eq!(
         game_state
-            .toggle_dungeon_door(&entrance.id, depth, door.door_id)
+            .toggle_dungeon_door(&player_id, &entrance.id, depth, door.door_id)
             .await,
         Some(false)
     );
@@ -3585,11 +3699,15 @@ async fn dungeon_door_blocks_movement_until_opened() {
 async fn floor_entry_pushes_open_door_snapshot() {
     let game_state = make_test_game_state("dungeon_door_entry_snapshot");
     let (entrance, depth, door) = first_dungeon_door(&game_state);
+    let opener_id = pid("opener");
+    let mut opener = make_player("opener", entrance.x, entrance.z);
+    opener.floor_level = -(depth as i8);
+    game_state.add_player(opener).await;
 
     // Player A opens a door before B has ever seen the dungeon.
     assert_eq!(
         game_state
-            .toggle_dungeon_door(&entrance.id, depth, door.door_id)
+            .toggle_dungeon_door(&opener_id, &entrance.id, depth, door.door_id)
             .await,
         Some(true)
     );


### PR DESCRIPTION
## Overview

The dungeon door handler did not pass the authenticated player ID into `toggle_dungeon_door`. The game-state method could therefore change a valid door's shared state and passability without checking whether the requester was on that door's floor.

This change validates the requester's authoritative floor before creating dungeon runtime state or toggling a door.

## Steps to reproduce

1. Create a player on surface floor `0`.
2. Load a dungeon with a valid interior door at depth `1`.
3. Submit `ToggleDungeonDoor` with that entrance, depth, and door ID.
4. Observe that the connection handler calls `toggle_dungeon_door` without the authenticated player ID.
5. Observe that `open_doors` and the target floor's passability change even though the requester is not on floor `-1`.

The same path can be used from floor `-1` against depth `2`, or by a delayed request after a player leaves the target floor.

## Observed behavior

A player on surface floor `0` could submit a valid entrance ID, depth-1 door ID, and depth. The server validated the dungeon, created its runtime if needed, changed `open_doors`, rebuilt passability, and published the result even though the player had never entered floor `-1`.

Filtering the outbound event was not enough because the shared state had already changed.

## Expected behavior

- An interior door at depth `n` can be toggled only by a player on floor `-n`.
- A surface depth-0 request requires floor `0`.
- A missing player, an unsafe depth conversion, or a floor mismatch is rejected before dungeon runtime, door state, passability, or messages change.
- Same-floor open and close behavior remains unchanged.

## Root cause

The authenticated `PlayerId` was available in connection state but was dropped at the game-state API
boundary. `toggle_dungeon_door` could confirm only that the entrance ID referred to a configured
dungeon; it had no requester identity with which to read the current floor.

## Changes

- Pass the authenticated `PlayerId` from the connection handler to `toggle_dungeon_door`.
- Derive the expected floor with a checked `i8` conversion.
- Compare the expected floor with the player's current authoritative floor before any mutation.
- Update existing door fixtures to place valid requesters and movement commands on the floor under test.
- Add regressions for cross-floor rejection and same-floor compatibility.

## Validation

The tests verify that:

- a surface player cannot toggle a depth-1 door;
- a rejected request does not create dungeon runtime state;
- a rejected request leaves `open_doors` and passability unchanged;
- target-floor observers receive no toggle event;
- a same-floor player can still open and close the door;
- existing passability and floor-entry snapshot behavior remains valid.

Implemented and validated on a branch based on `master`:

- `cargo test -p onlinerpg-server dungeon_door -- --nocapture` — 4 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked` — 497 passed, including 136 server tests
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
