### PR TITLE
Add /help command and a command hint in the chat input

### DIFF
--- a/client/src/lib/chat-commands.ts
+++ b/client/src/lib/chat-commands.ts
@@ -16,249 +16,319 @@ import {
 import { computeGrassPlacement, regenerateVegMeta } from './utils/grass-data'
 import { dungeonManager } from './managers/dungeonManager'
 
-type CommandHandler = (args: string) => void
+/** Every command lives here once: its `/help` line, whether it is admin-only,
+ *  and who executes it. */
+type Command = {
+  desc: string
+  admin: boolean
+  /** Client-side handler. Omit it to let the text through to the server. */
+  run?: (args: string) => void
+}
 
-const ADMIN_COMMANDS = new Set(['/drop', '/time', '/dungeon'])
-
-const commands: Record<string, CommandHandler> = {
-  '/pos': () => {
-    const player = get(gameStore).currentPlayer
-    if (player) {
-      const pos = player.position
-      const { tileX, tileZ, cellX, cellZ } = worldToTileCell(pos.x, pos.z)
-      const deg = MathUtils.radToDeg(player.rotation).toFixed(1)
-      addChatMessage({
-        text: `Position: world(${pos.x.toFixed(1)}, ${pos.y.toFixed(1)}, ${pos.z.toFixed(1)}) tile(${tileX}, ${tileZ}) cell(${cellX}, ${cellZ}) rot(${deg}°)`,
-        sender: 'system',
-      })
-    } else {
-      addChatMessage({ text: 'Position: unknown', sender: 'system' })
-    }
-  },
-
-  '/drop': (args) => {
-    const player = get(gameStore).currentPlayer
-    if (!player) {
-      addChatMessage({
-        text: 'Drop: player position unknown',
-        sender: 'system',
-      })
-      return
-    }
-
-    const itemDefId = args.trim() || 'goblin_sword'
-    networkManager.sendDebugDropItem(itemDefId)
-
-    addChatMessage({
-      text: `Drop: requested ${itemDefId} near 1m ahead`,
-      sender: 'system',
-    })
-  },
-
-  '/time': (args) => {
-    const match = args.trim().match(/^(\d{1,2})(?::(\d{1,2}))?$/)
-    if (!match) {
-      addChatMessage({
-        text: 'Usage: /time HH[:MM] — jump the game clock forward to that time (e.g. /time 9:30)',
-        sender: 'system',
-      })
-      return
-    }
-    const hour = Math.min(parseInt(match[1], 10), 23)
-    const minute = Math.min(match[2] ? parseInt(match[2], 10) : 0, 59)
-    networkManager.sendDebugSetTime(hour, minute)
-    addChatMessage({
-      text: `Time: requested jump to ${hour}:${String(minute).padStart(2, '0')}`,
-      sender: 'system',
-    })
-  },
-
-  '/dungeon': (args) => {
-    const player = get(gameStore).currentPlayer
-    if (!player) {
-      addChatMessage({ text: 'Dungeon: player unknown', sender: 'system' })
-      return
-    }
-
-    const arg = args.trim()
-    if (arg === 'exit') {
-      const ent = dungeonManager.entrancePos
-      if (ent) {
-        networkManager.sendDebugTeleport({ x: ent.x, y: ent.y, z: ent.z })
-      }
-      dungeonManager.exit()
-      addChatMessage({ text: 'Dungeon: exited to surface', sender: 'system' })
-      return
-    }
-
-    if (arg === 'resetprops' || arg === 'reset-props') {
-      const entranceId = dungeonManager.dungeonId
-      if (!entranceId) {
+const COMMANDS: Record<string, Command> = {
+  '/help': {
+    desc: 'List the available commands',
+    admin: false,
+    run: () => {
+      const line = (name: string) =>
         addChatMessage({
-          text: 'Dungeon props: no active dungeon',
+          text: `${name} — ${COMMANDS[name].desc}`,
+          sender: 'system',
+        })
+      const listed = visibleCommandNames()
+
+      addChatMessage({ text: 'Available commands:', sender: 'system' })
+      for (const name of listed.filter((n) => !COMMANDS[n].admin)) line(name)
+
+      const adminOnly = listed.filter((n) => COMMANDS[n].admin)
+      if (adminOnly.length > 0) {
+        addChatMessage({ text: 'Admin commands:', sender: 'system' })
+        for (const name of adminOnly) line(name)
+      }
+    },
+  },
+
+  '/who': { desc: 'Show how many players are online', admin: false },
+  '/escape': {
+    desc: 'Return to the starting point when you get stuck',
+    admin: false,
+  },
+  '/w': { desc: 'Send a private message: /w <player> <message>', admin: false },
+  '/whisper': {
+    desc: 'Send a private message: /whisper <player> <message>',
+    admin: false,
+  },
+  '/block': {
+    desc: 'Block whispers from a player: /block <player>',
+    admin: false,
+  },
+  '/unblock': { desc: 'Unblock a player: /unblock <player>', admin: false },
+  '/give': { desc: 'Give yourself an item: /give <item_id>', admin: true },
+  '/notice': {
+    desc: 'Set the server banner, or clear it with a bare /notice',
+    admin: true,
+  },
+
+  '/pos': {
+    desc: 'Show your current position',
+    admin: false,
+    run: () => {
+      const player = get(gameStore).currentPlayer
+      if (player) {
+        const pos = player.position
+        const { tileX, tileZ, cellX, cellZ } = worldToTileCell(pos.x, pos.z)
+        const deg = MathUtils.radToDeg(player.rotation).toFixed(1)
+        addChatMessage({
+          text: `Position: world(${pos.x.toFixed(1)}, ${pos.y.toFixed(1)}, ${pos.z.toFixed(1)}) tile(${tileX}, ${tileZ}) cell(${cellX}, ${cellZ}) rot(${deg}°)`,
+          sender: 'system',
+        })
+      } else {
+        addChatMessage({ text: 'Position: unknown', sender: 'system' })
+      }
+    },
+  },
+
+  '/drop': {
+    desc: 'Drop an item in front of you',
+    admin: true,
+    run: (args) => {
+      const player = get(gameStore).currentPlayer
+      if (!player) {
+        addChatMessage({
+          text: 'Drop: player position unknown',
           sender: 'system',
         })
         return
       }
-      networkManager.sendDebugResetDungeonProps(entranceId)
+
+      const itemDefId = args.trim() || 'goblin_sword'
+      networkManager.sendDebugDropItem(itemDefId)
+
       addChatMessage({
-        text: 'Dungeon props: reset requested',
+        text: `Drop: requested ${itemDefId} near 1m ahead`,
         sender: 'system',
       })
-      return
-    }
-
-    const requested = Math.max(1, parseInt(arg || '1', 10) || 1)
-    if (!dungeonManager.active) {
-      // Debug dungeon anchored at the player's current position.
-      dungeonManager.enter('debug', {
-        x: player.position.x,
-        y: player.position.y,
-        z: player.position.z,
-      })
-    }
-    const total = dungeonManager.floors.length
-    const depth = Math.min(requested, total)
-    const layout = dungeonManager.layoutAt(depth)
-    if (!layout) {
-      addChatMessage({ text: 'Dungeon: layout missing', sender: 'system' })
-      return
-    }
-    const target = dungeonManager.cellCenter(
-      depth,
-      dungeonManager.shaftExitCell(layout.upShaft)
-    )
-    dungeonManager.setDepth(depth)
-    networkManager.sendDebugTeleport(target)
-    addChatMessage({
-      text: `Dungeon: depth ${depth}/${total} (rooms=${layout.rooms.length}, spawns=${layout.spawns.length})`,
-      sender: 'system',
-    })
+    },
   },
 
-  '/wireframe': () => {
-    const next = !get(riverWireframeVisible)
-    riverWireframeVisible.set(next)
-    addChatMessage({
-      text: `River wireframe: ${next ? 'on' : 'off'}`,
-      sender: 'system',
-    })
-  },
-
-  '/shore_wave': () => {
-    const next = !get(shoreWaveDebugVisible)
-    shoreWaveDebugVisible.set(next)
-    addChatMessage({
-      text: `Shore wave debug: ${next ? 'on' : 'off'}`,
-      sender: 'system',
-    })
-  },
-
-  '/passability': () => {
-    const next = !get(passabilityDebugVisible)
-    passabilityDebugVisible.set(next)
-    addChatMessage({
-      text: `Passability debug: ${next ? 'on' : 'off'} (walls red, furniture orange)`,
-      sender: 'system',
-    })
-  },
-
-  '/regrow': () => {
-    const player = get(gameStore).currentPlayer
-    if (!player) {
-      addChatMessage({
-        text: 'Regrow: player position unknown',
-        sender: 'system',
-      })
-      return
-    }
-
-    const hMgr = get(editorHeightManager)
-    const sMgr = get(editorSplatManager)
-    const gMgr = get(editorGrassDataManager)
-    if (!hMgr || !sMgr || !gMgr) {
-      addChatMessage({
-        text: 'Regrow: terrain managers not ready',
-        sender: 'system',
-      })
-      return
-    }
-
-    const { tileX, tileZ } = worldToTileCell(
-      player.position.x,
-      player.position.z
-    )
-    const splatData = sMgr.getSplatData(tileX, tileZ)
-    if (!splatData) {
-      addChatMessage({
-        text: `Regrow: no splatmap for tile(${tileX}, ${tileZ})`,
-        sender: 'system',
-      })
-      return
-    }
-
-    addChatMessage({
-      text: `Regrow: regenerating grass for tile(${tileX}, ${tileZ})...`,
-      sender: 'system',
-    })
-
-    regenerateVegMeta(splatData, tileX, tileZ)
-    // Refresh GPU texture + mark tile dirty for the debounced save.
-    sMgr.setSplatmap(tileX, tileZ, splatData)
-    sMgr.markDirty(tileX, tileZ)
-    sMgr.saveAllDirty().catch((err) => {
-      addChatMessage({
-        text: `Regrow: splatmap save failed — ${err}`,
-        sender: 'system',
-      })
-    })
-
-    const data = computeGrassPlacement(tileX, tileZ, splatData, hMgr)
-    gMgr.saveGrassData(tileX, tileZ, data).then(
-      () => {
+  '/time': {
+    desc: 'Jump the game clock to HH[:MM]',
+    admin: true,
+    run: (args) => {
+      const match = args.trim().match(/^(\d{1,2})(?::(\d{1,2}))?$/)
+      if (!match) {
         addChatMessage({
-          text: `Regrow: done — short=${data.shortCount} tall=${data.tallCount} flower=${data.flowerCount}`,
+          text: 'Usage: /time HH[:MM] — jump the game clock forward to that time (e.g. /time 9:30)',
           sender: 'system',
         })
-      },
-      (err) => {
+        return
+      }
+      const hour = Math.min(parseInt(match[1], 10), 23)
+      const minute = Math.min(match[2] ? parseInt(match[2], 10) : 0, 59)
+      networkManager.sendDebugSetTime(hour, minute)
+      addChatMessage({
+        text: `Time: requested jump to ${hour}:${String(minute).padStart(2, '0')}`,
+        sender: 'system',
+      })
+    },
+  },
+
+  '/dungeon': {
+    desc: 'Enter or adjust the debug dungeon',
+    admin: true,
+    run: (args) => {
+      const player = get(gameStore).currentPlayer
+      if (!player) {
+        addChatMessage({ text: 'Dungeon: player unknown', sender: 'system' })
+        return
+      }
+
+      const arg = args.trim()
+      if (arg === 'exit') {
+        const ent = dungeonManager.entrancePos
+        if (ent) {
+          networkManager.sendDebugTeleport({ x: ent.x, y: ent.y, z: ent.z })
+        }
+        dungeonManager.exit()
+        addChatMessage({ text: 'Dungeon: exited to surface', sender: 'system' })
+        return
+      }
+
+      if (arg === 'resetprops' || arg === 'reset-props') {
+        const entranceId = dungeonManager.dungeonId
+        if (!entranceId) {
+          addChatMessage({
+            text: 'Dungeon props: no active dungeon',
+            sender: 'system',
+          })
+          return
+        }
+        networkManager.sendDebugResetDungeonProps(entranceId)
         addChatMessage({
-          text: `Regrow: grass save failed — ${err}`,
+          text: 'Dungeon props: reset requested',
           sender: 'system',
+        })
+        return
+      }
+
+      const requested = Math.max(1, parseInt(arg || '1', 10) || 1)
+      if (!dungeonManager.active) {
+        // Debug dungeon anchored at the player's current position.
+        dungeonManager.enter('debug', {
+          x: player.position.x,
+          y: player.position.y,
+          z: player.position.z,
         })
       }
-    )
+      const total = dungeonManager.floors.length
+      const depth = Math.min(requested, total)
+      const layout = dungeonManager.layoutAt(depth)
+      if (!layout) {
+        addChatMessage({ text: 'Dungeon: layout missing', sender: 'system' })
+        return
+      }
+      const target = dungeonManager.cellCenter(
+        depth,
+        dungeonManager.shaftExitCell(layout.upShaft)
+      )
+      dungeonManager.setDepth(depth)
+      networkManager.sendDebugTeleport(target)
+      addChatMessage({
+        text: `Dungeon: depth ${depth}/${total} (rooms=${layout.rooms.length}, spawns=${layout.spawns.length})`,
+        sender: 'system',
+      })
+    },
+  },
+
+  '/wireframe': {
+    desc: 'Toggle the river wireframe overlay',
+    admin: true,
+    run: () => {
+      const next = !get(riverWireframeVisible)
+      riverWireframeVisible.set(next)
+      addChatMessage({
+        text: `River wireframe: ${next ? 'on' : 'off'}`,
+        sender: 'system',
+      })
+    },
+  },
+
+  '/shore_wave': {
+    desc: 'Toggle the shore-wave debug overlay',
+    admin: true,
+    run: () => {
+      const next = !get(shoreWaveDebugVisible)
+      shoreWaveDebugVisible.set(next)
+      addChatMessage({
+        text: `Shore wave debug: ${next ? 'on' : 'off'}`,
+        sender: 'system',
+      })
+    },
+  },
+
+  '/passability': {
+    desc: 'Toggle the passability overlay',
+    admin: true,
+    run: () => {
+      const next = !get(passabilityDebugVisible)
+      passabilityDebugVisible.set(next)
+      addChatMessage({
+        text: `Passability debug: ${next ? 'on' : 'off'} (walls red, furniture orange)`,
+        sender: 'system',
+      })
+    },
+  },
+
+  '/regrow': {
+    desc: 'Regenerate grass on your current tile',
+    admin: true,
+    run: () => {
+      const player = get(gameStore).currentPlayer
+      if (!player) {
+        addChatMessage({
+          text: 'Regrow: player position unknown',
+          sender: 'system',
+        })
+        return
+      }
+
+      const hMgr = get(editorHeightManager)
+      const sMgr = get(editorSplatManager)
+      const gMgr = get(editorGrassDataManager)
+      if (!hMgr || !sMgr || !gMgr) {
+        addChatMessage({
+          text: 'Regrow: terrain managers not ready',
+          sender: 'system',
+        })
+        return
+      }
+
+      const { tileX, tileZ } = worldToTileCell(
+        player.position.x,
+        player.position.z
+      )
+      const splatData = sMgr.getSplatData(tileX, tileZ)
+      if (!splatData) {
+        addChatMessage({
+          text: `Regrow: no splatmap for tile(${tileX}, ${tileZ})`,
+          sender: 'system',
+        })
+        return
+      }
+
+      addChatMessage({
+        text: `Regrow: regenerating grass for tile(${tileX}, ${tileZ})...`,
+        sender: 'system',
+      })
+
+      regenerateVegMeta(splatData, tileX, tileZ)
+      // Refresh GPU texture + mark tile dirty for the debounced save.
+      sMgr.setSplatmap(tileX, tileZ, splatData)
+      sMgr.markDirty(tileX, tileZ)
+      sMgr.saveAllDirty().catch((err) => {
+        addChatMessage({
+          text: `Regrow: splatmap save failed — ${err}`,
+          sender: 'system',
+        })
+      })
+
+      const data = computeGrassPlacement(tileX, tileZ, splatData, hMgr)
+      gMgr.saveGrassData(tileX, tileZ, data).then(
+        () => {
+          addChatMessage({
+            text: `Regrow: done — short=${data.shortCount} tall=${data.tallCount} flower=${data.flowerCount}`,
+            sender: 'system',
+          })
+        },
+        (err) => {
+          addChatMessage({
+            text: `Regrow: grass save failed — ${err}`,
+            sender: 'system',
+          })
+        }
+      )
+    },
   },
 }
 
-/** Handled by the server (`game_state::chat`); listed only for autocomplete. */
-const SERVER_COMMANDS = [
-  '/escape',
-  '/who',
-  '/w',
-  '/whisper',
-  '/block',
-  '/unblock',
-]
-
-const commandNames = [...Object.keys(commands), ...SERVER_COMMANDS].sort()
+const commandNames = Object.keys(COMMANDS).sort()
 
 /** Command names for autocomplete; hides admin commands from non-admins. */
 export function visibleCommandNames(): string[] {
   if (get(isAdminUser)) return commandNames
-  return commandNames.filter((n) => !ADMIN_COMMANDS.has(n))
+  return commandNames.filter((n) => !COMMANDS[n].admin)
 }
 
 export function handleCommand(input: string): boolean {
   const spaceIndex = input.indexOf(' ')
   const name = spaceIndex === -1 ? input : input.slice(0, spaceIndex)
   const args = spaceIndex === -1 ? '' : input.slice(spaceIndex + 1)
-  const handler = commands[name]
-  if (!handler) return false
-  if (ADMIN_COMMANDS.has(name) && !get(isAdminUser)) {
+  const command = COMMANDS[name]
+  if (!command?.run) return false
+  if (command.admin && !get(isAdminUser)) {
     addChatMessage({ text: `${name}: admin only`, sender: 'system' })
     return true
   }
-  handler(args)
+  command.run(args)
   return true
 }

--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -72,6 +72,21 @@
     }
   }
 
+  /** Completion candidates for a prefix. `/help` goes first so typing just `/`
+   *  finds it. */
+  function commandMatches(prefix: string): string[] {
+    const matches = visibleCommandNames().filter((n) => n.startsWith(prefix))
+    if (!matches.includes('/help')) return matches
+    return ['/help', ...matches.filter((n) => n !== '/help')]
+  }
+
+  // Grey preview of what Tab would complete to.
+  let commandGhost = $derived.by(() => {
+    if (!messageInput.startsWith('/') || messageInput.includes(' ')) return ''
+    const match = commandMatches(messageInput).find((n) => n !== messageInput)
+    return match ? match.slice(messageInput.length) : ''
+  })
+
   let tabCycle: { matches: string[]; index: number } | null = null
 
   function completeCommand() {
@@ -81,9 +96,7 @@
       messageInput = tabCycle.matches[tabCycle.index]
       return
     }
-    const matches = visibleCommandNames().filter((n) =>
-      n.startsWith(messageInput)
-    )
+    const matches = commandMatches(messageInput)
     if (matches.length === 0) return
     tabCycle = { matches, index: 0 }
     messageInput = matches[0]
@@ -195,22 +208,31 @@
   </div>
 
   <div class="chat-input" class:disconnected={!isConnected}>
-    <input
-      type="text"
-      bind:this={chatInput}
-      bind:value={messageInput}
-      onkeydown={handleKeyDown}
-      onfocus={() => {
-        inputFocused = true
-        activeTab = 'say'
-      }}
-      onblur={() => {
-        inputFocused = false
-        restoreViewportAfterKeyboard()
-      }}
-      placeholder="Type a message..."
-      disabled={!isConnected}
-    />
+    <div class="input-wrap">
+      {#if commandGhost}
+        <div class="input-ghost" aria-hidden="true">
+          <span class="ghost-typed">{messageInput}</span><span
+            class="ghost-suffix">{commandGhost}</span
+          >
+        </div>
+      {/if}
+      <input
+        type="text"
+        bind:this={chatInput}
+        bind:value={messageInput}
+        onkeydown={handleKeyDown}
+        onfocus={() => {
+          inputFocused = true
+          activeTab = 'say'
+        }}
+        onblur={() => {
+          inputFocused = false
+          restoreViewportAfterKeyboard()
+        }}
+        placeholder="Type a message... (/help for commands)"
+        disabled={!isConnected}
+      />
+    </div>
     <button
       onclick={sendMessage}
       disabled={!isConnected || !messageInput.trim()}
@@ -372,14 +394,45 @@
     background: #742a2a;
   }
 
+  .input-wrap {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+  }
+
   .chat-input input {
     flex: 1;
+    min-width: 0;
     padding: 8px 10px;
     border: none;
     border-radius: 0 0 0 8px;
     background: transparent;
     color: #ffffff;
     font-size: 12px;
+  }
+
+  /* Grey ghost aligned under the real input: an invisible copy of the typed
+     text reserves the caret's width so the suggestion trails it exactly. */
+  .input-ghost {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    padding: 8px 10px;
+    font-size: 12px;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .input-ghost .ghost-typed {
+    color: transparent;
+    white-space: pre;
+  }
+
+  .input-ghost .ghost-suffix {
+    color: rgba(113, 128, 150, 0.7);
+    white-space: pre;
   }
 
   .chat-input input:focus {


### PR DESCRIPTION
Players had no way to discover the slash commands.

- **`/help`** lists every command visible to the user with a one-line description. Non-admins get one flat list; admins additionally get an `Admin commands:` section.
- **Completion ghost**: typing a command prefix shows a grey inline preview of what Tab would complete to. A bare `/` offers `/help` rather than the alphabetically first command.
- **`/wireframe`, `/shore_wave`, `/passability`, `/regrow` are admin-only now** — they were reachable by any player.
- The server's `/give` and `/notice` are listed for the first time, so admins can find them.

Command metadata lived in four places (handler map, `SERVER_COMMANDS`, descriptions, admin set), so adding one meant touching all of them — which is how those debug commands stayed open. `/help` needs a description per command, which would have made it a fifth parallel table, so they are merged instead: a single `COMMANDS` record keyed by name, each entry carrying its description, a required `admin` flag, and an optional `run`; omitting `run` means the server handles it. Most of the diff is indentation churn from that move — ignoring whitespace it is about +119/-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)