### PR TITLE
Render inventory items beyond 50 slots

### DIFF
--- a/client/src/lib/components/InventoryPanel.svelte
+++ b/client/src/lib/components/InventoryPanel.svelte
@@ -14,6 +14,7 @@
     FALLBACK_ICON,
   } from '../stores/dragStore'
   import { itemTooltip } from '../actions/itemTooltip'
+  import { buildInventorySlots } from './inventorySlots'
 
   interface Props {
     visible: boolean
@@ -40,18 +41,7 @@
     return total
   })
 
-  const COLS = 5
-  const ROWS = 10
-  const TOTAL_SLOTS = COLS * ROWS
-
-  const slots = $derived.by(() => {
-    const bag = $inventoryStore.bag
-    const result: (ItemInstance | null)[] = new Array(TOTAL_SLOTS).fill(null)
-    for (let i = 0; i < bag.length && i < TOTAL_SLOTS; i++) {
-      result[i] = bag[i]
-    }
-    return result
-  })
+  const slots = $derived.by(() => buildInventorySlots($inventoryStore.bag))
 
   let panelEl = $state<HTMLDivElement | null>(null)
 
@@ -227,7 +217,7 @@
   .bag-grid {
     display: grid;
     grid-template-columns: repeat(5, var(--inventory-slot-size));
-    grid-template-rows: repeat(10, var(--inventory-slot-size));
+    grid-auto-rows: var(--inventory-slot-size);
     gap: var(--inventory-slot-gap);
     max-height: calc(
       var(--inventory-slot-size) * var(--inventory-visible-rows) +

--- a/client/src/lib/components/inventorySlots.test.ts
+++ b/client/src/lib/components/inventorySlots.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { ItemInstance } from '../network/networkTypes'
+import { buildInventorySlots } from './inventorySlots'
+
+function makeItem(instanceId: number): ItemInstance {
+  return {
+    instance_id: instanceId,
+    item_def_id: `item-${instanceId}`,
+    quantity: 1,
+    enchant: 0,
+  }
+}
+
+describe('buildInventorySlots', () => {
+  it('renders 50 empty slots for an empty inventory', () => {
+    expect(buildInventorySlots([])).toEqual(new Array(50).fill(null))
+  })
+
+  it('keeps a minimum of 50 slots for short inventories', () => {
+    const bag = Array.from({ length: 49 }, (_, index) => makeItem(index + 1))
+    const slots = buildInventorySlots(bag)
+
+    expect(slots).toHaveLength(50)
+    expect(slots.slice(0, bag.length)).toEqual(bag)
+    expect(slots[49]).toBeNull()
+  })
+
+  it('keeps exactly 50 items without adding another row', () => {
+    const bag = Array.from({ length: 50 }, (_, index) => makeItem(index + 1))
+    const slots = buildInventorySlots(bag)
+
+    expect(slots).toHaveLength(50)
+    expect(slots).toEqual(bag)
+  })
+
+  it.each([
+    [51, 55],
+    [56, 60],
+  ])(
+    'expands %i items to %i slots without truncation',
+    (itemCount, slotCount) => {
+      const bag = Array.from({ length: itemCount }, (_, index) =>
+        makeItem(index + 1)
+      )
+      const slots = buildInventorySlots(bag)
+
+      expect(slots).toHaveLength(slotCount)
+      expect(slots.slice(0, bag.length)).toEqual(bag)
+      expect(slots[itemCount - 1]).toBe(bag[itemCount - 1])
+      expect(slots.slice(itemCount)).toEqual(
+        new Array(slotCount - itemCount).fill(null)
+      )
+    }
+  )
+})

--- a/client/src/lib/components/inventorySlots.ts
+++ b/client/src/lib/components/inventorySlots.ts
@@ -1,0 +1,15 @@
+import type { ItemInstance } from '../network/networkTypes'
+
+const INVENTORY_COLUMNS = 5
+const INVENTORY_MIN_SLOTS = 50
+
+export function buildInventorySlots(
+  bag: readonly ItemInstance[]
+): (ItemInstance | null)[] {
+  const slotCount = Math.max(
+    INVENTORY_MIN_SLOTS,
+    Math.ceil(bag.length / INVENTORY_COLUMNS) * INVENTORY_COLUMNS
+  )
+
+  return Array.from({ length: slotCount }, (_, index) => bag[index] ?? null)
+}


### PR DESCRIPTION
## Overview

Players whose carry weight permits more than 50 bag entries can collect those items successfully, but the inventory panel only renders the first 50. The hidden entries remain in inventory state while being inaccessible from the UI.

## Reported reproduction

1. Use a character with enough Strength to carry more than 50 item entries.
2. Collect a 51st item while remaining below the carry-weight limit.
3. Open the inventory panel.

## Observed

The pickup succeeds and the item remains in inventory state, but the panel stops after 50 rendered slots.

## Expected

Every collected bag entry is rendered and remains accessible through the inventory panel.

## Root cause

`InventoryPanel` created a fixed 5-by-10 array and copied items only while the index was below 50. The grid had scrolling enabled, but no cells existed for later entries.

## Changes

- Keep 50 slots as the minimum inventory layout.
- Expand the slot list in complete five-column rows when the bag contains more than 50 entries.
- Use dynamic grid rows so additional entries remain accessible through the existing scroll container.
- Add regressions for empty, short, exactly 50, 51, and 56 item inventories.

## Validation

- `npm test` - 33 test files, 296 tests passed
- `npm run check` - 0 errors and 0 warnings
- `npm run lint` - passed
- `npm run format:check` - passed
- `git diff --check` - passed

## Risk

This is a client-only rendering change. Server pickup, carry weight, persistence, inventory messages, item order, and item actions are unchanged. The existing 50-slot presentation remains unchanged until the bag exceeds 50 entries.
