### PR TITLE
fix(server): fail closed when chest claim persistence fails

### DIFF
--- a/server/src/game_state/dungeon.rs
+++ b/server/src/game_state/dungeon.rs
@@ -248,6 +248,19 @@ impl GameState {
         true
     }
 
+    async fn rollback_chest_open_claim(
+        &self,
+        character_id: i64,
+        entrance_id: &str,
+        opened_game_seconds: i64,
+    ) {
+        let key = (character_id, entrance_id.to_string());
+        let mut chest_opens = self.chest_opens.write().await;
+        if chest_opens.get(&key) == Some(&opened_game_seconds) {
+            chest_opens.remove(&key);
+        }
+    }
+
     /// Open the final-floor treasure chest: requires standing next to it on
     /// the last floor with the boss dead, and one open per character per
     /// night. Loot (2–3 equipment rolls + depth-scaled gold) goes straight to
@@ -333,6 +346,16 @@ impl GameState {
         .await
         {
             warn!("Failed to persist chest open for character {character_id}: {err}");
+            self.rollback_chest_open_claim(character_id, entrance_id, now_seconds)
+                .await;
+            self.send_direct_message(
+                player_id,
+                ServerMessage::InteractionRejected {
+                    reason: "The chest could not be saved; try again".to_string(),
+                },
+            )
+            .await;
+            return;
         }
 
         // Roll loot: 2–3 distinct equipment items priced for endgame.

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -3961,6 +3961,83 @@ async fn dungeon_chest_stays_shut_until_the_guardian_dies() {
     );
 }
 
+/// The nightly claim is the durable anti-duplication boundary. A failed DB
+/// write must reject the open without rewards and release only this attempt's
+/// in-memory claim so a repaired storage layer can retry.
+#[tokio::test]
+async fn dungeon_chest_persistence_failure_rejects_without_reward_and_can_retry() {
+    let db_path = std::env::temp_dir().join(format!(
+        "onlinerpg_chest_persist_fail_auth_{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    let auth = crate::auth::AuthService::new(db_path.clone()).unwrap();
+    let account = auth.login_npc("npc_chest_persist_fail").unwrap();
+    let character = create_test_character(&auth, &account, "CarefulDelver");
+
+    let game_state = make_test_game_state("chest_persist_fail");
+    let player_id = stage_chest_opener(&game_state, "CarefulDelver", character.id).await;
+    game_state
+        .inventories
+        .write()
+        .await
+        .insert(player_id, PlayerInventory::default());
+    let mut direct_rx = game_state.register_direct_channel(&player_id).await;
+
+    rusqlite::Connection::open(&db_path)
+        .unwrap()
+        .execute("DROP TABLE character_dungeon_chests", [])
+        .unwrap();
+
+    game_state
+        .open_dungeon_chest(&player_id, CRYPT_ID, &auth)
+        .await;
+
+    assert_chest_rejected(&mut direct_rx, "saved");
+    assert_eq!(
+        game_state.get_player_gold(&player_id).await,
+        0,
+        "failed persistence must not pay gold"
+    );
+    assert!(
+        game_state
+            .get_player_inventory(&player_id)
+            .await
+            .expect("staged inventory")
+            .bag
+            .is_empty(),
+        "failed persistence must not grant chest items"
+    );
+
+    let repaired_auth = crate::auth::AuthService::new(db_path).unwrap();
+
+    while direct_rx.try_recv().is_ok() {}
+    game_state
+        .open_dungeon_chest(&player_id, CRYPT_ID, &repaired_auth)
+        .await;
+
+    assert!(
+        game_state.get_player_gold(&player_id).await > 0,
+        "retry after schema repair should pay out"
+    );
+    assert!(
+        !game_state
+            .get_player_inventory(&player_id)
+            .await
+            .expect("staged inventory")
+            .bag
+            .is_empty(),
+        "retry after schema repair should grant chest items"
+    );
+    assert_eq!(
+        repaired_auth
+            .load_dungeon_chest_opens(character.id)
+            .unwrap()
+            .len(),
+        1,
+        "successful retry should persist exactly one chest claim"
+    );
+}
+
 /// The nightly refill gate compares two of these, so the index has to move
 /// forward exactly once a day and never backwards — including across the
 /// seasonal swing in sunset time.


### PR DESCRIPTION
Closes #40

## 문제

`open_dungeon_chest`는 캐릭터의 nightly claim을 in-memory map에 등록한 뒤 SQLite에 저장합니다. 하지만 `record_dungeon_chest_open`이 실패하면 경고만 남기고 보상 경로를 계속 실행해 아이템과 금화를 지급했습니다.

이 문제는 #30에서 수정된 정상적인 로그아웃·재접속 복원과 별개입니다. #30은 정상 저장된 claim을 새 세션에 복원하는 문제였고, 이 PR은 claim 저장 자체가 실패한 오류 경로를 fail-closed로 바꿉니다.

수정 전 회귀 테스트에서는 DB 테이블을 제거한 뒤 상자를 열었을 때 `InteractionRejected` 대신 첫 chest item의 `InventoryUpdated`가 도착해 보상 경로 진입이 확인됐습니다.

## 원인

코드는 “보상 전에 claim을 영속화한다”고 설명하지만, persistence 오류 분기가 `warn!` 이후 반환하지 않았습니다. 그 결과 durable claim 없이 다음 동작이 진행됐습니다.

- 2~3개 장비와 signature drop 지급
- 깊이 기반 금화 지급
- 캐릭터 dirty 표시와 후속 저장
- 주변 플레이어에게 상자 개봉 fanout

## 수정

- persistence 오류가 발생하면 같은 요청이 등록한 in-memory claim만 timestamp compare-and-remove로 롤백합니다.
- 플레이어에게 `InteractionRejected`를 보내고 loot roll 전에 즉시 반환합니다.
- DB가 정상화된 뒤 같은 캐릭터가 다시 시도할 수 있습니다.
- 정상 저장 경로, one-open-per-night 규칙과 nightfall refill 계산은 변경하지 않습니다.

timestamp를 비교한 뒤 제거하므로, 실패한 오래된 요청이 다른 요청이 남긴 최신 claim을 무조건 삭제하지 않습니다.

## 회귀 테스트

`dungeon_chest_persistence_failure_rejects_without_reward_and_can_retry`는 다음을 확인합니다.

1. `character_dungeon_chests` 테이블을 제거해 저장 실패를 강제합니다.
2. 상자 열기가 `InteractionRejected`로 끝나는지 확인합니다.
3. 금화와 인벤토리가 변경되지 않았는지 확인합니다.
4. 새 `AuthService`로 스키마를 복구합니다.
5. 재시도 시 보상이 지급되고 claim 하나가 DB에 기록되는지 확인합니다.

## 검증

- 수정 전 회귀 테스트: failed, chest item `InventoryUpdated` observed before any rejection
- 수정 후 회귀 테스트: passed
- `cargo fmt --all --check` - passed
- `cargo clippy --workspace -- -D warnings` - passed
- `cargo test --workspace` - passed
  - agent-client: 78 passed
  - server: 135 passed
  - shared: 261 passed
  - terrain: 27 passed
  - terrain-gen: 4 passed
- `git diff --check` - passed

## 범위 밖

이 PR은 현재 설계의 at-most-once 순서를 유지합니다. claim 저장 성공 직후 보상 전 서버가 종료되면 해당 밤의 상자를 잃을 수 있다는 기존 선택은 변경하지 않습니다. SQLite `BUSY`, 디스크 부족과 동시 요청을 각각 강제하는 별도 테스트도 포함하지 않았습니다.
