### PR TITLE
Keep ground item drops above uneven terrain

### DIFF
--- a/client/src/lib/components/GroundItem.svelte
+++ b/client/src/lib/components/GroundItem.svelte
@@ -8,6 +8,7 @@
   import { createRng } from '../utils/simplex-noise'
   import { localPlayerRightHand } from '../stores/playerHandRegistry'
   import type { TerrainHeightManager } from '../managers/terrainHeightManager'
+  import { groundItemBaseY } from '../managers/ground-item-ground'
   import {
     evaluateSpawnAnimation,
     type GroundItemData,
@@ -301,10 +302,18 @@
         : 0.3
   )
   const displayX = $derived(data.position.x + (spawnTransform?.offsetX ?? 0))
-  const displayY = $derived(
-    data.position.y + restHover + (spawnTransform?.offsetY ?? 0)
-  )
   const displayZ = $derived(data.position.z + (spawnTransform?.offsetZ ?? 0))
+  const baseY = $derived(
+    groundItemBaseY(
+      heightManager ?? null,
+      data.floorLevel,
+      Boolean(data.inHand),
+      displayX,
+      displayZ,
+      data.position.y
+    )
+  )
+  const displayY = $derived(baseY + restHover + (spawnTransform?.offsetY ?? 0))
   const shouldTiltToTerrain = $derived(!data.inHand && !spawnTransform)
   // Flat pickup pad laid under a grounded item so small models still offer a
   // generous click target. It is a child of the root group (so a click on it
@@ -349,7 +358,7 @@
   const terrainAlignmentQuaternion = $derived(
     getTerrainAlignmentQuaternion(
       displayX,
-      data.position.y,
+      baseY,
       displayZ,
       shouldTiltToTerrain
     )

--- a/client/src/lib/components/GroundItem.svelte
+++ b/client/src/lib/components/GroundItem.svelte
@@ -303,16 +303,26 @@
   )
   const displayX = $derived(data.position.x + (spawnTransform?.offsetX ?? 0))
   const displayZ = $derived(data.position.z + (spawnTransform?.offsetZ ?? 0))
-  const baseY = $derived(
-    groundItemBaseY(
+  let heightRevision = $state({})
+  $effect(() => {
+    const manager = heightManager
+    heightRevision = {}
+    if (!manager) return
+    return manager.onHeightChanged(() => {
+      heightRevision = {}
+    })
+  })
+  const baseY = $derived.by(() => {
+    void heightRevision
+    return groundItemBaseY(
       heightManager ?? null,
       data.floorLevel,
       Boolean(data.inHand),
-      displayX,
-      displayZ,
+      data.position.x,
+      data.position.z,
       data.position.y
     )
-  )
+  })
   const displayY = $derived(baseY + restHover + (spawnTransform?.offsetY ?? 0))
   const shouldTiltToTerrain = $derived(!data.inHand && !spawnTransform)
   // Flat pickup pad laid under a grounded item so small models still offer a

--- a/client/src/lib/managers/entity-ground.ts
+++ b/client/src/lib/managers/entity-ground.ts
@@ -16,7 +16,8 @@ export function entityGroundY(
   floorLevel: number,
   x: number,
   z: number,
-  fallbackY: number
+  fallbackY: number,
+  bridgeReferenceY: number | null = null
 ): number {
   const wx = wrapWorldX(x)
 
@@ -34,7 +35,7 @@ export function entityGroundY(
   if (rampY !== null) return rampY
   const houseY = housingManager.floorHeightAt(0, wx, z)
   if (houseY !== null) return houseY
-  const deckY = bridgeManager.findDeckYAt(wx, z, null)
+  const deckY = bridgeManager.findDeckYAt(wx, z, bridgeReferenceY)
   if (deckY !== null) return deckY
 
   // getHeightAtWorldPosition returns 0 for unloaded tiles rather than null,

--- a/client/src/lib/managers/ground-item-ground.test.ts
+++ b/client/src/lib/managers/ground-item-ground.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { bridgeManager } from './bridgeManager'
+import type { TerrainHeightManager } from './terrainHeightManager'
+import { groundItemBaseY } from './ground-item-ground'
+
+function heightManager(loaded: boolean, height: number): TerrainHeightManager {
+  return {
+    hasHeightDataForGrid: vi.fn(() => loaded),
+    getHeightAtWorldPosition: vi.fn(() => height),
+  } as unknown as TerrainHeightManager
+}
+
+describe('groundItemBaseY', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses loaded terrain at the displayed drop coordinates', () => {
+    const manager = heightManager(true, 8.5)
+
+    expect(groundItemBaseY(manager, 0, false, 12, 20, 3)).toBe(8.5)
+    expect(manager.hasHeightDataForGrid).toHaveBeenCalledWith(12, 20)
+    expect(manager.getHeightAtWorldPosition).toHaveBeenCalledWith(12, 20)
+  })
+
+  it('keeps the stored height until terrain data is loaded', () => {
+    const manager = heightManager(false, 8.5)
+
+    expect(groundItemBaseY(manager, 0, false, 12, 20, 3)).toBe(3)
+    expect(manager.getHeightAtWorldPosition).not.toHaveBeenCalled()
+  })
+
+  it('keeps the stored height while the item is in hand', () => {
+    const manager = heightManager(true, 8.5)
+
+    expect(groundItemBaseY(manager, 0, true, 12, 20, 3)).toBe(3)
+    expect(manager.hasHeightDataForGrid).not.toHaveBeenCalled()
+  })
+
+  it('does not snap dungeon items to outdoor terrain', () => {
+    const manager = heightManager(true, 8.5)
+
+    expect(groundItemBaseY(manager, -1, false, 12, 20, 3)).toBe(3)
+    expect(manager.hasHeightDataForGrid).not.toHaveBeenCalled()
+  })
+
+  it('uses the stored height to reject an elevated bridge substrate', () => {
+    const manager = heightManager(true, 2.5)
+    const findDeck = vi
+      .spyOn(bridgeManager, 'findDeckYAt')
+      .mockImplementation((_x, _z, currentY) => (currentY === null ? 9 : null))
+
+    expect(groundItemBaseY(manager, 0, false, 12, 20, 2)).toBe(2.5)
+    expect(findDeck).toHaveBeenCalledWith(12, 20, 2)
+  })
+})

--- a/client/src/lib/managers/ground-item-ground.test.ts
+++ b/client/src/lib/managers/ground-item-ground.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { bridgeManager } from './bridgeManager'
-import type { TerrainHeightManager } from './terrainHeightManager'
+import { TerrainHeightManager } from './terrainHeightManager'
+import { VERTS_PER_SIDE, encodeHeight } from './terrain-height-types'
 import { groundItemBaseY } from './ground-item-ground'
 
-function heightManager(loaded: boolean, height: number): TerrainHeightManager {
+function fakeHeightManager(
+  loaded: boolean,
+  height: number
+): TerrainHeightManager {
   return {
     hasHeightDataForGrid: vi.fn(() => loaded),
     getHeightAtWorldPosition: vi.fn(() => height),
@@ -13,10 +17,11 @@ function heightManager(loaded: boolean, height: number): TerrainHeightManager {
 describe('groundItemBaseY', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
-  it('uses loaded terrain at the displayed drop coordinates', () => {
-    const manager = heightManager(true, 8.5)
+  it('uses loaded terrain at the landing coordinates', () => {
+    const manager = fakeHeightManager(true, 8.5)
 
     expect(groundItemBaseY(manager, 0, false, 12, 20, 3)).toBe(8.5)
     expect(manager.hasHeightDataForGrid).toHaveBeenCalledWith(12, 20)
@@ -24,33 +29,74 @@ describe('groundItemBaseY', () => {
   })
 
   it('keeps the stored height until terrain data is loaded', () => {
-    const manager = heightManager(false, 8.5)
+    const manager = fakeHeightManager(false, 8.5)
 
     expect(groundItemBaseY(manager, 0, false, 12, 20, 3)).toBe(3)
     expect(manager.getHeightAtWorldPosition).not.toHaveBeenCalled()
   })
 
   it('keeps the stored height while the item is in hand', () => {
-    const manager = heightManager(true, 8.5)
+    const manager = fakeHeightManager(true, 8.5)
 
     expect(groundItemBaseY(manager, 0, true, 12, 20, 3)).toBe(3)
     expect(manager.hasHeightDataForGrid).not.toHaveBeenCalled()
   })
 
   it('does not snap dungeon items to outdoor terrain', () => {
-    const manager = heightManager(true, 8.5)
+    const manager = fakeHeightManager(true, 8.5)
 
     expect(groundItemBaseY(manager, -1, false, 12, 20, 3)).toBe(3)
     expect(manager.hasHeightDataForGrid).not.toHaveBeenCalled()
   })
 
   it('uses the stored height to reject an elevated bridge substrate', () => {
-    const manager = heightManager(true, 2.5)
+    const manager = fakeHeightManager(true, 2.5)
     const findDeck = vi
       .spyOn(bridgeManager, 'findDeckYAt')
       .mockImplementation((_x, _z, currentY) => (currentY === null ? 9 : null))
 
     expect(groundItemBaseY(manager, 0, false, 12, 20, 2)).toBe(2.5)
     expect(findDeck).toHaveBeenCalledWith(12, 20, 2)
+  })
+
+  it('updates from fallback when height tiles load without moving the item', async () => {
+    const manager = new TerrainHeightManager()
+    const heightmap = new Uint16Array(VERTS_PER_SIDE ** 2).fill(
+      encodeHeight(8.5)
+    )
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('height-original')) {
+          return { ok: false, status: 404 }
+        }
+        return {
+          ok: true,
+          status: 200,
+          arrayBuffer: async () => heightmap.buffer.slice(0),
+        }
+      })
+    )
+
+    const x = 12
+    const z = 20
+    const fallbackY = 3
+    let renderedY = groundItemBaseY(manager, 0, false, x, z, fallbackY)
+    const unsubscribe = manager.onHeightChanged(() => {
+      renderedY = groundItemBaseY(manager, 0, false, x, z, fallbackY)
+    })
+
+    expect(renderedY).toBe(fallbackY)
+
+    await Promise.all([
+      manager.loadHeightmap(0, 0),
+      manager.loadHeightmap(1, 0),
+      manager.loadHeightmap(0, 1),
+      manager.loadHeightmap(1, 1),
+    ])
+
+    expect(renderedY).toBe(8.5)
+    unsubscribe()
   })
 })

--- a/client/src/lib/managers/ground-item-ground.ts
+++ b/client/src/lib/managers/ground-item-ground.ts
@@ -1,0 +1,15 @@
+import type { TerrainHeightManager } from './terrainHeightManager'
+import { entityGroundY } from './entity-ground'
+
+export function groundItemBaseY(
+  heightManager: TerrainHeightManager | null,
+  floorLevel: number,
+  inHand: boolean,
+  x: number,
+  z: number,
+  fallbackY: number
+): number {
+  return inHand
+    ? fallbackY
+    : entityGroundY(heightManager, floorLevel, x, z, fallbackY, fallbackY)
+}

--- a/client/src/lib/managers/terrainHeightManager.ts
+++ b/client/src/lib/managers/terrainHeightManager.ts
@@ -86,7 +86,10 @@ export class TerrainHeightManager {
   // --- Data loading ---
 
   async loadHeightmap(tileX: number, tileZ: number): Promise<Uint16Array> {
-    return doLoad(
+    const key = tileKey(tileX, tileZ)
+    const shouldNotify =
+      !this.state.heightmaps.has(key) && !this.inflightHeightmaps.has(key)
+    const data = await doLoad(
       this.state,
       this.inflightHeightmaps,
       this.terrainApiUrl,
@@ -94,6 +97,10 @@ export class TerrainHeightManager {
       tileZ,
       (tx, tz) => this.loadOriginalHeightmap(tx, tz)
     )
+    if (shouldNotify) {
+      this.notifyHeightChanged([{ tileX, tileZ }])
+    }
+    return data
   }
 
   async loadOriginalHeightmap(


### PR DESCRIPTION
## Overview

Ground items scattered away from a monster kept the monster's original Y coordinate. On rising terrain, the item root could end up below the terrain mesh, hiding both the model and its sparkle effect.

## Reported reproduction

1. Defeat a monster on uneven outdoor terrain.
2. Let its item scatter toward a nearby point whose terrain is higher than the monster's death position.
3. Observe the item model and sparkles below the terrain surface.

## Observed

The client rendered the item root at the server-provided Y even though its X/Z had moved to a different terrain height.

## Expected

Grounded items use the substrate height at their landing X/Z. Held items, dungeon floors, housing floors, entrance ramps, and bridge decks retain their existing substrate behavior.

## Root cause

The server scatters drops in X/Z while preserving the monster Y. `GroundItem` used that stale Y directly for the root group. Because the sparkles and pickup pad are children of that group, the whole drop could be hidden below the map.

## Changes

- Resolve grounded item Y at its landing coordinates through the existing floor-aware substrate helper.
- Keep spawn offsets render-only so terrain changes along the flight path do not distort the existing arc.
- Use the resolved Y for both the item root and terrain tilt.
- Re-evaluate grounded items when height data first loads or later changes.
- Preserve stored Y while held and use it as the bridge-height reference so an under-bridge drop is not lifted onto the deck.
- Add regressions for loaded and missing terrain, post-render tile loading, held items, dungeon floors, and elevated bridges.

## Validation

- `npx vitest run src/lib/managers/ground-item-ground.test.ts` — 6 passed
- `npm test` — 32 files, 290 tests passed
- `npm run check` — 0 errors and 0 warnings
- `npm run lint` — passed
- `npm run format:check` — passed
- `git diff --check` — passed

## Risk

This is a client-only rendering correction. Server item positions, floor levels, ownership, and pickup validation are unchanged.
