### PR TITLE
Tell the agent when a chase can't reach its monster

### DIFF
--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -26,6 +26,18 @@ use super::movement::{execute_move, MoveResult};
 /// the web client's grab moment partway into its pickup animation.
 const PICKUP_GRAB_DELAY_MS: u64 = 700;
 
+/// Feedback for an attack whose chase never reached the monster, so the agent
+/// stops re-issuing it. `dist` is the monster's distance, `None` if out of sight.
+fn unreachable_note(monster_id: &str, dist: Option<f32>) -> String {
+    match dist {
+        Some(d) => format!(
+            "[Unreachable] Could not reach monster {monster_id}: it is {d:.0}m away, \
+             too far or blocked. Move closer first, or pick a nearer monster."
+        ),
+        None => format!("[Unreachable] Monster {monster_id} is gone. Pick a different target."),
+    }
+}
+
 /// Parse and execute the agent's response.
 /// Returns the monster_id if the last action was an attack (for combat loop).
 /// If `memory_file` is set and the response contains `memory_update`, appends to file.
@@ -109,6 +121,13 @@ pub(super) async fn handle_response(
                 }
                 ChaseResult::Lost | ChaseResult::Error => {
                     warn!("Could not reach monster {monster_id}, skipping attack");
+                    let mut s = state.lock().await;
+                    let dist = s
+                        .self_player
+                        .as_ref()
+                        .zip(s.nearby_monsters.get(monster_id))
+                        .map(|(p, m)| m.position.dist_xz_sq(&p.position).sqrt());
+                    s.push_agent_event(unreachable_note(monster_id, dist));
                     continue;
                 }
             }
@@ -870,6 +889,20 @@ mod tests {
             resolve_ground_item(&s, &PickupRef::Name("Iron Sword".to_string())),
             Some((1, "iron_sword".to_string()))
         );
+    }
+
+    /// A too-far monster and a vanished one produce different guidance, so the
+    /// agent walks up to the first and drops the second instead of re-attacking.
+    #[test]
+    fn an_unreachable_attack_tells_the_agent_why() {
+        let present = unreachable_note("m19_21", Some(22.8));
+        assert!(present.contains("m19_21"));
+        assert!(present.contains("23m"));
+        assert!(present.to_lowercase().contains("closer"));
+
+        let gone = unreachable_note("m5_2", None);
+        assert!(gone.contains("m5_2"));
+        assert!(gone.to_lowercase().contains("gone"));
     }
 
     /// The item map reaches further than both the world state and the chase,


### PR DESCRIPTION
When an agent issues an `attack`, the client chases the monster and only sends the attack once it is in range. If the chase gives up — the monster is past the chase leash, walled off on a dungeon floor, or already gone — `execute.rs` logged a warning and skipped in silence. Nothing was written to the agent's event feed, so the LLM never learned the attack didn't happen.

The result is a loop: the agent re-issues the same `attack` on the same unreachable monster turn after turn. Running a DeepSeek ranger on the live server, I caught it retrying one monster **22.8m away six times over thirteen minutes** — never taking the ~3m step that would have closed the gap, one OpenRouter call each time. Across that session 202 attacks were skipped this way (121 because the monster sat past the leash, the rest blocked underground or timed out).

Every other failed action already reports back through an agent event (`[DealFailed]`, `[UseFailed]`, `[TradeError]`, …). The chase-failure path was the only silent one.

## Fix

On a failed chase, push an `[Unreachable]` event:

- monster still in sight → its current distance, with a nudge to move closer or pick a nearer target;
- monster gone → say so, so the agent retargets instead of walking to where a corpse used to be.

The agent then decides for itself: a hunter closes the distance or switches targets; a posted guard, whose prompt says *a post is a post*, reads the same note and stays put.

## Why not just widen the chase leash?

The gap exists because sight (27m) reaches further than the monster chase leash (`MAX_CHASE_DISTANCE`, 20m), so the agent is shown monsters it will not chase. Raising the leash to match sight was tempting, but that constant is deliberately short — it keeps guard NPCs from being lured off their post — so widening it would fix hunters at the cost of a guard-discipline regression. Feedback leaves the leash untouched and lets each role's own prompt make the call.

## Tested

- `cargo test -p agent-client` — 101 pass, including a new unit test covering the too-far vs. gone messages.
- `cargo fmt` and `cargo clippy` clean.
- Additive change: one helper plus the previously-silent match arm, in a single file.
