### PR TITLE
Retry dirty player state after failed database saves

### DIFF
--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -937,29 +937,33 @@ impl super::GameState {
         }
     }
 
-    pub async fn collect_dirty_inventory_states(&self) -> Vec<(i64, Vec<ItemRow>)> {
+    pub async fn collect_dirty_inventory_states(
+        &self,
+    ) -> (Vec<PlayerId>, Vec<(i64, Vec<ItemRow>)>) {
         let dirty_ids: Vec<PlayerId> = {
             let mut dirty = self.dirty_inventories.write().await;
             dirty.drain().collect()
         };
 
         if dirty_ids.is_empty() {
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
 
         let inventories = self.inventories.read().await;
         let player_chars = self.player_characters.read().await;
 
+        let mut collected_ids = Vec::with_capacity(dirty_ids.len());
         let mut result = Vec::with_capacity(dirty_ids.len());
         for pid in &dirty_ids {
             if let (Some(inv), Some((char_id, _, _))) =
                 (inventories.get(pid), player_chars.get(pid))
             {
+                collected_ids.push(*pid);
                 result.push((*char_id, serialize_inventory(inv)));
             }
         }
 
-        result
+        (collected_ids, result)
     }
 }
 

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -99,19 +99,24 @@ pub(crate) struct MoveCommand {
     pub(crate) append: bool,
 }
 
-/// Run a blocking DB save on the blocking pool and await it, logging a join
-/// panic or a save error under `what` instead of propagating. Awaiting is the
-/// point: callers rely on the write having completed before they continue.
-async fn flush_save<F>(op: F, what: &str)
+/// Run a blocking DB save on the blocking pool and report whether it committed.
+async fn flush_save<F>(op: F, what: &str) -> bool
 where
     F: FnOnce() -> Result<(), AuthError> + Send + 'static,
 {
-    let result = tokio::task::spawn_blocking(op).await.unwrap_or_else(|e| {
-        error!("spawn_blocking panicked: {}", e);
-        Ok(())
-    });
-    if let Err(e) = result {
-        error!("Failed to save {}: {}", what, e);
+    let result = match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(e) => {
+            error!("spawn_blocking panicked while saving {}: {}", what, e);
+            return false;
+        }
+    };
+    match result {
+        Ok(()) => true,
+        Err(e) => {
+            error!("Failed to save {}: {}", what, e);
+            false
+        }
     }
 }
 
@@ -322,7 +327,7 @@ impl super::GameState {
         let inventories = Vec::from_iter(self.take_player_inventory(player_id).await);
 
         let auth = auth.clone();
-        flush_save(
+        let _ = flush_save(
             move || auth.save_batch(&characters, &inventories, None),
             "player state",
         )
@@ -338,7 +343,7 @@ impl super::GameState {
         let inventory_count = inventories.len();
         let datetime = self.current_game_datetime();
         let auth = auth.clone();
-        flush_save(
+        let _ = flush_save(
             move || {
                 auth.save_batch(&characters, &inventories, Some(&datetime))?;
                 info!(
@@ -392,8 +397,8 @@ impl super::GameState {
     pub async fn flush_dirty_saves(&self, auth: &AuthService) {
         let _persistence = self.persistence_lock.lock().await;
 
-        let dirty_states = self.collect_dirty_character_states().await;
-        let dirty_inventories = self.collect_dirty_inventory_states().await;
+        let (dirty_player_ids, dirty_states) = self.collect_dirty_character_states().await;
+        let (dirty_inventory_ids, dirty_inventories) = self.collect_dirty_inventory_states().await;
         if dirty_states.is_empty() && dirty_inventories.is_empty() {
             return;
         }
@@ -401,7 +406,7 @@ impl super::GameState {
         let character_count = dirty_states.len();
         let inventory_count = dirty_inventories.len();
         let auth = auth.clone();
-        flush_save(
+        let saved = flush_save(
             move || {
                 auth.save_batch(&dirty_states, &dirty_inventories, None)?;
                 info!(
@@ -413,6 +418,13 @@ impl super::GameState {
             "dirty state",
         )
         .await;
+        if !saved {
+            self.dirty_players.write().await.extend(dirty_player_ids);
+            self.dirty_inventories
+                .write()
+                .await
+                .extend(dirty_inventory_ids);
+        }
     }
 
     pub async fn add_player(&self, mut player: Player) -> Option<ServerMessage> {
@@ -1179,31 +1191,33 @@ impl super::GameState {
         dirty.remove(player_id);
     }
 
-    pub async fn collect_dirty_character_states(&self) -> Vec<CharacterSaveData> {
+    pub async fn collect_dirty_character_states(&self) -> (Vec<PlayerId>, Vec<CharacterSaveData>) {
         let dirty_ids: Vec<PlayerId> = {
             let mut dirty = self.dirty_players.write().await;
             dirty.drain().collect()
         };
 
         if dirty_ids.is_empty() {
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
 
         let players = self.players.read().await;
         let player_chars = self.player_characters.read().await;
         let gold_map = self.player_gold.read().await;
 
+        let mut collected_ids = Vec::with_capacity(dirty_ids.len());
         let mut result = Vec::with_capacity(dirty_ids.len());
         for pid in &dirty_ids {
             if let (Some(player), Some((char_id, xp, _))) =
                 (players.get(pid), player_chars.get(pid))
             {
                 let gold = gold_map.get(pid).copied().unwrap_or(0);
+                collected_ids.push(*pid);
                 result.push(build_save_data(player, *char_id, *xp, gold));
             }
         }
 
-        result
+        (collected_ids, result)
     }
 
     pub async fn get_player_save_data(&self, player_id: &PlayerId) -> Option<CharacterSaveData> {

--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -3945,6 +3945,121 @@ async fn furniture_removal_reopens_blocked_cells() {
     assert_eq!(player_xz(&game_state, &player_id).await, (0.5, 6.5));
 }
 
+#[tokio::test]
+async fn dirty_save_is_retried_after_failure() {
+    let db_path = std::env::temp_dir().join(format!(
+        "onlinerpg_dirty_save_retry_auth_{}.db",
+        uuid::Uuid::new_v4()
+    ));
+    let auth = crate::auth::AuthService::new(db_path.clone()).unwrap();
+    let account = auth.login_npc("npc_dirty_save_retry").unwrap();
+    let attributes = attrs_with_cha(12);
+    let record = create_test_character(&auth, &account, "Retryknight");
+    let initial_inventory = auth
+        .load_inventory(record.id)
+        .unwrap()
+        .into_iter()
+        .map(|item| {
+            (
+                item.item_def_id,
+                item.quantity,
+                item.equip_slot,
+                item.enchant,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let game_state = make_test_game_state("dirty_save_retry");
+    let player_id = pid("dirty_save_retry");
+    let mut player = make_player("dirty_save_retry", 42.0, 0.0);
+    player.name = record.name.clone();
+    game_state.add_player(player).await;
+    game_state
+        .register_player_character(&player_id, record.id, record.xp, attributes, record.gold)
+        .await;
+    game_state.inventories.write().await.insert(
+        player_id,
+        PlayerInventory {
+            bag: vec![bag_item(1, "torch", 1)],
+            equipped: Default::default(),
+        },
+    );
+    game_state.mark_dirty(&player_id).await;
+    game_state.mark_inventory_dirty(&player_id).await;
+
+    let failure_connection = rusqlite::Connection::open(&db_path).unwrap();
+    failure_connection
+        .execute_batch(
+            "CREATE TRIGGER fail_character_update
+             BEFORE UPDATE ON characters
+             BEGIN
+                 SELECT RAISE(FAIL, 'test save failure');
+             END;",
+        )
+        .unwrap();
+
+    game_state.flush_dirty_saves(&auth).await;
+
+    assert!(game_state.dirty_players.read().await.contains(&player_id));
+    assert!(game_state
+        .dirty_inventories
+        .read()
+        .await
+        .contains(&player_id));
+    assert_ne!(
+        auth.get_character_for_account(&account, record.id)
+            .unwrap()
+            .last_x,
+        42.0
+    );
+    let inventory_after_failure = auth
+        .load_inventory(record.id)
+        .unwrap()
+        .into_iter()
+        .map(|item| {
+            (
+                item.item_def_id,
+                item.quantity,
+                item.equip_slot,
+                item.enchant,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(inventory_after_failure, initial_inventory);
+
+    failure_connection
+        .execute("DROP TRIGGER fail_character_update", [])
+        .unwrap();
+    game_state.flush_dirty_saves(&auth).await;
+
+    assert!(!game_state.dirty_players.read().await.contains(&player_id));
+    assert!(!game_state
+        .dirty_inventories
+        .read()
+        .await
+        .contains(&player_id));
+    assert_eq!(
+        auth.get_character_for_account(&account, record.id)
+            .unwrap()
+            .last_x,
+        42.0
+    );
+    let saved_inventory = auth
+        .load_inventory(record.id)
+        .unwrap()
+        .into_iter()
+        .map(|item| {
+            (
+                item.item_def_id,
+                item.quantity,
+                item.equip_slot,
+                item.enchant,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(saved_inventory, vec![("torch".to_string(), 1, None, 0)]);
+}
+
 // F-015: session replacement (kick) must flush the departing session's
 // inventory to the DB before a replacement login can load it. Otherwise the
 // old async disconnect-save races the new session's load, letting a dropped


### PR DESCRIPTION
## Overview

The periodic save path removed player IDs from the dirty sets before the database transaction completed. When `save_batch` failed, it logged the error without restoring those IDs. Unless the same in-memory state changed again, later periodic flushes had nothing to retry.

This change retains the IDs for collected character and inventory snapshots until the transaction result is known. If the save fails, it restores their dirty markers so a later periodic flush can retry the same state.

## Steps to reproduce

1. Update a connected player's character state and inventory.
2. Mark both snapshots dirty.
3. Force the next `save_batch` transaction to fail.
4. Run the periodic dirty-state flush.
5. Restore database writes without changing the player again.
6. Run the next periodic flush.
7. Before this change, the second flush finds no dirty IDs, leaving the persisted character and inventory data stale.

## Observed behavior

Both snapshot collectors called `drain()` before the database transaction began. `flush_save` waited for the blocking operation and logged failures, but it did not return the outcome to `flush_dirty_saves`. It also mapped a `spawn_blocking` join panic to `Ok(())`, so a panicked save appeared successful.

As a result, a transient database failure permanently discarded the retry signal for that batch. The in-memory state remained correct, but persisted position, gold, or inventory data could remain stale until another action marked the state dirty again.

## Expected behavior

- A collected snapshot remains retry-eligible until its batch commits successfully.
- A failed character snapshot remains eligible for the next periodic flush.
- A failed inventory snapshot remains eligible for the next periodic flush.
- A successful retry clears both markers and persists the unchanged live state.

## Root cause

The persistence code treated snapshot collection as if the save had completed. Because it discarded the collected snapshot IDs before the transaction result was available, the failure path could log the error but could no longer restore the retry set.

## Changes

- Return whether the blocking database save committed, treating a join panic as a failure.
- Return the player IDs that produced the character and inventory snapshots alongside each batch.
- Reinsert those IDs into their respective dirty sets when the batch fails.
- Preserve the existing success behavior for periodic flushes, logout, and shutdown.
- Add a SQLite regression that fails the first transaction and verifies the next flush retries the same state.

## Validation

The regression starts with different in-memory and persisted character and inventory states. It uses a SQLite trigger to fail the first transaction and confirms that:

- both dirty markers remain set;
- neither durable snapshot changes after the failed transaction;
- a second flush succeeds without another live-state mutation;
- both dirty markers clear after the successful transaction;
- the changed position and inventory are persisted together.

Local validation:

- `cargo test -p onlinerpg-server dirty_save_is_retried_after_failure -- --nocapture` — 1 passed
- `cargo check --workspace --locked` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked` — 524 passed, including 142 server tests
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Scope and limitations

This PR changes only the in-process retry bookkeeping. It leaves the save interval, database schema, and transaction boundaries unchanged. During a permanent database outage, the server continues to log errors and retry on later periodic flushes for as long as the player's state remains in memory. The logout and shutdown save-failure policy also remains unchanged. This PR does not add a durable retry queue that survives a process exit.
