### PR TITLE
fix(server): reject monster moves through blocked terrain

### DIFF
--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -219,6 +219,29 @@ impl super::GameState {
                 self.send_direct_message(mover_id, correction).await;
                 return;
             }
+            let blocked = {
+                let cache = self.passability_read();
+                let floor =
+                    onlinerpg_shared::dungeon::passability_floor_for_level(monster.floor_level);
+                super::passability::wrapped_block_info(
+                    &cache,
+                    monster.position.x,
+                    monster.position.z,
+                    new_position.x,
+                    new_position.z,
+                    floor,
+                    monster.position.y,
+                )
+                .is_some()
+            };
+            if blocked {
+                monster.move_budget = budget;
+                debug!("Rejected monster move through blocked terrain: {monster_id} by {mover_id}");
+                let correction = Self::move_correction(monster_id, monster);
+                drop(monsters);
+                self.send_direct_message(mover_id, correction).await;
+                return;
+            }
             monster.move_budget = budget - dist;
             let old_position = monster.position;
             monster.position = new_position;

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -1502,6 +1502,70 @@ async fn non_finite_spawn_request_is_rejected() {
     }
 }
 
+/// A client-owned monster is still untrusted movement. Staying within the
+/// speed bucket must not let its owner walk it through the same solid cell that
+/// blocks server-simulated player movement.
+#[tokio::test]
+async fn client_owned_monster_cannot_cross_solid_furniture() {
+    let game_state = make_test_game_state("monster_furniture_collision");
+    let owner_id = pid("monster_owner");
+    let observer_id = pid("monster_observer");
+    let start = Position {
+        x: 0.5,
+        y: 0.0,
+        z: 4.5,
+    };
+    let destination = Position {
+        x: 0.5,
+        y: 0.0,
+        z: 6.5,
+    };
+
+    game_state
+        .add_player(make_player("monster_owner", start.x, start.z))
+        .await;
+    game_state
+        .add_player(make_player("monster_observer", start.x, start.z))
+        .await;
+    let mut owner_rx = game_state.register_direct_channel(&owner_id).await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+    game_state.sync_region_furniture(0, 0, &[table_placement(0.5, 5.5)]);
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        let mut monster = make_monster("wall_walking_monster", start, 0);
+        monster.owner_id = Some(owner_id);
+        monster.move_budget = 10.0;
+        monster.last_move_at = GameState::now_ms();
+        monsters.insert(monster.id.clone(), monster);
+    }
+
+    game_state
+        .update_monster_position(
+            &owner_id,
+            "wall_walking_monster".to_string(),
+            destination,
+            0.0,
+            MonsterState::Run,
+            destination,
+        )
+        .await;
+
+    assert_eq!(
+        game_state.monsters.read().await["wall_walking_monster"].position,
+        start,
+        "solid furniture must block a client-owned monster move"
+    );
+    assert!(matches!(
+        observer_rx.try_recv(),
+        Err(MpscTryRecvError::Empty)
+    ));
+    match owner_rx.try_recv() {
+        Ok(ServerMessage::MonsterMoved { position, .. }) => assert_eq!(position, start),
+        other => panic!("a blocked monster move must correct its owner, got {other:?}"),
+    }
+}
+
 /// Even the owner can't teleport a monster onto a distant victim: a move is
 /// capped to what the monster could run since its last accepted move, so an
 /// owned monster stays a melee threat only where it could actually walk.


### PR DESCRIPTION
Closes #38

## 문제

클라이언트 소유 몬스터의 이동은 ownership, finite input, token-bucket speed limit을 통과하면 바로 authoritative state에 반영됐습니다. 이 경로에는 서버 passability 검사가 없어서, 이동 거리가 예산 이내라면 solid furniture를 가로질러도 승인됐습니다.

이 문제는 #8에서 추가된 장거리 순간이동 제한과 별개입니다. 속도 예산은 이동량을 제한하지만, 이동 경로가 벽이나 solid cell을 통과하는지는 보장하지 않습니다.

수정 전 회귀 테스트 결과:

```text
assertion `left == right` failed: solid furniture must block a client-owned monster move
  left: Position { x: 0.5, y: 0.0, z: 6.5 }
 right: Position { x: 0.5, y: 0.0, z: 4.5 }
```

## 원인

`update_monster_position`은 token bucket을 계산한 뒤 `monster.position = new_position`을 적용하지만, 그 사이에 player movement가 사용하는 `wrapped_block_info` 계열 검증이 없었습니다.

소유 클라이언트가 몬스터 이동을 시뮬레이션하더라도, 서버가 저장하고 fanout하는 위치는 authoritative state이므로 동일한 passability 경계를 적용해야 합니다.

## 수정

- `monster.floor_level`을 공유 `passability_floor_for_level`로 변환해 서버가 보유한 층을 사용합니다.
- 속도 예산 검사를 통과한 이동에 `wrapped_block_info` 경로 검사를 추가합니다.
- 차단된 이동은 authoritative position, rotation, state를 변경하지 않습니다.
- 차단 시 이번 요청의 이동 거리를 예산에서 소비하지 않고, 계산된 refill은 기존 speed-reject 경로와 같이 보존합니다.
- 주변 관전자에게는 거부된 이동을 보내지 않고, 낙관적으로 이동을 적용한 소유자에게 현재 authoritative state를 직접 교정합니다.

정상적인 unobstructed movement, ownership 규칙, token-bucket 상한과 refill 계산, wire format은 변경하지 않았습니다.

## 회귀 테스트

`client_owned_monster_cannot_cross_solid_furniture`는 다음을 확인합니다.

1. `(0.5, 5.5)`에 solid furniture를 등록합니다.
2. 몬스터가 이동 예산 안에서 `(0.5, 4.5)`에서 `(0.5, 6.5)`로 이동을 요청합니다.
3. 서버 위치가 시작점에 남는지 확인합니다.
4. observer가 `MonsterMoved`를 받지 않는지 확인합니다.
5. owner가 시작점을 담은 authoritative correction을 받는지 확인합니다.

## 검증

- `cargo test -p onlinerpg-server client_owned_monster_cannot_cross_solid_furniture -- --nocapture`
  - 수정 전: 0 passed, 1 failed
  - 수정 후: 1 passed, 0 failed
- `cargo fmt --all --check` - passed
- `cargo clippy --workspace -- -D warnings` - passed
- `cargo test --workspace` - passed
  - agent-client: 78 passed
  - server: 135 passed
  - shared: 261 passed
  - terrain: 27 passed
  - terrain-gen: 4 passed
- `git diff --check` - passed

## 범위 밖

이번 회귀 테스트는 solid furniture 경로를 직접 검증합니다. 주택 상층, 닫힌 던전 문, world X seam도 같은 passability cache와 wrapped query를 사용하지만 각각의 전용 회귀 테스트는 이 PR에 포함하지 않았습니다.
