### PR TITLE
fix(storage): replace mutable world files atomically

### DIFF
--- a/server/src/housing/mod.rs
+++ b/server/src/housing/mod.rs
@@ -2,6 +2,7 @@ pub mod routes;
 
 use onlinerpg_shared::housing::{HouseData, RoomData, RoomType, MAX_FLOOR_LEVEL};
 use onlinerpg_shared::world::{WORLD_MAX_X, WORLD_MIN_X};
+use onlinerpg_terrain::io::atomic_write;
 use std::path::PathBuf;
 use tokio::fs;
 use tracing::{error, info};
@@ -342,7 +343,7 @@ impl HousingIO {
 
         let json = serde_json::to_string_pretty(house)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(&path, json).await?;
+        atomic_write(&path, json.as_bytes()).await?;
         info!("Saved house {} to {:?}", house.id, path);
         Ok(())
     }
@@ -430,6 +431,9 @@ mod tests {
     use super::test_fixtures::{house_at, room_at};
     use super::{is_valid_house_id, validate_house, HousingIO, MAX_ROOMS, MAX_ROOM_OFFSET};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn accepts_valid_house() {
@@ -481,5 +485,28 @@ mod tests {
         let io = HousingIO::new(PathBuf::from("/base"));
         assert!(io.house_path(0, 0, "r+00_+00_1").is_ok());
         assert!(io.house_path(0, 0, "../../etc/passwd").is_err());
+    }
+
+    #[tokio::test]
+    async fn write_house_persists_readable_json() {
+        let dir = unique_temp_dir("housing_write");
+        let io = HousingIO::new(dir.clone());
+        let house = house_at(10.0, 10.0, vec![room_at(0, 0)]);
+
+        io.write_house(&house).await.unwrap();
+
+        let stored = io.find_house(&house.id).await.unwrap().unwrap();
+        assert_eq!(stored.id, house.id);
+        assert_eq!(stored.rooms.len(), 1);
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let counter = TEST_TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "_onlinerpg_{name}_{}_{}",
+            std::process::id(),
+            counter
+        ))
     }
 }

--- a/server/src/npc_schedule/mod.rs
+++ b/server/src/npc_schedule/mod.rs
@@ -1,5 +1,6 @@
 pub mod routes;
 
+use onlinerpg_terrain::io::atomic_write;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::fs;
@@ -80,6 +81,52 @@ impl NpcIO {
         let path = self.base_dir.join(name).join(SCHEDULE_FILENAME);
         let content = serde_json::to_string_pretty(data)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(&path, content).await
+        atomic_write(&path, content.as_bytes()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NpcIO, ScheduleEntry, ScheduleFile};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[tokio::test]
+    async fn write_schedule_persists_readable_json() {
+        let dir = unique_temp_dir("npc_schedule_write");
+        let io = NpcIO::new(dir.clone());
+        let schedule = ScheduleFile {
+            schedule: vec![ScheduleEntry {
+                at: "08:00".into(),
+                pos: [1.0, 2.0, 3.0],
+                rotation: 90.0,
+                floor_level: 1,
+                label: Some("counter".into()),
+                action: None,
+                waypoints: vec![[4.0, 5.0, 6.0]],
+            }],
+        };
+
+        tokio::fs::create_dir_all(dir.join("shopkeeper"))
+            .await
+            .unwrap();
+        io.write_schedule("shopkeeper", &schedule).await.unwrap();
+
+        let stored = io.read_schedule("shopkeeper").await.unwrap();
+        assert_eq!(stored.schedule.len(), 1);
+        assert_eq!(stored.schedule[0].at, "08:00");
+        assert_eq!(stored.schedule[0].waypoints, vec![[4.0, 5.0, 6.0]]);
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let counter = TEST_TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "_onlinerpg_{name}_{}_{}",
+            std::process::id(),
+            counter
+        ))
     }
 }

--- a/terrain/Cargo.toml
+++ b/terrain/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 onlinerpg-shared = { path = "../shared" }
 async-trait = "0.1"
-tokio = { version = "1.0", features = ["fs", "sync"] }
+tokio = { version = "1.0", features = ["fs", "io-util", "sync"] }
 tracing = "0.1"
 serde_json = "1.0"
 

--- a/terrain/src/io.rs
+++ b/terrain/src/io.rs
@@ -1,9 +1,113 @@
-use std::path::PathBuf;
-use tokio::fs;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::fs::{self, File, OpenOptions};
+use tokio::io::AsyncWriteExt;
 use tracing::warn;
 
 use crate::coords;
 use crate::defaults;
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Atomically replace a mutable world file after writing and syncing a
+/// same-directory temp file. This does not claim directory fsync durability
+/// across power loss.
+pub async fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    atomic_write_inner(path, data, None).await
+}
+
+async fn atomic_write_inner(
+    path: &Path,
+    data: &[u8],
+    fail_after_bytes: Option<usize>,
+) -> std::io::Result<()> {
+    let existing_permissions = match fs::metadata(path).await {
+        Ok(metadata) => Some(metadata.permissions()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e),
+    };
+    let (temp_path, mut file) = create_unique_temp_file(path).await?;
+    let write_result = async {
+        if let Some(fail_after_bytes) = fail_after_bytes {
+            let prefix_len = fail_after_bytes.min(data.len());
+            file.write_all(&data[..prefix_len]).await?;
+            return Err(std::io::Error::other("injected atomic write failure"));
+        }
+
+        file.write_all(data).await?;
+        if let Some(permissions) = existing_permissions {
+            file.set_permissions(permissions).await?;
+        }
+        file.sync_all().await
+    }
+    .await;
+
+    drop(file);
+
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&temp_path).await;
+        return Err(e);
+    }
+
+    match fs::rename(&temp_path, path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&temp_path).await;
+            Err(e)
+        }
+    }
+}
+
+async fn create_unique_temp_file(path: &Path) -> std::io::Result<(PathBuf, File)> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "target path has no file name",
+        )
+    })?;
+    let process_id = std::process::id();
+
+    for _ in 0..128 {
+        let counter = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut temp_name = OsString::from(".");
+        temp_name.push(file_name);
+        temp_name.push(format!(".{process_id}.{counter}.tmp"));
+        let candidate = parent.join(temp_name);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+            .await
+        {
+            Ok(file) => return Ok((candidate, file)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not allocate unique temp file",
+    ))
+}
+
+#[cfg(test)]
+pub(crate) async fn atomic_write_with_injected_failure(
+    path: &Path,
+    data: &[u8],
+    fail_after_bytes: usize,
+) -> std::io::Result<()> {
+    atomic_write_inner(path, data, Some(fail_after_bytes)).await
+}
+
+async fn write_terrain_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    atomic_write(path, data).await
+}
 
 pub struct TerrainIO {
     base_dir: PathBuf,
@@ -48,10 +152,7 @@ impl TerrainIO {
             ));
         }
         let path = coords::heightmap_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     pub async fn read_splatmap(&self, tx: i32, tz: i32) -> std::io::Result<Vec<u8>> {
@@ -84,10 +185,7 @@ impl TerrainIO {
             ));
         }
         let path = coords::splatmap_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     pub async fn read_minimap(&self, rx: i32, rz: i32) -> std::io::Result<Option<Vec<u8>>> {
@@ -101,10 +199,7 @@ impl TerrainIO {
 
     pub async fn write_minimap(&self, rx: i32, rz: i32, data: &[u8]) -> std::io::Result<()> {
         let path = coords::minimap_path(&self.base_dir, rx, rz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     /// Read pre-computed grass placement data (variable-length binary).
@@ -121,10 +216,7 @@ impl TerrainIO {
     /// Write pre-computed grass placement data (variable-length binary).
     pub async fn write_grass(&self, tx: i32, tz: i32, data: &[u8]) -> std::io::Result<()> {
         let path = coords::grass_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     /// Read original (pre-housing) heightmap. Returns None if not found.
@@ -168,10 +260,7 @@ impl TerrainIO {
             ));
         }
         let path = coords::original_heightmap_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     /// Read pre-computed tree placement data (variable-length binary).
@@ -188,10 +277,7 @@ impl TerrainIO {
     /// Write pre-computed tree placement data (variable-length binary).
     pub async fn write_trees(&self, tx: i32, tz: i32, data: &[u8]) -> std::io::Result<()> {
         let path = coords::tree_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     /// Read per-tile river-field data (pixel-aligned surfaceY + flowDir,
@@ -234,10 +320,7 @@ impl TerrainIO {
     /// Write original (pre-housing) grass placement data.
     pub async fn write_original_grass(&self, tx: i32, tz: i32, data: &[u8]) -> std::io::Result<()> {
         let path = coords::original_grass_path(&self.base_dir, tx, tz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&path, data).await
+        write_terrain_file(&path, data).await
     }
 
     /// Copy current heightmap → original heightmap if original doesn't exist yet.
@@ -349,12 +432,9 @@ impl TerrainIO {
         json: &serde_json::Value,
     ) -> std::io::Result<()> {
         let path = coords::zone_path(&self.base_dir, rx, rz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
         let json_str = serde_json::to_string_pretty(json)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(&path, json_str).await
+        write_terrain_file(&path, json_str.as_bytes()).await
     }
 
     /// Read object data for a region. Returns empty JSON object if file not found.
@@ -378,11 +458,8 @@ impl TerrainIO {
         json: &serde_json::Value,
     ) -> std::io::Result<()> {
         let path = coords::object_path(&self.base_dir, rx, rz);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
         let json_str = serde_json::to_string_pretty(json)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(&path, json_str).await
+        write_terrain_file(&path, json_str.as_bytes()).await
     }
 }

--- a/terrain/src/tests.rs
+++ b/terrain/src/tests.rs
@@ -1,7 +1,19 @@
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::coords;
 use crate::defaults;
+
+static TEST_TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+    let counter = TEST_TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "_onlinerpg_{name}_{}_{}",
+        std::process::id(),
+        counter
+    ))
+}
 
 #[test]
 fn tile_to_region_positive() {
@@ -209,6 +221,95 @@ async fn splatmap_write_read_roundtrip() {
     assert_eq!(read_back, data);
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn atomic_write_replaces_file_only_after_success() {
+    let dir = unique_temp_dir("atomic_success");
+    let target = dir.join("nested").join("world.bin");
+    let replacement = b"complete replacement";
+
+    tokio::fs::create_dir_all(target.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&target, b"old complete file")
+        .await
+        .unwrap();
+    crate::io::atomic_write(&target, replacement).await.unwrap();
+
+    assert_eq!(tokio::fs::read(&target).await.unwrap(), replacement);
+    assert_no_atomic_temp_files(target.parent().unwrap(), "world.bin").await;
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn atomic_write_preserves_existing_unix_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = unique_temp_dir("atomic_permissions");
+    let target = dir.join("world.bin");
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    tokio::fs::write(&target, b"old").await.unwrap();
+    tokio::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o640))
+        .await
+        .unwrap();
+
+    crate::io::atomic_write(&target, b"new").await.unwrap();
+
+    let mode = tokio::fs::metadata(&target)
+        .await
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o640);
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn injected_partial_atomic_write_failure_keeps_existing_target_unchanged() {
+    let dir = unique_temp_dir("atomic_failure_existing");
+    let target = dir.join("world.bin");
+    let original = b"original bytes";
+    let replacement = b"new bytes that must not reach final path";
+
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    tokio::fs::write(&target, original).await.unwrap();
+
+    let result = crate::io::atomic_write_with_injected_failure(&target, replacement, 9).await;
+
+    assert!(result.is_err());
+    assert_eq!(tokio::fs::read(&target).await.unwrap(), original);
+    assert_no_atomic_temp_files(&dir, "world.bin").await;
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn injected_partial_atomic_write_failure_does_not_create_final_path() {
+    let dir = unique_temp_dir("atomic_failure_missing");
+    let target = dir.join("world.bin");
+
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    let result = crate::io::atomic_write_with_injected_failure(&target, b"partial", 3).await;
+
+    assert!(result.is_err());
+    assert!(tokio::fs::metadata(&target).await.is_err());
+    assert_no_atomic_temp_files(&dir, "world.bin").await;
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+async fn assert_no_atomic_temp_files(dir: &Path, file_name: &str) {
+    let mut entries = tokio::fs::read_dir(dir).await.unwrap();
+    let temp_prefix = format!(".{file_name}.");
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        assert!(
+            !(name.starts_with(&temp_prefix) && name.ends_with(".tmp")),
+            "unexpected atomic temp file left behind: {name}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #41

## 문제

runtime의 mutable world storage가 기존 대상 경로에 `fs::write`로 직접 덮어썼습니다. 이 방식은 대상 파일을 먼저 truncate하므로, 쓰기 도중 프로세스가 종료되거나 I/O가 실패하면 이전 정상본을 잃고 새 데이터 일부만 최종 경로에 남길 수 있습니다.

OS file-size limit을 사용한 재현에서는 기존 128-byte 파일이 직접 쓰기 중단 후 1024 bytes의 부분 새 데이터로 바뀌었습니다. 같은 장애에서 temp file에 쓴 뒤 rename한 대조군은 기존 128-byte 대상 파일을 그대로 유지했습니다.

## 수정

`onlinerpg_terrain::io::atomic_write` 공통 helper를 추가했습니다.

1. 대상과 같은 디렉터리에 process id와 atomic counter를 포함한 고유 temp 이름을 만듭니다.
2. `create_new`로 temp 파일 충돌을 거부합니다.
3. 전체 데이터를 기록하고 temp 파일을 `sync_all`합니다.
4. 기존 대상이 있으면 platform permissions를 temp 파일에 복사합니다.
5. 파일 handle을 닫은 뒤에만 rename합니다.
6. write, sync 또는 rename 실패 시 temp 파일을 best-effort로 정리합니다.

부모 디렉터리 동작은 기존 호출자와 동일하게 유지했습니다.

- `TerrainIO`: 기존처럼 필요한 디렉터리를 생성
- `HousingIO::write_house`: 기존 chunk 디렉터리 생성을 유지
- `NpcIO::write_schedule`: 기존처럼 NPC 디렉터리가 없으면 실패

## 적용 범위

- terrain heightmap, splatmap, minimap
- grass, trees와 original snapshots
- region zone/object JSON
- housing JSON
- NPC schedule JSON

## 회귀 테스트

- 성공 시 기존 파일이 완성된 새 데이터로 교체됨
- temp에 일부만 쓴 뒤 오류를 주입해도 기존 대상이 byte-for-byte 유지됨
- 기존 대상이 없을 때 실패하면 최종 파일이 생성되지 않음
- 실패 후 atomic temp 파일이 남지 않음
- Unix에서 기존 `0640` mode가 교체 후 유지됨
- housing과 NPC schedule이 교체 후 읽을 수 있는 JSON을 저장함

## 검증

- `cargo test -p onlinerpg-terrain atomic_write -- --nocapture` - 4 passed
- `cargo fmt --all --check` - passed
- `cargo clippy --workspace -- -D warnings` - passed
- `cargo test --workspace` - passed
  - agent-client: 78 passed
  - server: 136 passed
  - shared: 261 passed
  - terrain: 31 passed
  - terrain-gen: 4 passed
- `git diff --check` - passed

## 범위 밖

temp 파일과 대상이 같은 filesystem에 있다는 전제의 rename 원자성을 사용합니다. 부모 디렉터리를 fsync하지 않으므로 갑작스러운 전원 차단 이후 directory entry durability까지 보장하지 않습니다. 여러 프로세스의 동일 대상 동시 쓰기는 완성된 파일 단위의 last-rename-wins이며 순서를 보장하지 않습니다. 기존 permissions는 보존하지만 ownership, ACL, xattr 전체 복제를 보장하지 않습니다. offline terrain-generation tool의 별도 출력 경로는 이번 runtime storage 범위에 포함하지 않았습니다.
