### PR TITLE
Reject shop interactions when players and traders are on different floors

### DIFF
--- a/server/src/game_state/tests.rs
+++ b/server/src/game_state/tests.rs
@@ -2259,6 +2259,82 @@ async fn sell_item_applies_deal_bonus() {
 }
 
 #[tokio::test]
+async fn cross_floor_shop_actions_leave_economy_state_unchanged() {
+    let game_state = make_test_game_state("cross_floor_shop");
+    let (mut buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 0).await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        let mut inv: onlinerpg_shared::inventory::PlayerInventory = Default::default();
+        inv.bag.push(bag_item(7, "iron_sword", 1));
+        inv.bag.push(bag_item(8, "dagger", 1));
+        inventories.insert(pid("buyer"), inv);
+    }
+
+    game_state
+        .sell_item(&pid("buyer"), &pid("npc_rica"), 7)
+        .await;
+    let entry_id = {
+        let buybacks = game_state.buybacks.read().await;
+        buybacks[&(1, "Rica".to_string())][0].entry.entry_id
+    };
+    game_state
+        .players
+        .write()
+        .await
+        .get_mut(&pid("buyer"))
+        .unwrap()
+        .floor_level = 1;
+
+    while buyer_rx.try_recv().is_ok() {}
+    let gold_before = game_state.get_player_gold(&pid("buyer")).await;
+    let bag_before = game_state.inventories.read().await[&pid("buyer")]
+        .bag
+        .clone();
+
+    game_state
+        .open_shop(&pid("buyer"), &pid("npc_rica"), true)
+        .await;
+    game_state
+        .buy_item(&pid("buyer"), &pid("npc_rica"), "iron_sword")
+        .await;
+    game_state
+        .sell_item(&pid("buyer"), &pid("npc_rica"), 8)
+        .await;
+    game_state
+        .buyback_item(&pid("buyer"), &pid("npc_rica"), entry_id)
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("buyer")).await, gold_before);
+    let bag_after = game_state.inventories.read().await[&pid("buyer")]
+        .bag
+        .clone();
+    assert_eq!(bag_after.len(), bag_before.len());
+    for (after, before) in bag_after.iter().zip(&bag_before) {
+        assert_eq!(after.instance_id, before.instance_id);
+        assert_eq!(after.item_def_id, before.item_def_id);
+        assert_eq!(after.quantity, before.quantity);
+        assert_eq!(after.enchant, before.enchant);
+    }
+    assert!(
+        game_state.open_shops.read().await.is_empty(),
+        "a rejected shop open must not register a hold"
+    );
+    assert_eq!(
+        game_state.buybacks.read().await[&(1, "Rica".to_string())].len(),
+        1,
+        "a rejected buyback must remain available"
+    );
+    for _ in 0..4 {
+        match buyer_rx.try_recv() {
+            Ok(ServerMessage::TradeError { message }) => {
+                assert!(message.contains("another floor"), "got: {message}")
+            }
+            other => panic!("Expected cross-floor TradeError, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
 async fn sell_to_merchant_records_buyback_and_restores_item() {
     let game_state = make_test_game_state("buyback_roundtrip");
     let (_buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 0).await;
@@ -2959,6 +3035,33 @@ async fn open_trade_pushes_shop_state_to_the_player() {
         other => panic!("Expected TradeError, got {:?}", other),
     }
     drop(npc_rx);
+}
+
+#[tokio::test]
+async fn cross_floor_open_trade_is_rejected_before_reaching_the_player() {
+    let game_state = make_test_game_state("cross_floor_open_trade");
+    setup_resident_trade(&game_state, 1_000, vec![], vec![]).await;
+    game_state
+        .players
+        .write()
+        .await
+        .get_mut(&pid("seller"))
+        .unwrap()
+        .floor_level = 1;
+    let mut seller_rx = game_state.register_direct_channel(&pid("seller")).await;
+    let mut npc_rx = game_state.register_direct_channel(&pid("npc_karl")).await;
+
+    game_state
+        .open_trade(&pid("npc_karl"), &pid("seller"))
+        .await;
+
+    assert!(matches!(seller_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    match npc_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("another floor"), "got: {message}")
+        }
+        other => panic!("Expected cross-floor TradeError, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -163,6 +163,9 @@ impl super::GameState {
         }
         let def = trader_def_by_name(&npc.name).ok_or("This NPC does not trade")?;
 
+        if player.floor_level != npc.floor_level {
+            return Err("The trader is on another floor");
+        }
         let dx = onlinerpg_shared::shortest_world_delta_x(npc.position.x, player.position.x);
         let dz = player.position.z - npc.position.z;
         if dx * dx + dz * dz > MAX_TRADE_DISTANCE * MAX_TRADE_DISTANCE {
@@ -225,6 +228,9 @@ impl super::GameState {
                 (Some(_), None) => Err("that player is not here"),
                 (Some(_), Some(target)) if target.is_official_npc => {
                     Err("trade windows can only be opened for players")
+                }
+                (Some(npc), Some(target)) if npc.floor_level != target.floor_level => {
+                    Err("the player is on another floor")
                 }
                 (Some(npc), Some(target)) => {
                     let dx =


### PR DESCRIPTION
## Overview

Trading validated NPC identity and XZ distance but did not require the player and trader to be on the same floor. Because stacked floors share XZ coordinates, a player could open a shop or mutate economy state through a trader on another floor.

This change applies the existing floor-isolation invariant to player-initiated shop actions and NPC-initiated trade windows.

## Steps to reproduce

1. Place a player and a valid trading NPC at the same XZ position but on different floors.
2. Submit `OpenShop`, `BuyItem`, `SellItem`, or `BuybackItem` with that NPC ID.
3. Observe that `validate_trader` accepts the participants because identity and planar distance pass.
4. For the reverse path, let the official NPC call `open_trade` for the cross-floor player.
5. Observe that the NPC-specific preflight also accepts the planar distance and can push a shop window.

These cases do not require an invalid NPC ID or an out-of-range position. Stacked floors naturally share XZ space.

## Observed behavior

`validate_trader` was shared by shop open, buy, sell, and buyback, but it checked only whether the target was a trading NPC and within `MAX_TRADE_DISTANCE`. `open_trade` had a second role-specific distance check with the same omission.

That allowed several stale or crafted cross-floor paths:

- opening a shop and registering a movement hold for a trader on another floor;
- buying or selling while the authoritative participants were on different floors;
- consuming a buyback entry from another floor;
- an official NPC pushing a shop window to a player on another floor.

AOI filtering does not protect these methods because the message already identifies both participants and the server performs its own direct lookup.

## Expected behavior

- Each covered path—shop open, buy, sell, buyback, and NPC-initiated trade-window delivery—requires the player and trader to share the same authoritative `floor_level`.
- A rejected request does not change gold, inventory, buyback entries, or shop holds.
- An NPC-initiated cross-floor request reports the error to the NPC and sends no shop state to the player.
- Same-floor range, catalog, wallet, deal, and buyback behavior remains unchanged.

## Root cause

The trade boundary treated XZ distance as sufficient proximity. Floor-aware AOI elsewhere in the server does not protect direct trade methods because they resolve both participant IDs from authoritative state without consulting AOI membership.

## Changes

- Add a same-floor check to the common `validate_trader` gate.
- Add the equivalent check to the role-specific `open_trade` preflight.
- Add a state-invariant regression spanning shop open, buy, sell, and buyback.
- Add a separate regression for NPC-initiated trade-window delivery.

## Validation

The regressions verify that a cross-floor request:

- creates no `open_shops` hold;
- leaves player gold and bag item identity, quantity, and enchant unchanged;
- retains the existing buyback entry;
- produces four player-facing `TradeError` responses for the four player actions;
- sends no `ShopState` to the target of an NPC-initiated request;
- reports the rejection to the initiating NPC.

Local validation:

- `cargo test -p onlinerpg-server cross_floor_shop_actions_leave_economy_state_unchanged -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server cross_floor_open_trade_is_rejected_before_reaching_the_player -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server` — 136 passed
- `cargo check --workspace --locked` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked` — 506 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Scope and limitations

This PR adds floor isolation only to shop open, buy, sell, buyback, and NPC-initiated trade-window delivery. It does not change `OfferDeal`, trade distance, pricing, stock, deal budgets, buyback lifetime, or NPC movement-hold policy.
