### PR TITLE
Add client tests for fishing store, water field sampling, and cast-vs-walk intent

### DIFF
--- a/client/src/lib/managers/inputHandler.test.ts
+++ b/client/src/lib/managers/inputHandler.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as THREE from 'three'
+
+const MIN_FISHABLE_DEPTH_M = 0.3
+
+vi.mock('../wasm/onlinerpg_shared', () => ({
+  min_fishable_depth_m: () => MIN_FISHABLE_DEPTH_M,
+}))
+
+import { inputHandler, type RaycastContext } from './inputHandler'
+import { resetFishingStore } from '../stores/fishingStore'
+
+const RECT = { left: 0, top: 0, width: 100, height: 100 }
+
+/** A canvas click at the viewport center, as processCanvasClick consumes it. */
+function centerClick(): MouseEvent {
+  return {
+    clientX: RECT.width / 2,
+    clientY: RECT.height / 2,
+    target: { getBoundingClientRect: () => RECT },
+  } as unknown as MouseEvent
+}
+
+/** Camera 10m above the origin looking straight down at a flat ground plane
+ *  at y = 0 — the center click ray hits the ground at (0, 0, 0). */
+function groundScene() {
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100)
+  camera.position.set(0, 10, 0)
+  camera.lookAt(0, 0, 0)
+  camera.updateMatrixWorld(true)
+
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(100, 100))
+  ground.rotateX(-Math.PI / 2)
+  ground.updateMatrixWorld(true)
+
+  return { camera, ground }
+}
+
+function contextWith(
+  overrides: Partial<RaycastContext> = {}
+): RaycastContext {
+  const { camera, ground } = groundScene()
+  return {
+    camera,
+    monsterMeshes: [],
+    npcMeshes: [],
+    doorMeshes: [],
+    objectMeshes: [],
+    propMeshes: [],
+    groundItemMeshes: [],
+    groundMeshes: [ground],
+    playerPosition: { x: 0, y: 0, z: 0 },
+    playerFloorLevel: 0,
+    isMonsterDead: () => false,
+    ...overrides,
+  }
+}
+
+describe('processCanvasClick cast-vs-walk', () => {
+  beforeEach(() => {
+    resetFishingStore()
+    inputHandler.clearTransientInput()
+  })
+
+  it('casts when a rod is equipped and the click lands on deep enough water', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => 1.0,
+      })
+    )
+
+    expect(intent.type).toBe('cast_fishing')
+    if (intent.type === 'cast_fishing') {
+      expect(intent.position.x).toBeCloseTo(0)
+      expect(intent.position.z).toBeCloseTo(0)
+    }
+  })
+
+  it('walks when no rod is equipped, even over water', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: false,
+        waterSurfaceAt: () => 1.0,
+      })
+    )
+
+    expect(intent.type).toBe('move_to_ground')
+  })
+
+  it('walks when the water is too shallow to fish', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => MIN_FISHABLE_DEPTH_M - 0.05,
+      })
+    )
+
+    expect(intent.type).toBe('move_to_ground')
+  })
+
+  it('walks at exactly the minimum depth — the cast needs strictly deeper water', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => MIN_FISHABLE_DEPTH_M,
+      })
+    )
+
+    expect(intent.type).toBe('move_to_ground')
+  })
+
+  it('walks when no water sampler is wired up (dungeon / upper floors)', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({ canCastFishing: true })
+    )
+
+    expect(intent.type).toBe('move_to_ground')
+  })
+})

--- a/client/src/lib/managers/waterFieldManager.test.ts
+++ b/client/src/lib/managers/waterFieldManager.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WaterFieldManager } from './waterFieldManager'
+import {
+  WATER_FIELD_GRID,
+  type WaterFieldTileData,
+} from '../utils/water-field-data'
+import { SEA_LEVEL } from '../components/game-scene/terrain-utils'
+
+vi.mock('../utils/networkUtils', () => ({
+  getTerrainApiUrl: () => 'http://test',
+}))
+
+const decodeWaterFieldData = vi.hoisted(() => vi.fn())
+vi.mock('../utils/water-field-data', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/water-field-data')>()),
+  decodeWaterFieldData,
+}))
+
+function tileWithSurface(fill: (cx: number, cz: number) => number) {
+  const count = WATER_FIELD_GRID * WATER_FIELD_GRID
+  const surfaceY = new Float32Array(count)
+  for (let cz = 0; cz < WATER_FIELD_GRID; cz++) {
+    for (let cx = 0; cx < WATER_FIELD_GRID; cx++) {
+      surfaceY[cz * WATER_FIELD_GRID + cx] = fill(cx, cz)
+    }
+  }
+  const zeros = () => new Float32Array(count)
+  return {
+    surfaceY,
+    flowX: zeros(),
+    flowZ: zeros(),
+    riverness: zeros(),
+    turbulence: zeros(),
+  } satisfies WaterFieldTileData
+}
+
+function fetchResponding(status: number) {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  })) as unknown as typeof fetch
+}
+
+describe('WaterFieldManager', () => {
+  let manager: WaterFieldManager
+
+  beforeEach(() => {
+    manager = new WaterFieldManager()
+    decodeWaterFieldData.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('surfaceAt', () => {
+    it('returns sea level when the tile is not cached — never fetches on the click path', () => {
+      const fetchSpy = fetchResponding(200)
+      vi.stubGlobal('fetch', fetchSpy)
+
+      expect(manager.surfaceAt(0, 0)).toBe(SEA_LEVEL)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns the baked height inside a loaded tile', async () => {
+      vi.stubGlobal('fetch', fetchResponding(200))
+      decodeWaterFieldData.mockReturnValue(tileWithSurface(() => 5))
+      await manager.loadWaterField(0, 0)
+
+      expect(manager.surfaceAt(0, 0)).toBeCloseTo(5)
+      expect(manager.surfaceAt(-31.9, 31.9)).toBeCloseTo(5)
+    })
+
+    it('bilinearly interpolates between grid cells', async () => {
+      vi.stubGlobal('fetch', fetchResponding(200))
+      // 1m per cell; height = local x in meters makes interpolation visible.
+      decodeWaterFieldData.mockReturnValue(tileWithSurface((cx) => cx))
+      await manager.loadWaterField(0, 0)
+
+      // Tile 0 spans [-32, 32): world -32 is local 0, world -31.5 is local 0.5.
+      expect(manager.surfaceAt(-32, 0)).toBeCloseTo(0)
+      expect(manager.surfaceAt(-31.5, 0)).toBeCloseTo(0.5)
+      expect(manager.surfaceAt(0, 0)).toBeCloseTo(32)
+    })
+
+    it('returns sea level for a tile the server marked riverless (404)', async () => {
+      vi.stubGlobal('fetch', fetchResponding(404))
+      await manager.loadWaterField(0, 0)
+
+      expect(manager.surfaceAt(0, 0)).toBe(SEA_LEVEL)
+    })
+  })
+
+  describe('loadWaterField', () => {
+    it('fetches a tile once and serves repeats from cache', async () => {
+      const fetchSpy = fetchResponding(200)
+      vi.stubGlobal('fetch', fetchSpy)
+      decodeWaterFieldData.mockReturnValue(tileWithSurface(() => 1))
+
+      await manager.loadWaterField(0, 0)
+      await manager.loadWaterField(0, 0)
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches a 404 — a riverless tile is an answer, not an error', async () => {
+      const fetchSpy = fetchResponding(404)
+      vi.stubGlobal('fetch', fetchSpy)
+
+      expect(await manager.loadWaterField(0, 0)).toBeNull()
+      expect(await manager.loadWaterField(0, 0)).toBeNull()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('dedupes concurrent requests for the same tile', async () => {
+      const fetchSpy = fetchResponding(200)
+      vi.stubGlobal('fetch', fetchSpy)
+      decodeWaterFieldData.mockReturnValue(tileWithSurface(() => 1))
+
+      await Promise.all([
+        manager.loadWaterField(0, 0),
+        manager.loadWaterField(0, 0),
+      ])
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not cache a server error, so the next call retries', async () => {
+      const fetchSpy = fetchResponding(500)
+      vi.stubGlobal('fetch', fetchSpy)
+
+      expect(await manager.loadWaterField(0, 0)).toBeNull()
+      expect(await manager.loadWaterField(0, 0)).toBeNull()
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/client/src/lib/stores/fishingStore.test.ts
+++ b/client/src/lib/stores/fishingStore.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { get } from 'svelte/store'
+import {
+  applyStruggleTension,
+  fishingBobbers,
+  markBobberBite,
+  myFishing,
+  removeBobber,
+  resetFishingStore,
+  upsertBobber,
+  type StruggleRound,
+} from './fishingStore'
+
+const ID = 7
+
+function struggleRound(overrides: Partial<StruggleRound> = {}): StruggleRound {
+  return {
+    round: 1,
+    totalRounds: 3,
+    fishState: 'pulling',
+    respondWithinMs: 1200,
+    tension: 50,
+    ...overrides,
+  }
+}
+
+describe('myFishing transitions', () => {
+  beforeEach(() => {
+    resetFishingStore()
+  })
+
+  it('starts idle', () => {
+    expect(get(myFishing)).toEqual({ phase: 'idle' })
+  })
+
+  it('updates tension during a struggle', () => {
+    myFishing.set({ phase: 'struggle', struggle: struggleRound() })
+
+    applyStruggleTension(80)
+
+    const state = get(myFishing)
+    expect(state.phase).toBe('struggle')
+    if (state.phase === 'struggle') {
+      expect(state.struggle.tension).toBe(80)
+      expect(state.struggle.round).toBe(1)
+    }
+  })
+
+  it('ignores tension outside a struggle — a late RoundResult must not corrupt the phase', () => {
+    for (const phase of ['idle', 'casting', 'bite'] as const) {
+      myFishing.set({ phase })
+      applyStruggleTension(80)
+      expect(get(myFishing)).toEqual({ phase })
+    }
+  })
+})
+
+describe('fishingBobbers', () => {
+  beforeEach(() => {
+    resetFishingStore()
+  })
+
+  it('upserts a bobber without a bite', () => {
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+
+    expect(get(fishingBobbers).get(ID)).toEqual({
+      position: { x: 1, y: 0, z: 2 },
+      bite: false,
+    })
+  })
+
+  it('re-casting resets a previous bite', () => {
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+    markBobberBite(ID)
+    upsertBobber(ID, { x: 3, y: 0, z: 4 })
+
+    expect(get(fishingBobbers).get(ID)).toEqual({
+      position: { x: 3, y: 0, z: 4 },
+      bite: false,
+    })
+  })
+
+  it('marks a bite only for an existing bobber', () => {
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+
+    markBobberBite(ID)
+    markBobberBite(99)
+
+    const map = get(fishingBobbers)
+    expect(map.get(ID)?.bite).toBe(true)
+    expect(map.has(99)).toBe(false)
+  })
+
+  it('a bite for an unknown player does not touch the map — no spurious rerender', () => {
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+    const before = get(fishingBobbers)
+
+    markBobberBite(99)
+
+    expect(get(fishingBobbers)).toBe(before)
+  })
+
+  it('removes a bobber; removing an absent one keeps the same map', () => {
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+
+    removeBobber(ID)
+    expect(get(fishingBobbers).size).toBe(0)
+
+    const before = get(fishingBobbers)
+    removeBobber(ID)
+    expect(get(fishingBobbers)).toBe(before)
+  })
+
+  it('reset clears the phase and every bobber', () => {
+    myFishing.set({ phase: 'struggle', struggle: struggleRound() })
+    upsertBobber(ID, { x: 1, y: 0, z: 2 })
+
+    resetFishingStore()
+
+    expect(get(myFishing)).toEqual({ phase: 'idle' })
+    expect(get(fishingBobbers).size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Fills the client test gaps listed in `doc/TODO.md` (낚시 후속 / PR #53 review follow-ups):

> 클라이언트 테스트 공백: waterFieldManager.surfaceAt, processClick의 cast_fishing 분기, fishing 스토어 전이

- **`fishingStore.test.ts`** — `myFishing` phase transitions (tension only applies during a struggle, so a late `FishingRoundResult` can't corrupt the phase), bobber upsert/re-cast bite reset, no-op updates keep the same Map reference (no spurious re-render), reset.
- **`waterFieldManager.test.ts`** — `surfaceAt` returns sea level for uncached tiles without fetching on the click path, bilinear interpolation, 404 (riverless tile) is cached while server errors are retried, concurrent request dedupe.
- **`inputHandler.test.ts`** — `processCanvasClick` cast-vs-walk: rod + deep water → `cast_fishing`, no rod / shallow water / exact-threshold depth / missing sampler → `move_to_ground`. Uses a real THREE camera + ground-plane raycast.

## Test plan

- [x] `npx vitest run` — 348 passed (22 new)
- [x] `npm run lint` — clean
- [x] `npm run check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)