### PR TITLE
Give the client job the generated data and models it needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,23 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
       - run: npm ci
+      # data/*.json is generated, not committed. The tools build:wasm runs
+      # first — measure-monster-attack-clips reads data/monsters.json — so a
+      # clean checkout needs the conversion before them. On a developer's
+      # machine a cargo build has already produced it, which is why this only
+      # ever fails in CI.
+      - run: npm run generate:csv
+      # Those same tools parse GLBs, and on a fresh checkout every file shares
+      # one mtime, so the up-to-date check always misses and they really do
+      # regenerate. Fetch the models they open — 28 MB of the 245 MB tree —
+      # rather than the whole of LFS on every run.
+      - name: Fetch the GLBs the generators read
+        working-directory: .
+        run: |
+          git lfs pull --include="client/public/models/monsters/*.glb,\
+          client/public/models/animations/combat_melee.glb,\
+          client/public/models/animations/locomotion.glb,\
+          client/public/models/characters/female_knight.glb"
       - run: npm run build:wasm
       - run: npm test
       - run: npm run check


### PR DESCRIPTION
## Problem

The client job has been failing on every PR since `generate:monster-clips` joined `build:wasm` — including PRs that touch no client code at all (#49 is one). Two things a developer's machine always happens to have are missing on a clean runner:

**1. `data/monsters.json`.** It is generated, not committed. The generators live in `server/build.rs` and `agent-client/build.rs`, neither of which this job runs — and `shared/`, the crate `wasm-pack` builds, has no build script. So the file exists everywhere except CI:

```
Error: ENOENT: no such file or directory, open '.../data/monsters.json'
    at tools/measure-monster-attack-clips.mjs:28:14
```

**2. The GLBs those tools parse.** Checkout skips LFS to stay off the bandwidth quota, so the models arrive as pointer text:

```
Error: Not a GLB file: .../client/public/models/monsters/scp939.glb
```

Note the tools do *try* to skip when their output is current, but a fresh checkout stamps every file with the same mtime, so the up-to-date check always misses and they genuinely regenerate. CI cannot rely on the committed outputs being taken as fresh.

## Fix

- `npm run generate:csv` before `build:wasm` — the same `data-src/*.csv` → `data/*.json` conversion the Rust build tool performs, already wired up as an npm script and already used by `check` and `lint` for this reason.
- `git lfs pull` for exactly the four paths the tools open: the monster models, `combat_melee.glb`, `locomotion.glb`, `female_knight.glb`. That is 28 MB against 245 MB for the whole model tree, so the bandwidth argument for skipping LFS still holds.

## Verification

Both jobs green on a clean runner: [run 30210068793](https://github.com/jckdotim/OpenMMO/actions/runs/30210068793) (the failures above are from the runs before each step was added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)