### PR TITLE
Sandbox the claude backend like the codex one

### DIFF
--- a/agent-client/src/claude.rs
+++ b/agent-client/src/claude.rs
@@ -81,7 +81,15 @@ impl LlmBackend for ClaudeInvoker {
             cmd.arg("--system-prompt").arg(&self.system_prompt);
         }
 
-        cmd.arg(content)
+        // Other players' chat reaches the model verbatim, so assume every
+        // prompt carries an injection attempt (doc/REMOTE_AGENT_CLIENT.md).
+        // Running from a temp dir keeps the runner's repository — npc_token,
+        // the account database, config.toml's OAuth secret, AGENTS.md — out of
+        // the CLI's working directories, and --strict-mcp-config stops it
+        // loading their MCP servers. Same hygiene codex.rs already applies.
+        cmd.arg("--strict-mcp-config")
+            .arg(content)
+            .current_dir(std::env::temp_dir())
             .env_remove("CLAUDECODE")
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## Problem

`doc/REMOTE_AGENT_CLIENT.md` is explicit about the threat model:

> 프롬프트에는 게임 월드에서 온 다른 플레이어의 채팅이 그대로 들어가므로, 인젝션 시도는 항상 있다고 가정한다 — 위 샌드박스 옵션을 임의로 낮추지 말 것.

`codex.rs` honours that: `--sandbox read-only`, `--ephemeral`, `--skip-git-repo-check`, and `current_dir(temp_dir)`. `claude.rs` has none of them. It spawns the CLI with the agent-client directory inherited as cwd, so Claude Code takes both `agent-client/` and the repository root as working directories — and a player's chat is in the same context window.

Measured on a live agent (Google-mode, `llm = "claude"`) before this change, by putting the request in the prompt the way a player's chat arrives:

| Target | Result |
|---|---|
| `../data/npc_token` | **read — 32 characters, correct** |
| repository sources | read |
| `~/.config/onlinerpg/google.json` | refused (outside working directories) |
| shell commands | refused (no approval in `-p` mode) |

So the exposure was bounded to the repository — but that is where the secrets are. `data/npc_token` is the shared secret every operator NPC authenticates with; on the machine that runs Rica and Karl it is the live one. `data/game_data.db` and `agent-client/data/config.toml` (OAuth client secret) sit in the same tree. The only thing that stopped a credential from coming back out in my test was the model declining on its own judgement — not a control.

## Fix

Give the claude backend the same hygiene codex already has:

- `current_dir(std::env::temp_dir())` — the repository stops being a working directory, so the paths above are no longer reachable. This is also what keeps the runner's `AGENTS.md`/`CLAUDE.md` from being pulled in, matching the comment already on the codex call.
- `--strict-mcp-config` — the runner's MCP servers stay out of an agent session.

Nothing depends on the old cwd: the prompt is a plain string argument, and the prompt/memory files are read by agent-client itself, not by the CLI.

## Verification

- `cargo test -p agent-client` 90/90; `cargo clippy -p agent-client -- -D warnings` clean
- Re-ran the same probe from a temp cwd: `/…/OpenMMO/data/npc_token` now comes back *"That path is outside my allowed working directories"*
- Ran an agent against the live server on the patched build — normal play, chat and combat unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)