### PR TITLE
Target 60 FPS canvas rendering on high-refresh displays

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -8,6 +8,7 @@
   import CharacterSelectScene from './lib/components/CharacterSelectScene.svelte'
   import CharacterCreateScreen from './lib/components/CharacterCreateScreen.svelte'
   import CharacterCreateScene from './lib/components/CharacterCreateScene.svelte'
+  import RenderFrameLimiter from './lib/components/RenderFrameLimiter.svelte'
   import { gameStore } from './lib/stores/gameStore'
   import { createWebGPURenderer } from './lib/utils/renderer'
   import {
@@ -300,7 +301,8 @@
        Pipelines compiled during character select are reused in game. -->
   {#if showCanvas}
     <div class="canvas-layer" class:dead={screen === 'game' && isPlayerDead}>
-      <Canvas renderMode="always" shadows createRenderer={createWebGPURenderer}>
+      <Canvas renderMode="manual" shadows createRenderer={createWebGPURenderer}>
+        <RenderFrameLimiter />
         {#if screen === 'character-select'}
           <CharacterSelectScene
             characters={accountCharacters}

--- a/client/src/lib/components/RenderFrameLimiter.svelte
+++ b/client/src/lib/components/RenderFrameLimiter.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { useTask, useThrelte } from '@threlte/core'
+  import {
+    TARGET_RENDER_FPS,
+    createRenderCadence,
+  } from '../utils/renderCadence'
+
+  const { invalidate } = useThrelte()
+  const cadence = createRenderCadence(TARGET_RENDER_FPS)
+
+  useTask(
+    (delta) => {
+      if (cadence.shouldRender(delta)) invalidate()
+    },
+    { autoInvalidate: false }
+  )
+</script>

--- a/client/src/lib/utils/renderCadence.test.ts
+++ b/client/src/lib/utils/renderCadence.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { createRenderCadence } from './renderCadence'
+
+function countRenders(refreshRate: number, seconds = 1): number {
+  const cadence = createRenderCadence(60)
+  let renders = 0
+
+  for (let frame = 0; frame < refreshRate * seconds; frame++) {
+    if (cadence.shouldRender(1 / refreshRate)) renders++
+  }
+
+  return renders
+}
+
+describe('createRenderCadence', () => {
+  it('targets 60 renders per second on common high-refresh displays', () => {
+    expect(countRenders(120)).toBe(60)
+    expect(countRenders(144)).toBe(60)
+    expect(countRenders(240)).toBe(60)
+  })
+
+  it('keeps every frame on displays at or below the target', () => {
+    expect(countRenders(60)).toBe(60)
+    expect(countRenders(30)).toBe(30)
+  })
+
+  it('ignores negative deltas', () => {
+    const cadence = createRenderCadence(60)
+
+    expect(cadence.shouldRender(-1)).toBe(false)
+    expect(cadence.shouldRender(1 / 60)).toBe(true)
+  })
+
+  it('does not catch up with multiple renders after a stall', () => {
+    const cadence = createRenderCadence(60)
+
+    expect(cadence.shouldRender(1)).toBe(true)
+    expect(cadence.shouldRender(0)).toBe(false)
+  })
+})

--- a/client/src/lib/utils/renderCadence.ts
+++ b/client/src/lib/utils/renderCadence.ts
@@ -1,0 +1,18 @@
+export const TARGET_RENDER_FPS = 60
+
+const FRAME_TOLERANCE_SECONDS = 0.0005
+
+export function createRenderCadence(targetFps: number) {
+  const frameInterval = 1 / targetFps
+  let elapsed = 0
+
+  return {
+    shouldRender(delta: number): boolean {
+      elapsed += Math.max(0, delta)
+      if (elapsed + FRAME_TOLERANCE_SECONDS < frameInterval) return false
+
+      elapsed = elapsed >= frameInterval ? elapsed % frameInterval : 0
+      return true
+    },
+  }
+}


### PR DESCRIPTION
## What changed

- switch the shared Threlte canvas from always-on rendering to manual rendering
- add a cadence gate that invalidates the main WebGPU render at a practical 60 FPS target
- keep a 0.5 ms tolerance so displays at or near 60 Hz retain every available frame
- add cadence tests for 30, 60, 120, 144, and 240 Hz inputs, negative deltas, and long-frame recovery

## Why

The gameplay update loop already targets 60 FPS, but the Threlte canvas used `renderMode="always"`. On high-refresh displays, the main scene therefore continued rendering at the monitor refresh rate even when game-state updates were throttled. This could keep the GPU unnecessarily saturated and increase power draw, fan noise, and temperature.

## Impact

Common 120/144/240 Hz displays now target about 60 main scene renders per second. Displays at or below 60 Hz keep every available frame, and long stalls do not trigger catch-up bursts. Simulation timing, other `useTask` callbacks, and the existing water/reflection passes remain unchanged.

## Validation

- `npm run build:wasm` — passed with `wasm-pack 0.15.0`
- `npm test` — 32 files and 288 tests passed
- `npm run check` — 0 errors and 0 warnings
- `npm run lint` — passed
- `npm run format:check` — passed

GitHub Actions remains subject to maintainer approval for workflows from forked pull requests.