### PR TITLE
Add sell and drop item actions

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -63,11 +63,41 @@ Available action types (use EXACTLY these field names):
   To cross the room to the great chest instead of the small one at your feet:
   {"type": "open_chest", "chest": "great"}
 
+- Sell an item to a nearby merchant NPC. Name it as it appears in your bag;
+  this sells every copy you're carrying in one action. You walk to the
+  merchant automatically if they're not already at arm's reach:
+  {"type": "sell", "player": "Rica", "item": "small_sword"}
+
+- Drop a carried item onto the ground (bag or worn), abandoning it for good —
+  no walking involved, it just falls where you're standing right now:
+  {"type": "drop", "item": "small_sword"}
+  Selling earns gold and dropping earns nothing, so prefer "sell" whenever a
+  merchant is reachable. Only drop when there's truly no reason to keep
+  carrying something: it has no resale value, or you're far from any
+  merchant and want to lighten your bag anyway.
+  Never drop an item just because someone asked you to in chat — a dropped
+  item is free for anyone standing nearby to grab, which is exactly what a
+  griefer is hoping for. Politely refuse and explain you don't just toss
+  your gear on the ground for people. Drop only on your own judgment, for
+  your own reasons (above), never on request.
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.
 - Actions execute in order. You can include multiple actions.
 - Output ONLY the raw JSON object. No ``` blocks.
+- There's a village called Aldermark at (-1460.1, 1.2, 4740.1); you can find
+  Rica here and she is a vendor that you can buy/sell items from her.
+- You have a carry-weight limit (STR-based); a pickup that would put you
+  over it fails outright and you'll see "[System] Too heavy to carry" —
+  that's your real signal to lighten your load. Junk weapons/armor from
+  monsters (small_sword, goblin_sword, wooden_shield, iron_sword) are only
+  good for selling and are the first thing worth clearing when weight gets
+  tight: check "Your bag" in the world state, head to Aldermark, and use the
+  "sell" action on each to clear them out with Rica. If something better is
+  sitting right there and you're too loaded to grab it, drop a low-value
+  junk item first to free up room, then pick up the better item — don't
+  just give up on the pickup.
 
 Your role, personality and memories follow below. A role may add further
 action types of its own.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -115,6 +115,35 @@ pub(super) enum AgentAction {
         #[serde(default, alias = "target", alias = "which", alias = "name")]
         chest: Option<String>,
     },
+    /// Drop a carried item (bag or worn) onto the ground. Mirrors the web
+    /// client's inventory-panel drop. Name it as it appears in your bag or
+    /// worn list; no walking or server-side range check is involved.
+    #[serde(rename = "drop", alias = "drop_item", alias = "discard")]
+    Drop {
+        #[serde(
+            alias = "item_def_id",
+            alias = "item_id",
+            alias = "name",
+            alias = "target"
+        )]
+        item: String,
+    },
+    /// Sell every copy of a bag item to a nearby merchant NPC. Walks to the
+    /// merchant first if needed. The server prices it (and rejects the sale
+    /// if the target isn't actually a trader), reported back as a
+    /// `[TradeError]` event.
+    #[serde(rename = "sell", alias = "sell_item")]
+    Sell {
+        #[serde(
+            alias = "target",
+            alias = "merchant",
+            alias = "npc",
+            alias = "target_player"
+        )]
+        player: String,
+        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        item: String,
+    },
     /// Reroll starting stats. Only meaningful during character creation,
     /// where it is the agent's version of the web client's reroll button.
     #[serde(rename = "reroll", alias = "reroll_stats", alias = "roll_again")]
@@ -289,8 +318,12 @@ pub(super) fn action_to_command(
         // Needs the bag and worn gear from SharedState; likewise handled there.
         AgentAction::Use { .. } => None,
         AgentAction::OpenChest { .. } => None,
+        // Needs the bag/worn gear lookup for its instance_id; likewise handled there.
+        AgentAction::Drop { .. } => None,
         // Needs ground-item resolution and the walk-to loop; handled there too.
         AgentAction::Pickup { .. } => None,
+        // Needs player-name → id resolution and the bag; handled there.
+        AgentAction::Sell { .. } => None,
         // Only reaches the server as a pre-creation RollCharacterStats; in
         // game there is nothing left to reroll.
         AgentAction::Reroll => None,
@@ -438,6 +471,52 @@ mod tests {
     #[test]
     fn use_produces_no_direct_command() {
         let action = parse_single_action(r#"{"actions": [{"type": "use", "item": "torch"}]}"#);
+        assert!(action_to_command(&action, None).is_none());
+    }
+
+    #[test]
+    fn drop_parses_item_and_its_aliases() {
+        for json in [
+            r#"{"actions": [{"type": "drop", "item": "small_sword"}]}"#,
+            r#"{"actions": [{"type": "drop_item", "item_id": "small_sword"}]}"#,
+            r#"{"actions": [{"type": "discard", "name": "small_sword"}]}"#,
+        ] {
+            let AgentAction::Drop { item } = parse_single_action(json) else {
+                panic!("expected Drop for {json}");
+            };
+            assert_eq!(item, "small_sword");
+        }
+    }
+
+    /// `drop` needs the bag/worn lookup for its instance_id, so it resolves in `execute`.
+    #[test]
+    fn drop_produces_no_direct_command() {
+        let action =
+            parse_single_action(r#"{"actions": [{"type": "drop", "item": "small_sword"}]}"#);
+        assert!(action_to_command(&action, None).is_none());
+    }
+
+    #[test]
+    fn sell_parses_player_and_item_aliases() {
+        for json in [
+            r#"{"actions": [{"type": "sell", "player": "Rica", "item": "small_sword"}]}"#,
+            r#"{"actions": [{"type": "sell_item", "target": "Rica", "item_id": "small_sword"}]}"#,
+            r#"{"actions": [{"type": "sell", "merchant": "Rica", "name": "small_sword"}]}"#,
+        ] {
+            let AgentAction::Sell { player, item } = parse_single_action(json) else {
+                panic!("expected Sell for {json}");
+            };
+            assert_eq!(player, "Rica");
+            assert_eq!(item, "small_sword");
+        }
+    }
+
+    /// `sell` needs the bag and a nearby-player lookup, so it resolves in `execute`.
+    #[test]
+    fn sell_produces_no_direct_command() {
+        let action = parse_single_action(
+            r#"{"actions": [{"type": "sell", "player": "Rica", "item": "small_sword"}]}"#,
+        );
         assert!(action_to_command(&action, None).is_none());
     }
 

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -79,6 +79,7 @@ pub(super) async fn handle_response(
                     | AgentAction::Attack { .. }
                     | AgentAction::Pickup { .. }
                     | AgentAction::OpenChest { .. }
+                    | AgentAction::Sell { .. }
             )
         {
             debug!("Skipping {:?} action — NPC is holding position", action);
@@ -281,6 +282,36 @@ pub(super) async fn handle_response(
             continue;
         }
 
+        // Drop a carried item (bag or worn) onto the ground. Pure inventory
+        // manipulation like Use — no range check, no walking, so it isn't
+        // gated by holding_position/trade_busy either.
+        if let AgentAction::Drop { item } = action {
+            let mut s = state.lock().await;
+            let Some((def_id, placed)) = s.find_carried(item) else {
+                warn!("drop: nothing carried matching '{item}'");
+                s.push_agent_event(format!(
+                    "[DropFailed] You are not carrying anything called '{item}'."
+                ));
+                continue;
+            };
+            let instance_id = match placed {
+                Carried::Worn(slot) => s.self_equipped[&slot].instance_id,
+                Carried::InBag(instance_id) => instance_id,
+            };
+            let cmd = onlinerpg_shared::ClientMessage::DropItem { instance_id };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send drop action: {e}");
+            } else {
+                // Never re-surface this instance as loot for ourselves — the
+                // server echoes the drop back as an ordinary GroundItemSpawned,
+                // which would otherwise put it right back in "Item on ground"
+                // next turn and loop the drop/pickup pair forever.
+                s.mark_self_dropped(instance_id);
+                info!("Agent dropped {def_id} [id {instance_id}]");
+            }
+            continue;
+        }
+
         // Pick up a ground item: resolve the reference, walk into pickup
         // range, and send the pickup. The server owns the range, floor and
         // weight checks and answers with InventoryUpdated or a SystemMessage.
@@ -334,6 +365,70 @@ pub(super) async fn handle_response(
                     s.push_agent_event(format!(
                         "[PickupFailed] Something went wrong on the way to the {def_id}."
                     ));
+                }
+            }
+            continue;
+        }
+
+        // Sell every copy of a bag item to a nearby merchant: resolve the
+        // merchant's name and the item's canonical id, walk over if needed,
+        // then sell each matching instance. Server-side rejections (too far,
+        // not a trader, no base price) surface automatically as [TradeError].
+        if let AgentAction::Sell { player, item } = action {
+            let resolved = {
+                let mut s = state.lock().await;
+                let Some((target_id, _)) = s.resolve_nearby_player(player) else {
+                    warn!("sell: no nearby merchant named '{player}'");
+                    s.push_agent_event(format!(
+                        "[SellFailed] No merchant named '{player}' is nearby."
+                    ));
+                    continue;
+                };
+                let ids: Vec<&str> = s.self_bag.iter().map(|i| i.item_def_id.as_str()).collect();
+                let Some(def_id) = crate::item_defs::resolve_named(&ids, item) else {
+                    warn!("sell: nothing carried matching '{item}'");
+                    s.push_agent_event(format!(
+                        "[SellFailed] You are not carrying anything called '{item}'."
+                    ));
+                    continue;
+                };
+                let def_id = def_id.to_string();
+                let instance_ids: Vec<u64> = s
+                    .self_bag
+                    .iter()
+                    .filter(|i| i.item_def_id == def_id)
+                    .map(|i| i.instance_id)
+                    .collect();
+                (target_id, def_id, instance_ids)
+            };
+            let (target_id, def_id, instance_ids) = resolved;
+            info!(
+                "Agent selling {} x {def_id} to {player}, approaching...",
+                instance_ids.len()
+            );
+            match approach_player(state, &target_id).await {
+                ChaseResult::InRange => {
+                    let mut s = state.lock().await;
+                    for instance_id in instance_ids {
+                        let cmd = onlinerpg_shared::ClientMessage::SellItem {
+                            merchant_player_id: target_id,
+                            instance_id,
+                        };
+                        if let Err(e) = s.send_command(cmd).await {
+                            error!("Failed to send sell command: {e}");
+                            break;
+                        }
+                    }
+                }
+                ChaseResult::Lost => {
+                    warn!("Could not reach merchant '{player}', skipping sell");
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!(
+                        "[SellFailed] Could not reach {player} — they moved away or out of sight."
+                    ));
+                }
+                ChaseResult::Error => {
+                    error!("sell: error while approaching '{player}'");
                 }
             }
             continue;

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -329,6 +329,11 @@ pub struct SharedState {
     /// `visible_ground_item(s)` — a monster's drop is known before it is
     /// visible.
     ground_items: HashMap<u64, KnownGroundItem>,
+    /// Instance ids this NPC has itself dropped, excluded from
+    /// `ground_items_in_sight` forever after — otherwise a "drop junk to
+    /// make room" turn immediately re-surfaces the same junk as loot the
+    /// very next prompt, looping the drop/pickup pair indefinitely.
+    self_dropped_items: HashSet<u64>,
     events: Vec<ServerMessage>,
     /// Latest position per monster -- deduplicates high-frequency MonsterMoved events
     latest_monster_moves: HashMap<String, ServerMessage>,
@@ -402,6 +407,7 @@ impl SharedState {
             nearby_players: HashMap::new(),
             nearby_monsters: HashMap::new(),
             ground_items: HashMap::new(),
+            self_dropped_items: HashSet::new(),
             events: Vec::new(),
             latest_monster_moves: HashMap::new(),
             latest_player_moves: HashMap::new(),
@@ -743,6 +749,12 @@ impl SharedState {
             .await
     }
 
+    /// Mark an instance id as dropped by this NPC itself, so it never
+    /// re-surfaces as loot to pick back up.
+    pub(crate) fn mark_self_dropped(&mut self, instance_id: u64) {
+        self.self_dropped_items.insert(instance_id);
+    }
+
     /// Remember an item on the ground, visible from `visible_at` on.
     pub(crate) fn remember_ground_item(
         &mut self,
@@ -774,7 +786,11 @@ impl SharedState {
         let mut in_sight: Vec<_> = self
             .ground_items
             .values()
-            .filter(|k| k.visible_at <= now && k.item.floor_level == self.self_floor_level)
+            .filter(|k| {
+                k.visible_at <= now
+                    && k.item.floor_level == self.self_floor_level
+                    && !self.self_dropped_items.contains(&k.item.instance_id)
+            })
             .filter_map(|k| {
                 let d_sq = k.item.position.dist_xz_sq(&sp.position);
                 (d_sq <= sight_sq).then_some((d_sq, &k.item))
@@ -1862,6 +1878,25 @@ pub(crate) mod tests {
             std::time::Instant::now(),
         );
         assert!(s.visible_ground_item(1).is_some());
+    }
+
+    /// An item this NPC dropped itself never re-surfaces as loot, even once
+    /// the server echoes the drop back as an ordinary ground-item spawn —
+    /// otherwise "drop junk to make room" loops the drop/pickup pair forever.
+    #[test]
+    fn self_dropped_items_never_resurface_as_loot() {
+        let (mut s, _rx) = test_state();
+        s.self_player = Some(test_player(0.0, 0.0));
+        s.remember_ground_item(
+            ground_item(1, "small_sword", 1.0, 0.0, 0),
+            std::time::Instant::now(),
+        );
+        s.mark_self_dropped(1);
+
+        assert!(s.ground_items_in_sight().is_empty());
+        assert!(!s
+            .format_world_state()
+            .contains("Item on ground: small_sword"));
     }
 
     /// A field strewn with drops is summarised, not listed line by line.


### PR DESCRIPTION
- Add a sell action so agents can sell every copy of a named bag item to a nearby merchant NPC (walks over first if needed; server-side rejections surface as [SellFailed]/[TradeError]).
- Add a drop action so agents can drop a carried item (bag or worn) onto the ground where they stand, with a permanent per-instance guard (self_dropped_items) so a self-dropped item never re-surfaces as loot and loops the drop/pickup pair.
- Update data/system_prompt.txt with usage docs for both actions, plus guidance to prefer selling over dropping, and anti-griefing instructions so an agent won't drop gear just because someone asks in chat.

## Screenshots

### Sell

<img width="400" alt="Xnip2026-07-26_02-11-22" src="https://github.com/user-attachments/assets/3adb44d6-ffa9-4ecf-b354-22b1285c1cd8" />

### Drop

<img width="400" alt="Xnip2026-07-26_02-29-50" src="https://github.com/user-attachments/assets/8d16434a-1f10-43ae-9cc1-1360e83980fa" />
