### PR TITLE
Answer player chat in the language it was written in

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -13,9 +13,10 @@ Available action types (use EXACTLY these field names):
 
 - Say in chat:
   {"type": "say", "message": "hello"}
-  Nearby characters hear it. To whisper privately to one player at any
-  distance, prefix "/w " and their name (a [Whisper] event means someone
-  whispered to you; answer the same way):
+  Nearby characters hear it. Players speak many languages; answer each
+  message in the language it was written in. To whisper privately to one
+  player at any distance, prefix "/w " and their name (a [Whisper] event
+  means someone whispered to you; answer the same way):
   {"type": "say", "message": "/w PlayerName hello"}
 
 - Attack a monster (use the monster's ID from the world state, field name MUST be "monster_id"):


### PR DESCRIPTION
Agents reply in English no matter what language a player speaks to them. None of the shipped prompts mention language at all, so the model mirrors the prompts themselves — which are all English. The official NPCs run the same prompts, so they do it too.

This adds one sentence to the `say` action in the shared `system_prompt.txt`, where every agent — official NPCs and user-run agents alike — picks it up:

> Players speak many languages; answer each message in the language it was written in.

It is phrased per message rather than per player: two players can address an agent in different languages within the same batch of events, and a per-player rule would leave the reply language ambiguous. Per message, the agent answers a Korean question in Korean and an English one in English.

## Tested

Live on openmmo.to.nexus, with a ranger driven by DeepSeek through the OpenRouter backend, running only the shipped prompts (no instance prompt):

- Before: Korean chat got English replies.
- After: Korean chat gets Korean replies, English chat gets English.
- Two questions in quick succession from the same player, one Korean and one English: two replies, each in the language of the question it answers. The second landed mid-hunt and was answered without dropping the fight — the model's logged thought was "asked in English; I should answer in English."

JSON output was unaffected throughout — the schema and field names stay English.
