### PR TITLE
Add SIDLA data link harness for agent control (opt-in feature)

### DIFF
--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -22,5 +22,11 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 async-trait = "0.1"
 axum = "0.8"
 
+[features]
+default = []
+# Experimental: route agent turns through the SIDLA data link protocol
+# (`src/sidla`). Off by default — a default build compiles none of it.
+sidla = []
+
 [build-dependencies]
 serde_json = "1.0"

--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -95,6 +95,23 @@ max_tokens = 1024                              # Max response tokens
 temperature = 0.7
 reasoning_effort = "none"                      # "none"/"low"/"medium"/"high"; "" omits it for models that reject it
 
+# --- SIDLA data link (experimental) ---
+# Replaces the prose decision channel with header-based packets, validated
+# against a per-header field matrix, with a deterministic fallback when a
+# packet is rejected. See agent-client/src/sidla/README.md.
+#
+# Needs the `sidla` cargo feature as well as `enabled`; without the feature
+# this table is ignored, so the same config file works with either build:
+#   cargo run -p agent-client --features sidla
+#
+# May also go under a [[npcs]] entry to opt one agent in.
+# [sidla]
+# enabled = true
+# wire = "compact"                             # "compact" (fewer tokens) or "json" (readable in logs)
+# shuffle = false                              # vary interchangeable objectives across turns
+# shuffle_seed = 1397705793                    # a fixed seed replays a run exactly
+# log_frames = false                           # log every frame and rejected reply at debug level
+
 # --- Multi-NPC Orchestrator Mode ---
 # When [[npcs]] is present, legacy single-NPC fields above are ignored.
 # Each NPC gets its own WebSocket connection and LLM session.

--- a/agent-client/data/prompts/sidla_protocol.txt
+++ b/agent-client/data/prompts/sidla_protocol.txt
@@ -1,0 +1,40 @@
+=== SIDLA DATA LINK PROTOCOL ===
+Reply with SIDLA packets only. No prose, no explanation, no markdown outside
+the packets. One JSON object per line.
+
+WORLD STATE reaches you as packets, not sentences:
+  A = an entity reporting itself   B = how you identify an entity
+Reply with:
+  C = an action to take            D = an objective to adopt
+
+FIELD RULES (a packet breaking these is discarded and you lose the turn):
+  H=A  requires SUB, STA, LOC   optional HP    forbids IFF REL ACT TAR OBJ MSG
+  H=B  requires SUB, TAR, IFF   optional REL   forbids STA ACT OBJ LOC HP MSG
+  H=C  requires SUB, TAR, ACT   optional MSG   forbids IFF STA REL OBJ LOC HP
+  H=D  requires SUB, OBJ        optional TAR   forbids IFF STA REL ACT LOC HP MSG
+
+VALUES (integers only — never a word where a number belongs):
+  IFF  0 Unknown  1 Friend  2 Hostile  3 Neutral
+  STA  0 Idle  1 Moving  2 Engaged  3 Panic  4 Dead
+  ACT  0 None  1 Talk  2 Attack  3 Gift  4 Flee
+  OBJ  0 None  1 Patrol  2 Search  3 Defend  4 Escort  5 Ambush  6 Raid
+       7 Charge  8 Exterminate
+  REL  -100..100 integer     HP  0..100 integer
+  SUB  your own identifier, exactly as it appears in the frame
+  TAR  an identifier from the frame, exactly as spelled there
+  LOC  a zone name, or [x, y, z]
+  MSG  the words you speak; allowed only with ACT=1
+
+ATTACK targets a monster identifier. GIFT targets a player name. Do not
+invent an identifier the frame did not give you.
+
+Speaking is a C packet with ACT=1 and MSG. Say what your character would say,
+in their voice, in MSG — that is the one field where words belong.
+
+EXAMPLE
+  frame in:
+    A|Mika|0|12.0,0.0,3.0|100
+    A|slime_4|1|14.0,0.0,6.0|60
+    B|Mika|slime_4|2|-100
+  reply:
+    {"H":"C","SUB":"Mika","TAR":"slime_4","ACT":2}

--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -11,6 +11,8 @@ mod openai;
 mod openrouter;
 mod orchestrator;
 mod shop_info;
+#[cfg(feature = "sidla")]
+mod sidla;
 mod state;
 mod terrain_http;
 mod watch;
@@ -92,6 +94,10 @@ struct Config {
     /// Generic OpenAI-compatible endpoint config
     #[serde(default)]
     openai: openai::OpenAiConfig,
+    /// SIDLA data link config (see `sidla`); off unless enabled.
+    #[cfg(feature = "sidla")]
+    #[serde(default)]
+    sidla: sidla::SidlaConfig,
 }
 
 /// How the client proves who it is to the game server.
@@ -215,6 +221,10 @@ async fn main() -> anyhow::Result<()> {
         }
         if npc.openai == openai::OpenAiConfig::default() {
             npc.openai = config.openai.clone();
+        }
+        #[cfg(feature = "sidla")]
+        if npc.sidla == sidla::SidlaConfig::default() {
+            npc.sidla = config.sidla.clone();
         }
     }
 

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -155,6 +155,12 @@ pub struct NpcConfig {
     pub codex: CodexConfig,
     #[serde(default)]
     pub openai: OpenAiConfig,
+    /// Route this NPC's turns through the SIDLA data link (see `crate::sidla`).
+    /// Only present under the `sidla` feature; the `[sidla]` table is ignored
+    /// by a default build.
+    #[cfg(feature = "sidla")]
+    #[serde(default)]
+    pub sidla: crate::sidla::SidlaConfig,
 
     // --- Auto-provisioning ---
     /// Character name to create if no characters exist on this account.
@@ -861,6 +867,29 @@ fn build_llm_backend(
     }
 }
 
+/// Wrap the provider in whatever experimental layers are compiled in. The one
+/// switch point for opt-in features, so the default build has nothing to skip
+/// at runtime.
+#[cfg(feature = "sidla")]
+fn experimental_layers(
+    invoker: Arc<dyn driver::LlmBackend>,
+    npc: &NpcConfig,
+    state: &Arc<Mutex<SharedState>>,
+) -> Arc<dyn driver::LlmBackend> {
+    // Outermost, so the spectator panel records the data link frames rather
+    // than the envelope they were translated into.
+    crate::sidla::SidlaBackend::wrap(invoker, Arc::clone(state), npc.sidla.clone(), npc.label())
+}
+
+#[cfg(not(feature = "sidla"))]
+fn experimental_layers(
+    invoker: Arc<dyn driver::LlmBackend>,
+    _npc: &NpcConfig,
+    _state: &Arc<Mutex<SharedState>>,
+) -> Arc<dyn driver::LlmBackend> {
+    invoker
+}
+
 /// WS URL → REST base URL: an explicit port means game port + 1; otherwise
 /// same origin with the path dropped (the reverse proxy routes `/api/*`).
 fn api_base_url(server_url: &str) -> String {
@@ -892,6 +921,9 @@ fn spawn_llm_task(
     let activity_window = Duration::from_secs(npc.activity_window_secs);
 
     let invoker = build_llm_backend(npc, watch, scheduler.request_timeout())?;
+    // Experimental layers wrap the finished provider, so with none compiled in
+    // the driver receives exactly the backend it always did.
+    let invoker = experimental_layers(invoker, npc, state);
 
     let state = Arc::clone(state);
     let scheduler = scheduler.clone();

--- a/agent-client/src/sidla/README.md
+++ b/agent-client/src/sidla/README.md
@@ -1,0 +1,332 @@
+# SIDLA — Scenario Interaction Data Link Architecture
+
+An experimental control protocol for LLM-driven agents. Off by default: nothing
+here compiles into a default build.
+
+LLM 기반 에이전트를 위한 실험적 제어 프로토콜입니다. 기본값은 비활성이며, 기본
+빌드에는 이 디렉터리의 코드가 **컴파일되지 않습니다**.
+
+> **Reference / 참조**
+> SIDLA (Scenario Interaction Data Link Architecture for Computing Resource
+> Optimization and Deterministic AI Model and AI Agent Control, and Control
+> Method Using the Same) — KR 10-2026-0065736, filed 2026-04-11.
+> IPC A63F 13/45; CPC A63F 2300/51, G06N 3/0455, H04L 49/9057, H04L 69/26.
+> Contributed to this project by the applicant.
+> 출원인이 본 프로젝트에 기여한 것입니다.
+
+---
+
+## Why / 배경
+
+**EN.** An LLM asked "what do you do?" in prose answers in prose, and prose can
+say anything: an action that does not exist, a target that was never in sight, a
+field the situation forbids. `driver/execute.rs` already meets this by dropping
+any reply it cannot parse — which trades a hallucinated action for an NPC that
+stands still for a turn.
+
+SIDLA narrows the channel instead. World state goes out as packets rather than
+sentences, decisions come back as packets, and every packet is checked against
+the field matrix its header declares before anything reaches the game.
+
+**KO.** 자연어로 "무엇을 하겠는가"를 물으면 자연어로 답이 돌아오고, 자연어는 무엇이든
+말할 수 있습니다. 존재하지 않는 행동, 시야에 없던 대상, 해당 상황에서 금지된 필드까지
+말입니다. 현재 `driver/execute.rs`는 파싱할 수 없는 응답을 폐기하는 방식으로 이에
+대응하는데, 이는 환각 행동 대신 **한 턴 동안 멈춰 있는 NPC**를 얻는 거래입니다.
+
+SIDLA는 대신 채널 자체를 좁힙니다. 월드 상태는 문장이 아닌 패킷으로 나가고, 의사결정도
+패킷으로 돌아오며, 모든 패킷은 게임에 도달하기 전에 자신의 헤더가 선언한 필드 매트릭스에
+대해 검증됩니다.
+
+---
+
+## How / 동작 구조
+
+```
+SharedState ──encode──► A (PPLI) + B (Track) frame ──► provider
+                                                          │
+                            C (Engage) / D (Mission) ◄─────┘
+                                        │
+                                 schema::validate
+                                 ├─ admitted ─► decode ─► {thought, actions[]}
+                                 └─ rejected ─► fsm::decide ─► decode ─► same
+```
+
+**EN.** Three barriers stand between the model and the game:
+
+1. Control fields deserialize from integers only, so a word where an enum
+   belongs fails to parse (`packet.rs`).
+2. Each header fixes which fields must, may and must not appear; a packet
+   carrying a field outside its purpose is rejected whole (`schema.rs`).
+3. A rejected packet is answered by a deterministic ladder over the same world,
+   so refusing a reply costs behaviour rather than removing it (`fsm.rs`).
+
+What reaches the game is therefore always a packet the schema admits. The
+guarantee is structural — it does not depend on the model cooperating, and it
+holds for a model that returns nothing intelligible at all.
+
+Determinism follows from the same arrangement: the uplink is a pure function of
+the state snapshot and the downlink a pure function of the packets and that
+snapshot, so an unchanged world and an unchanged reply produce byte-identical
+commands. Where variety is wanted it is added afterwards by `shuffle.rs`, seeded
+so a run stays reproducible.
+
+**KO.** 모델과 게임 사이에 세 개의 장벽이 있습니다.
+
+1. 제어 필드는 정수만 역직렬화하므로, 열거형 자리에 단어가 오면 파싱 자체가 실패합니다
+   (`packet.rs`).
+2. 각 헤더가 필수·선택·금지 필드를 고정하므로, 목적을 벗어난 필드를 실은 패킷은 통째로
+   폐기됩니다 (`schema.rs`).
+3. 폐기된 패킷은 동일한 월드에 대한 결정론적 판정 계단으로 응답합니다. 즉 응답을
+   거부하는 대가는 **행동의 소실이 아니라 행동의 대체**입니다 (`fsm.rs`).
+
+따라서 게임에 도달하는 것은 항상 스키마가 허용한 패킷입니다. 이 보장은 **구조적**입니다.
+모델의 협조에 의존하지 않으며, 모델이 전혀 해독 불가능한 응답을 반환하는 경우에도
+유지됩니다.
+
+결정론성도 같은 배치에서 따라옵니다. 업링크는 상태 스냅샷의 순수 함수이고, 다운링크는
+패킷과 그 스냅샷의 순수 함수이므로, 월드와 응답이 동일하면 바이트 단위로 동일한 명령이
+생성됩니다. 다양성이 필요한 경우 `shuffle.rs`가 검증 이후에 시드 기반으로 부여하므로,
+실행 전체는 여전히 재현 가능합니다.
+
+---
+
+## Measured / 실측
+
+**EN.** From the test suite, on this codebase. Tokens are estimated at four
+characters each, and only ever used to compare two renderings of the same
+content.
+
+**KO.** 본 코드베이스의 테스트에서 실측한 값입니다. 토큰은 4문자 = 1토큰으로 근사했으며,
+동일 내용의 두 표현을 비교하는 용도로만 사용합니다.
+
+| Measurement / 측정 항목 | Result / 결과 |
+| :--- | :--- |
+| Determinism / 결정론성 | 1,000 encodings of one world → 1 distinct frame / 동일 월드 1,000회 인코딩 → 프레임 1종 |
+| Uplink, 1 entity / 업링크 1개체 | prose 32 tok → compact 25 tok (-22 %) |
+| Uplink, 64 entities / 업링크 64개체 | prose 1,229 tok → compact 1,150 tok (-6 %) |
+| Downlink / 다운링크 | envelope 66 tok → packet 15 tok (-77 %) |
+| Adversarial corpus / 적대적 입력 | 21 malformed replies → 0 reached the game, 0 turns lost / 21종 비정상 응답 → 게임 도달 0건, 턴 소실 0건 |
+
+**EN.** The uplink saving is modest and shrinks as the world fills up:
+`format_world_state` is already terse, so re-encoding it as packets buys little.
+**The saving is on the downlink**, because the model stops narrating its
+reasoning to reach a decision. Note also that the JSON wire is *more* expensive
+than prose (2,295 tok at 64 entities); `wire = "compact"` is the setting that
+pays, and `json` is for reading logs.
+
+Do not read the -77 % as the specification's +85 % efficiency figure verified —
+that figure compares against a full natural-language exchange, and this is one
+measurement of one channel on one codebase.
+
+**KO.** 업링크 절감은 작고, 월드가 채워질수록 줄어듭니다. `format_world_state`가 이미
+간결하므로 패킷으로 재인코딩해도 얻는 것이 적습니다. **절감은 다운링크에서 발생**합니다.
+모델이 결정에 도달하기 위해 추론을 서술하지 않게 되기 때문입니다. 또한 JSON 와이어는
+자연어보다 오히려 **비쌉니다** (64개체에서 2,295토큰). 이득이 있는 설정은
+`wire = "compact"`이고, `json`은 로그 판독용입니다.
+
+-77 %를 명세서의 +85 % 효율 수치가 검증된 것으로 읽어서는 안 됩니다. 해당 수치는 전체
+자연어 교환을 대상으로 하며, 여기 실측은 하나의 코드베이스에서 한 채널을 측정한 값입니다.
+
+---
+
+## Headers / 헤더 규격
+
+After the J-series message families a tactical data link uses.
+전술 데이터링크의 J-series 메시지 계열을 차용했습니다.
+
+| Header | Purpose / 목적 | Required / 필수 | Optional / 선택 | Forbidden / 금지 |
+| :--- | :--- | :--- | :--- | :--- |
+| A (PPLI) | own state and position / 자체 상태·위치 | SUB, STA, LOC | HP | IFF, REL, ACT, TAR, OBJ, MSG |
+| B (Track) | observation and identification / 관측·피아식별 | SUB, TAR, IFF | REL | STA, ACT, OBJ, LOC, HP, MSG |
+| C (Engage) | action and interaction / 행동·상호작용 | SUB, TAR, ACT | MSG | IFF, STA, REL, OBJ, LOC, HP |
+| D (Mission) | objective change / 상위 목표 변경 | SUB, OBJ | TAR | IFF, STA, REL, ACT, LOC, HP, MSG |
+
+**EN.** Splitting position (A) from identification (B) is what keeps the field
+sets disjoint: where an entity is, is its own report; how we read it, is ours.
+
+**KO.** 위치(A)와 피아식별(B)을 분리한 것이 필드 집합을 서로소로 유지하는 핵심입니다.
+개체가 어디 있는지는 그 개체 자신의 보고이고, 그것을 어떻게 식별하는지는 관측자의 몫입니다.
+
+---
+
+## Dictionary / 데이터 사전
+
+| Field | Values / 값 |
+| :--- | :--- |
+| `IFF` | 0 Unknown, 1 Friend, 2 Hostile, 3 Neutral |
+| `STA` | 0 Idle, 1 Moving, 2 Engaged, 3 Panic, 4 Dead |
+| `ACT` | 0 None, 1 Talk, 2 Attack, 3 Gift, 4 Flee |
+| `OBJ` | 0 None, 1 Patrol, 2 Search, 3 Defend, 4 Escort, 5 Ambush, 6 Raid, 7 Charge, 8 Exterminate |
+| `REL` | -100 - +100 integer |
+| `SUB` / `TAR` | entity identifier / 개체 식별자 |
+| `LOC` | zone name, or `[x, y, z]` |
+| `HP` | 0 - 100 integer (extension / 확장) |
+| `MSG` | spoken line, `ACT = 1` only (extension / 확장) |
+
+**EN.** `HP` and `MSG` are domain extensions, not part of the core dictionary: a
+game needs to know how hurt a target is, and a talking NPC needs somewhere to
+put the line it speaks. Both are confined to one header.
+
+A scenario designer controls behaviour by editing this table, not by editing a
+prompt.
+
+**KO.** `HP`와 `MSG`는 핵심 사전이 아닌 도메인 확장입니다. 게임은 대상이 얼마나 다쳤는지
+알아야 하고, 말하는 NPC는 대사를 담을 자리가 필요합니다. 둘 다 각각 하나의 헤더에만
+허용됩니다.
+
+시나리오 기획자는 프롬프트를 고치는 대신 **이 표를 관리**하여 행동을 통제합니다.
+
+### Identifiers / 식별자
+
+**EN.** `SUB` and `TAR` carry the identifier the engine itself uses — a monster
+by its instance id (`monster_slime_00c1`), a character by the name the server
+answers to. `encode.rs` fills them from the live world, and `decode.rs` refuses
+any identifier that was not in the frame it sent. The specification's worked
+example uses illustrative character names; those are not the wire format.
+
+**KO.** `SUB`와 `TAR`에는 엔진이 실제로 사용하는 식별자가 들어갑니다. 몬스터는 인스턴스
+id(`monster_slime_00c1`), 캐릭터는 서버가 인식하는 이름입니다. `encode.rs`가 실시간
+월드에서 이를 채우고, `decode.rs`는 자신이 보낸 프레임에 없던 식별자를 거부합니다.
+명세서의 실시예에 등장하는 캐릭터 이름은 어디까지나 예시이며, 와이어 포맷이 아닙니다.
+
+---
+
+## Enabling it / 활성화 방법
+
+**EN.** Two switches, both of which must be on. The compile-time one exists so a
+default build carries no risk from an experiment.
+
+**KO.** 두 개의 스위치가 모두 켜져야 합니다. 컴파일 타임 스위치는 기본 빌드가 실험 기능의
+위험을 전혀 지지 않도록 하기 위한 것입니다.
+
+```
+cargo run -p agent-client --features sidla
+```
+
+```toml
+# agent-client/data/config.toml
+[sidla]
+enabled = true
+wire = "compact"     # or "json", easier to read in a log / 로그 가독성 우선 시 "json"
+shuffle = false      # vary interchangeable objectives across turns / 등가 목표 변주
+shuffle_seed = 1397705793
+log_frames = false   # log every frame and rejected reply at debug level
+```
+
+**EN.** The table may also go under a `[[npcs]]` entry to opt one agent in.
+Without the `sidla` feature the table is ignored, so a config file is safe to
+share across both builds.
+
+**KO.** 이 테이블은 `[[npcs]]` 항목 아래에 두어 특정 에이전트 하나만 적용할 수도 있습니다.
+`sidla` 피처가 없으면 테이블은 무시되므로, 하나의 설정 파일을 두 빌드에서 공유해도
+안전합니다.
+
+---
+
+## Files / 파일 구성
+
+| File | Role / 역할 |
+| :--- | :--- |
+| `packet.rs` | header taxonomy, integer-only field enums, the `Packet` they assemble into / 헤더 분류, 정수 전용 열거형, 패킷 구조체 |
+| `schema.rs` | the field matrix, `validate`, `parse_frame`, the violation taxonomy / 필드 매트릭스, 검증, 위반 분류 |
+| `wire.rs` | JSON and compact renderings; frame splitting that tolerates fences and prose / 두 가지 렌더링, 프레임 분해 |
+| `encode.rs` | `SharedState` to packets, with no natural-language step / 상태를 패킷으로, 자연어 단계 없음 |
+| `decode.rs` | validated packets to the driver's existing action envelope / 검증된 패킷을 기존 액션 봉투로 |
+| `fsm.rs` | the deterministic ladder a rejected reply falls back to / 폐기 시 결정론적 폴백 |
+| `shuffle.rs` | seeded variation, applied after validation / 검증 이후 시드 기반 변주 |
+| `backend.rs` | the `LlmBackend` decorator that runs a turn / 한 턴을 수행하는 데코레이터 |
+
+---
+
+## Integration notes / 통합 메모
+
+**EN.** The layer sits behind `driver::LlmBackend` and emits the same
+`{thought, actions[]}` JSON the driver already parses, so `driver/*` is
+untouched. It wraps outermost — after `TimeoutBackend` and `WatchedBackend` — so
+the spectator panel records the data link frames rather than the envelope they
+were translated into. `experimental_layers` in `orchestrator.rs` is the single
+switch point.
+
+The uplink replaces the prose world state but keeps the driver's
+`=== EVENTS ===` section verbatim. A player's chat line is not a control field
+and has no packet form; only the machine-actionable channel is constrained.
+
+**KO.** 이 계층은 `driver::LlmBackend` 뒤에 위치하며 드라이버가 이미 파싱하는
+`{thought, actions[]}` JSON을 그대로 생성하므로 `driver/*`는 손대지 않았습니다.
+`TimeoutBackend`와 `WatchedBackend` 다음의 **최외곽**에서 감싸므로, 관전 패널에는
+변환된 봉투가 아니라 데이터링크 프레임이 기록됩니다. `orchestrator.rs`의
+`experimental_layers`가 유일한 스위치 지점입니다.
+
+업링크는 자연어 월드 상태를 대체하지만 드라이버의 `=== EVENTS ===` 구간은 그대로
+유지합니다. 플레이어의 채팅 한 줄은 제어 필드가 아니며 패킷 형태가 없습니다. 제약 대상은
+기계가 실행하는 채널뿐입니다.
+
+---
+
+## Known limits / 알려진 한계
+
+**EN.**
+
+- `REL` is derived from `IFF` (Friend +50, Hostile -100, otherwise 0). The game
+  has no relationship store yet; `encode::rel_from_iff` is the one place to
+  change when it does.
+- A `D` packet installs an objective, but the game has no standing-objective
+  system, so `decode` translates it into a single immediate action. Patrol and
+  search both become one waypoint.
+- `ACT = Gift` maps to `open_trade`, the nearest thing the game offers.
+- The inference side of the referenced architecture — a deterministic latent
+  state encoder (DGAE-WL) and a sub-2-bit quantised engine — is not implemented
+  here. This client calls external providers, so determinism is enforced at the
+  output boundary instead.
+
+**KO.**
+
+- `REL`은 `IFF`에서 파생합니다 (Friend +50, Hostile -100, 그 외 0). 게임에 관계 저장소가
+  아직 없기 때문이며, 도입 시 `encode::rel_from_iff` 한 곳만 교체하면 됩니다.
+- `D` 패킷은 목표를 설치하지만 게임에 상시 목표 시스템이 없으므로 `decode`가 즉시 행동
+  하나로 변환합니다. Patrol과 Search는 모두 하나의 경로점이 됩니다.
+- `ACT = Gift`는 게임이 제공하는 가장 가까운 기능인 `open_trade`로 매핑됩니다.
+- 참조 아키텍처의 추론 측면 — 결정론적 잠재 상태 인코더(DGAE-WL)와 2 bit 이하 양자화
+  엔진 — 은 여기 구현되지 않았습니다. 이 클라이언트는 외부 제공자를 호출하므로, 결정론성은
+  대신 **출력 경계에서** 강제됩니다.
+
+---
+
+## Where DGAE-WL would fit / DGAE-WL 접목 지점
+
+**EN.** Not implemented, recorded so the seam is not lost. A deterministic
+Gaussian autoencoder trained with a wristband loss maps a state vector to a
+fixed latent coordinate — identical input, identical coordinate, no sampling.
+Three places in this client could use one:
+
+1. **Turn deduplication.** `encode::encode` already produces a stable frame; the
+   latent coordinate of that frame is a cheap cache key. An agent whose world
+   has not meaningfully changed could reuse its last decision instead of
+   spending a provider call, which is the dominant cost at fleet scale.
+2. **Frame compression.** The uplink currently sends per-entity packets. A
+   latent coordinate for the local situation would replace the bulk of them,
+   holding the context window flat as entity count grows.
+3. **Behaviour-tree selection.** `monster_ai.rs` picks a tree by monster type. A
+   latent coordinate over the tactical situation is a natural index for choosing
+   among trees deterministically, keeping the property that makes trees
+   debuggable in the first place.
+
+All three want the encoder trained on recorded frames from this client, which is
+a separate piece of work from the protocol.
+
+**KO.** 구현하지 않았으나 접목 지점을 잃지 않도록 기록합니다. Wristband loss로 학습한
+결정론적 가우스 오토인코더는 상태 벡터를 고정 잠재 좌표로 매핑합니다. 동일 입력 → 동일
+좌표, 샘플링 없음. 이 클라이언트에서 활용 가능한 지점은 세 곳입니다.
+
+1. **턴 중복 제거.** `encode::encode`는 이미 안정적인 프레임을 생성하므로, 그 프레임의
+   잠재 좌표는 저렴한 캐시 키가 됩니다. 월드가 유의미하게 바뀌지 않은 에이전트는 제공자
+   호출을 소모하는 대신 직전 결정을 재사용할 수 있습니다. 함대 규모에서는 이 호출 비용이
+   지배적입니다.
+2. **프레임 압축.** 현재 업링크는 개체별 패킷을 보냅니다. 국소 상황에 대한 잠재 좌표가
+   그 대부분을 대체하면, 개체 수가 늘어도 컨텍스트 윈도우가 평탄하게 유지됩니다.
+3. **행동 트리 선택.** `monster_ai.rs`는 몬스터 타입으로 트리를 고릅니다. 전술 상황에 대한
+   잠재 좌표는 트리를 결정론적으로 선택하는 자연스러운 인덱스이며, 트리를 디버깅 가능하게
+   만드는 성질을 그대로 유지합니다.
+
+세 가지 모두 이 클라이언트에서 기록한 프레임으로 인코더를 학습시키는 작업을 필요로 하며,
+이는 프로토콜과는 별개의 작업입니다.

--- a/agent-client/src/sidla/backend.rs
+++ b/agent-client/src/sidla/backend.rs
@@ -1,0 +1,646 @@
+//! The `LlmBackend` decorator that puts the protocol on the wire.
+//!
+//! Wrapping the seam rather than editing the driver means the whole harness is
+//! opt-in and reversible: with `[sidla] enabled = false` the wrapper is never
+//! constructed and the agent behaves exactly as before.
+//!
+//! One turn: encode the world into an uplink frame, ask the wrapped provider,
+//! validate the reply, and translate it. A reply that fails validation is
+//! discarded and answered from `super::fsm` instead, so the driver downstream
+//! always receives a well-formed action envelope.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use super::{decode, encode, fsm, schema, shuffle, wire, SidlaConfig};
+use crate::driver::LlmBackend;
+use crate::state::SharedState;
+
+const PROTOCOL_BRIEF: &str = include_str!("../../data/prompts/sidla_protocol.txt");
+
+/// Marker the driver's prompt uses for the event log. Everything above it is
+/// the world state the uplink frame replaces; the events themselves stay as
+/// they are, because a player's chat line is not a control field.
+const EVENTS_MARKER: &str = "=== EVENTS ===";
+
+/// Counts of what the validator did, for the operator to read.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Stats {
+    pub turns: u64,
+    pub accepted: u64,
+    pub discarded: u64,
+}
+
+impl Stats {
+    /// Share of turns answered by the fallback rather than the provider.
+    pub fn fallback_rate(&self) -> f64 {
+        if self.turns == 0 {
+            return 0.0;
+        }
+        self.discarded as f64 / self.turns as f64
+    }
+}
+
+pub struct SidlaBackend {
+    inner: Arc<dyn LlmBackend>,
+    state: Arc<Mutex<SharedState>>,
+    config: SidlaConfig,
+    label: String,
+    turn: AtomicU64,
+    stats: std::sync::Mutex<Stats>,
+}
+
+impl SidlaBackend {
+    /// Wrap `inner`, or hand it back untouched when the harness is off.
+    pub fn wrap(
+        inner: Arc<dyn LlmBackend>,
+        state: Arc<Mutex<SharedState>>,
+        config: SidlaConfig,
+        label: &str,
+    ) -> Arc<dyn LlmBackend> {
+        if !config.enabled {
+            return inner;
+        }
+        info!(
+            "[{label}] SIDLA data link enabled (wire={:?}, shuffle={})",
+            config.wire, config.shuffle
+        );
+        Arc::new(Self {
+            inner,
+            state,
+            config,
+            label: label.to_string(),
+            turn: AtomicU64::new(0),
+            stats: std::sync::Mutex::new(Stats::default()),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn stats(&self) -> Stats {
+        *self.stats.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn record(&self, accepted: bool) -> Stats {
+        let mut stats = self.stats.lock().unwrap_or_else(|e| e.into_inner());
+        stats.turns += 1;
+        if accepted {
+            stats.accepted += 1;
+        } else {
+            stats.discarded += 1;
+        }
+        *stats
+    }
+
+    /// Uplink frame: the protocol brief, the encoded world, and whatever event
+    /// log the driver had appended to its own prompt.
+    fn frame(&self, uplink: &encode::Uplink, driver_prompt: &str) -> String {
+        let mut out = String::with_capacity(PROTOCOL_BRIEF.len() + 512);
+        out.push_str(PROTOCOL_BRIEF);
+        out.push_str("\n=== FRAME ===\n");
+        out.push_str(&wire::render(&uplink.packets, self.config.wire));
+        out.push('\n');
+        if let Some(events) = driver_prompt.split_once(EVENTS_MARKER) {
+            out.push_str("\n=== EVENTS ===");
+            out.push_str(events.1.trim_end());
+            out.push('\n');
+        }
+        out.push_str("\nReply with SIDLA packets.");
+        out
+    }
+}
+
+#[async_trait]
+impl LlmBackend for SidlaBackend {
+    async fn send_message(&self, content: &str) -> anyhow::Result<String> {
+        let uplink = {
+            let state = self.state.lock().await;
+            encode::encode(&state)
+        };
+
+        let turn = self.turn.fetch_add(1, Ordering::Relaxed);
+        let variation = if self.config.shuffle {
+            shuffle::turn_seed(self.config.shuffle_seed, turn)
+        } else {
+            self.config.shuffle_seed
+        };
+
+        let frame = self.frame(&uplink, content);
+        if self.config.log_frames {
+            debug!("[{}] SIDLA uplink:\n{frame}", self.label);
+        }
+
+        let reply = self.inner.send_message(&frame).await?;
+        let envelope = match self.transcode(&reply, &uplink, variation) {
+            Ok(envelope) => {
+                self.record(true);
+                envelope
+            }
+            Err(violation) => {
+                let stats = self.record(false);
+                warn!(
+                    "[{}] SIDLA packet discarded ({violation}); falling back \
+                     ({}/{} turns, {:.0}%)",
+                    self.label,
+                    stats.discarded,
+                    stats.turns,
+                    stats.fallback_rate() * 100.0
+                );
+                if self.config.log_frames {
+                    debug!("[{}] SIDLA rejected downlink:\n{reply}", self.label);
+                }
+                self.fallback(&uplink, variation)?
+            }
+        };
+        Ok(envelope.to_string())
+    }
+}
+
+impl SidlaBackend {
+    fn transcode(
+        &self,
+        reply: &str,
+        uplink: &encode::Uplink,
+        variation: u64,
+    ) -> Result<serde_json::Value, schema::Violation> {
+        let packets = schema::parse_frame(reply)?;
+        let packets: Vec<_> = if self.config.shuffle {
+            packets
+                .iter()
+                .map(|p| shuffle::vary(p, variation))
+                .collect()
+        } else {
+            packets
+        };
+        decode::to_envelope(&packets, uplink, variation)
+    }
+
+    /// The fallback must itself be translatable; if it somehow is not, the
+    /// agent waits rather than acting on nothing.
+    fn fallback(
+        &self,
+        uplink: &encode::Uplink,
+        variation: u64,
+    ) -> anyhow::Result<serde_json::Value> {
+        let packet = fsm::decide(uplink);
+        schema::validate(&packet)
+            .map_err(|e| anyhow::anyhow!("SIDLA fallback produced an invalid packet: {e}"))?;
+        Ok(
+            decode::to_envelope(&[packet], uplink, variation).unwrap_or_else(|_| {
+                serde_json::json!({
+                    "thought": "SIDLA fallback: holding",
+                    "actions": [{"type": "wait"}],
+                })
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::packet::Header;
+    use crate::sidla::Wire;
+    use crate::state::tests::test_state;
+    use onlinerpg_shared::{
+        CharacterClass, ClientMessage, Monster, MonsterState, Player, PlayerId, Position,
+    };
+    use tokio::sync::mpsc::Receiver;
+
+    /// Keeps the command receiver alive for the duration of a test; nothing
+    /// here sends commands, but a live channel matches the real setup.
+    struct World {
+        state: Arc<Mutex<SharedState>>,
+        _rx: Receiver<ClientMessage>,
+    }
+
+    struct Canned(String);
+
+    #[async_trait]
+    impl LlmBackend for Canned {
+        async fn send_message(&self, _content: &str) -> anyhow::Result<String> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct Echo;
+
+    #[async_trait]
+    impl LlmBackend for Echo {
+        async fn send_message(&self, content: &str) -> anyhow::Result<String> {
+            Ok(content.to_string())
+        }
+    }
+
+    fn pos(x: f32, z: f32) -> Position {
+        Position { x, y: 0.0, z }
+    }
+
+    fn world() -> World {
+        let (mut state, rx) = test_state();
+        let me = Player {
+            id: PlayerId::from(1),
+            name: "Mika".into(),
+            position: pos(0.0, 0.0),
+            rotation: 0.0,
+            level: 3,
+            health: 100,
+            max_health: 100,
+            class: CharacterClass::Knight,
+            gender: Default::default(),
+            is_official_npc: false,
+            torch_on: false,
+            floor_level: 0,
+            object_type: None,
+            main_hand: None,
+            object_id: None,
+            last_combat_at: 0,
+            client_kind: Default::default(),
+        };
+        state.self_player_id = Some(me.id);
+        state.self_player = Some(me);
+        state.nearby_monsters.insert(
+            "slime_1".into(),
+            Monster {
+                id: "slime_1".into(),
+                monster_type: "slime".into(),
+                position: pos(0.0, 5.0),
+                rotation: 0.0,
+                state: MonsterState::Idle,
+                owner_id: None,
+                health: 10,
+                max_health: 10,
+                floor_level: 0,
+                level_override: None,
+                aggressive: true,
+                last_attack_at: 0,
+                last_move_at: 0,
+                move_budget: 0.0,
+            },
+        );
+        World {
+            state: Arc::new(Mutex::new(state)),
+            _rx: rx,
+        }
+    }
+
+    fn harness(reply: &str, config: SidlaConfig) -> (Arc<dyn LlmBackend>, World) {
+        let world = world();
+        let backend = SidlaBackend::wrap(
+            Arc::new(Canned(reply.to_string())),
+            Arc::clone(&world.state),
+            config,
+            "test",
+        );
+        (backend, world)
+    }
+
+    fn enabled() -> SidlaConfig {
+        SidlaConfig {
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    async fn envelope_of(backend: &Arc<dyn LlmBackend>) -> serde_json::Value {
+        let out = backend.send_message("").await.unwrap();
+        serde_json::from_str(&out).expect("envelope is not JSON")
+    }
+
+    #[tokio::test]
+    async fn a_disabled_harness_does_not_wrap_the_provider() {
+        let world = world();
+        let inner: Arc<dyn LlmBackend> = Arc::new(Canned("untouched".into()));
+        let wrapped = SidlaBackend::wrap(
+            Arc::clone(&inner),
+            Arc::clone(&world.state),
+            SidlaConfig::default(),
+            "test",
+        );
+        assert_eq!(wrapped.send_message("anything").await.unwrap(), "untouched");
+    }
+
+    #[tokio::test]
+    async fn a_valid_engage_packet_becomes_an_attack_action() {
+        let (backend, _world) = harness(
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2}"#,
+            enabled(),
+        );
+        let envelope = envelope_of(&backend).await;
+        assert_eq!(envelope["actions"][0]["type"], "attack");
+        assert_eq!(envelope["actions"][0]["monster_id"], "slime_1");
+    }
+
+    /// The uplink replaces the prose world state but keeps the event log,
+    /// which carries things — a player's chat line — that are not control
+    /// fields and have no packet form.
+    #[tokio::test]
+    async fn the_frame_carries_the_brief_the_packets_and_the_events() {
+        let world = world();
+        let uplink = {
+            let state = world.state.lock().await;
+            encode::encode(&state)
+        };
+        let backend = SidlaBackend {
+            inner: Arc::new(Echo),
+            state: Arc::clone(&world.state),
+            config: SidlaConfig {
+                enabled: true,
+                wire: Wire::Json,
+                ..Default::default()
+            },
+            label: "test".into(),
+            turn: AtomicU64::new(0),
+            stats: std::sync::Mutex::new(Stats::default()),
+        };
+        let driver_prompt = "=== CURRENT STATE ===\n\
+             You: Mika Lv.3 Knight HP 100/100 at (0.0, 0.0, 0.0)\n\
+             === EVENTS ===\n[Chat] Bob: hello there";
+        let frame = backend.frame(&uplink, driver_prompt);
+
+        assert!(frame.contains("SIDLA DATA LINK PROTOCOL"));
+        assert!(frame.contains(r#"{"H":"A","SUB":"Mika""#));
+        assert!(frame.contains(r#"{"H":"B","SUB":"Mika","TAR":"slime_1","IFF":2"#));
+        assert!(frame.contains("[Chat] Bob: hello there"));
+        assert!(
+            !frame.contains("Lv.3 Knight"),
+            "prose world state leaked into the frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_compact_wire_carries_the_same_frame_without_the_key_names() {
+        let world = world();
+        let uplink = {
+            let state = world.state.lock().await;
+            encode::encode(&state)
+        };
+        let backend = SidlaBackend {
+            inner: Arc::new(Echo),
+            state: Arc::clone(&world.state),
+            config: enabled(),
+            label: "test".into(),
+            turn: AtomicU64::new(0),
+            stats: std::sync::Mutex::new(Stats::default()),
+        };
+        let frame = backend.frame(&uplink, "=== CURRENT STATE ===\n");
+        let packets = frame.split_once("=== FRAME ===").expect("frame section").1;
+        assert!(packets.contains("A|Mika|"), "{packets}");
+        assert!(packets.contains("B|Mika|slime_1|2|-100"), "{packets}");
+        assert!(
+            !packets.contains(r#""SUB""#),
+            "json keys in a compact frame: {packets}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_frame_without_events_omits_the_section() {
+        let world = world();
+        let uplink = {
+            let state = world.state.lock().await;
+            encode::encode(&state)
+        };
+        let backend = SidlaBackend {
+            inner: Arc::new(Echo),
+            state: Arc::clone(&world.state),
+            config: enabled(),
+            label: "test".into(),
+            turn: AtomicU64::new(0),
+            stats: std::sync::Mutex::new(Stats::default()),
+        };
+        assert!(!backend
+            .frame(&uplink, "=== CURRENT STATE ===\n")
+            .contains("EVENTS"));
+    }
+
+    #[tokio::test]
+    async fn prose_instead_of_packets_falls_back_to_a_valid_action() {
+        let (backend, _world) = harness(
+            "I think Mika should probably talk to the slime first.",
+            enabled(),
+        );
+        let envelope = envelope_of(&backend).await;
+        let actions = envelope["actions"].as_array().unwrap();
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0]["type"], "attack");
+    }
+
+    #[tokio::test]
+    async fn a_forbidden_field_falls_back_rather_than_being_stripped() {
+        let (backend, _world) = harness(
+            r#"{"H":"A","SUB":"Mika","STA":0,"LOC":"Cafe","TAR":"slime_1"}"#,
+            enabled(),
+        );
+        let envelope = envelope_of(&backend).await;
+        assert!(envelope["thought"].as_str().unwrap().starts_with("SIDLA"));
+        assert_eq!(envelope["actions"][0]["type"], "attack");
+    }
+
+    #[tokio::test]
+    async fn an_invented_target_falls_back() {
+        let (backend, _world) = harness(
+            r#"{"H":"C","SUB":"Mika","TAR":"ancient_dragon","ACT":2}"#,
+            enabled(),
+        );
+        let envelope = envelope_of(&backend).await;
+        assert_eq!(envelope["actions"][0]["monster_id"], "slime_1");
+    }
+
+    #[tokio::test]
+    async fn every_turn_yields_an_envelope_the_driver_can_parse() {
+        let replies = [
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2}"#,
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":"attack"}"#,
+            r#"{"H":"A","SUB":"Mika","STA":4,"LOC":[0,0,0]}"#,
+            r#"{"H":"D","SUB":"Mika","OBJ":1}"#,
+            r#"{"H":"Z","SUB":"Mika"}"#,
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2,"HP":50}"#,
+            "",
+            "```json\n{\"H\":\"C\",\"SUB\":\"Mika\",\"TAR\":\"slime_1\",\"ACT\":1,\"MSG\":\"Back!\"}\n```",
+            "{}",
+            "null",
+            r#"{"H":"B","SUB":"Mika","TAR":"slime_1","IFF":2,"REL":-9999}"#,
+        ];
+        for reply in replies {
+            let (backend, _world) = harness(reply, enabled());
+            let out = backend.send_message("").await.unwrap();
+            let envelope: serde_json::Value = serde_json::from_str(&out)
+                .unwrap_or_else(|e| panic!("unparseable envelope for `{reply}`: {e}"));
+            let actions = envelope["actions"]
+                .as_array()
+                .unwrap_or_else(|| panic!("no actions for `{reply}`"));
+            assert!(!actions.is_empty(), "empty actions for `{reply}`");
+            assert!(
+                actions.iter().all(|a| a["type"].is_string()),
+                "untyped action for `{reply}`"
+            );
+        }
+    }
+
+    /// The structural claim, stated as a property: over a corpus of replies
+    /// that are wrong in every way a model can be wrong, no command reaching
+    /// the game names an entity the world did not contain, and no turn is
+    /// lost. The guarantee does not depend on the model cooperating.
+    #[tokio::test]
+    async fn nothing_unreal_reaches_the_game() {
+        let corpus = [
+            // Invented targets.
+            r#"{"H":"C","SUB":"Mika","TAR":"ancient_dragon","ACT":2}"#,
+            r#"{"H":"C","SUB":"Mika","TAR":"","ACT":2}"#,
+            r#"{"H":"D","SUB":"Mika","OBJ":8,"TAR":"lich_king"}"#,
+            // Prose where a code belongs.
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":"attack the slime"}"#,
+            r#"{"H":"A","SUB":"Mika","STA":"idle","LOC":"nowhere"}"#,
+            // Codes outside the dictionary.
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":42}"#,
+            r#"{"H":"B","SUB":"Mika","TAR":"slime_1","IFF":-1}"#,
+            // Fields the header forbids.
+            r#"{"H":"A","SUB":"Mika","STA":0,"LOC":"Cafe","ACT":2,"TAR":"slime_1"}"#,
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2,"LOC":[9,9,9]}"#,
+            // Missing what the header requires.
+            r#"{"H":"C","SUB":"Mika"}"#,
+            r#"{"H":"D"}"#,
+            // Invented fields and headers.
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2,"SPELL":"meteor"}"#,
+            r#"{"H":"X","SUB":"Mika","TAR":"slime_1","ACT":2}"#,
+            // Not a packet at all.
+            "Mika attacks the slime with her sword.",
+            "",
+            "{",
+            "[]",
+            "null",
+            "```json\n{}\n```",
+            // Well formed, but observation only.
+            r#"{"H":"B","SUB":"Mika","TAR":"slime_1","IFF":2}"#,
+            // Well formed and actionable — the control case.
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2}"#,
+        ];
+
+        // The only entity in this world besides the agent itself.
+        let real = ["slime_1"];
+
+        for reply in corpus {
+            let (backend, _world) = harness(reply, enabled());
+            let envelope = envelope_of(&backend).await;
+            let actions = envelope["actions"]
+                .as_array()
+                .unwrap_or_else(|| panic!("no actions array for `{reply}`"));
+
+            assert!(!actions.is_empty(), "turn lost for `{reply}`");
+            for action in actions {
+                assert!(
+                    action["type"].is_string(),
+                    "untyped action for `{reply}`: {action}"
+                );
+                for key in ["monster_id", "player", "target"] {
+                    if let Some(named) = action[key].as_str() {
+                        assert!(
+                            real.contains(&named),
+                            "`{reply}` reached the game naming `{named}`"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn the_same_reply_and_world_always_produce_the_same_envelope() {
+        let (backend, _world) = harness(
+            r#"{"H":"C","SUB":"Mika","TAR":"slime_1","ACT":2}"#,
+            enabled(),
+        );
+        let first = backend.send_message("").await.unwrap();
+        for _ in 0..16 {
+            assert_eq!(backend.send_message("").await.unwrap(), first);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_rejected_reply_falls_back_identically_every_time() {
+        let (backend, _world) = harness("no packets here", enabled());
+        let first = backend.send_message("").await.unwrap();
+        for _ in 0..16 {
+            assert_eq!(backend.send_message("").await.unwrap(), first);
+        }
+    }
+
+    #[tokio::test]
+    async fn shuffling_varies_an_idle_objective_across_turns() {
+        let config = SidlaConfig {
+            enabled: true,
+            shuffle: true,
+            shuffle_seed: 4321,
+            ..Default::default()
+        };
+        let world = world();
+        let backend = SidlaBackend::wrap(
+            Arc::new(Canned(r#"{"H":"D","SUB":"Mika","OBJ":1}"#.into())),
+            Arc::clone(&world.state),
+            config,
+            "test",
+        );
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..64 {
+            seen.insert(envelope_of(&backend).await["actions"][0].to_string());
+        }
+        assert!(seen.len() > 1, "shuffling produced no variety");
+    }
+
+    #[tokio::test]
+    async fn statistics_separate_accepted_turns_from_discarded_ones() {
+        let world = world();
+        let backend = SidlaBackend {
+            inner: Arc::new(Canned("prose".into())),
+            state: Arc::clone(&world.state),
+            config: enabled(),
+            label: "test".into(),
+            turn: AtomicU64::new(0),
+            stats: std::sync::Mutex::new(Stats::default()),
+        };
+        for _ in 0..4 {
+            backend.send_message("").await.unwrap();
+        }
+        let stats = backend.stats();
+        assert_eq!(stats.turns, 4);
+        assert_eq!(stats.discarded, 4);
+        assert_eq!(stats.accepted, 0);
+        assert!((stats.fallback_rate() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn a_provider_error_is_not_swallowed_by_the_fallback() {
+        struct Failing;
+        #[async_trait]
+        impl LlmBackend for Failing {
+            async fn send_message(&self, _content: &str) -> anyhow::Result<String> {
+                Err(anyhow::anyhow!("endpoint down"))
+            }
+        }
+        let world = world();
+        let backend = SidlaBackend::wrap(
+            Arc::new(Failing),
+            Arc::clone(&world.state),
+            enabled(),
+            "test",
+        );
+        assert!(backend.send_message("").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn the_uplink_frame_is_schema_valid_and_header_split() {
+        let world = world();
+        let uplink = {
+            let s = world.state.lock().await;
+            encode::encode(&s)
+        };
+        assert!(uplink.packets.iter().any(|p| p.h == Header::A));
+        assert!(uplink.packets.iter().any(|p| p.h == Header::B));
+        for packet in &uplink.packets {
+            schema::validate(packet).unwrap();
+        }
+    }
+}

--- a/agent-client/src/sidla/decode.rs
+++ b/agent-client/src/sidla/decode.rs
@@ -1,0 +1,409 @@
+//! Downlink: validated packets to the action envelope the driver already
+//! speaks.
+//!
+//! Emitting the existing `{thought, actions}` JSON rather than driver types
+//! keeps the protocol layer behind the backend seam — nothing downstream of
+//! `LlmBackend` needs to know SIDLA exists.
+//!
+//! Only C (Engage) and D (Mission) carry decisions. A and B are telemetry
+//! echoed back by the agent; the one exception is the subject reporting its
+//! own death, which is a fact the engine must act on.
+
+use serde_json::{json, Value};
+
+use super::encode::{EntityKind, Uplink};
+use super::packet::{Act, EntityId, Header, Obj, Packet};
+use super::schema::Violation;
+use super::shuffle;
+
+/// How far a flee action puts between the agent and what it is fleeing.
+const FLEE_DISTANCE: f32 = 15.0;
+/// Radius of the waypoint a patrol or search objective walks to.
+const PATROL_RADIUS: f32 = 12.0;
+
+/// Translate a validated frame. `variation` seeds the deterministic choice of
+/// heading for objectives that name no target; the same value always yields
+/// the same heading.
+pub fn to_envelope(
+    packets: &[Packet],
+    uplink: &Uplink,
+    variation: u64,
+) -> Result<Value, Violation> {
+    let mut actions: Vec<Value> = Vec::new();
+    let mut trace: Vec<String> = Vec::new();
+
+    for packet in packets {
+        let action = match packet.h {
+            Header::A => self_death(packet, uplink),
+            Header::B => None,
+            Header::C => engage(packet, uplink)?,
+            Header::D => mission(packet, uplink, variation)?,
+        };
+        if let Some(action) = action {
+            trace.push(summarise(packet));
+            actions.push(action);
+        }
+    }
+
+    if actions.is_empty() {
+        return Err(Violation::NoCommand);
+    }
+
+    Ok(json!({
+        "thought": format!("SIDLA {}", trace.join("; ")),
+        "actions": actions,
+    }))
+}
+
+/// The subject reporting `STA = Dead` is the one A packet that commands
+/// something. Another entity's death is just an observation.
+fn self_death(packet: &Packet, uplink: &Uplink) -> Option<Value> {
+    let is_subject = packet.sub.as_ref() == Some(&uplink.subject);
+    let dead = packet.sta == Some(super::packet::Sta::Dead);
+    (is_subject && dead).then(|| json!({"type": "respawn"}))
+}
+
+fn engage(packet: &Packet, uplink: &Uplink) -> Result<Option<Value>, Violation> {
+    let act = packet.act.ok_or(Violation::MissingRequired {
+        header: Header::C,
+        field: super::packet::Field::Act,
+    })?;
+    let tar = packet.tar.as_ref().ok_or(Violation::MissingRequired {
+        header: Header::C,
+        field: super::packet::Field::Tar,
+    })?;
+
+    match act {
+        Act::None => Ok(Some(json!({"type": "wait"}))),
+        Act::Talk => match &packet.msg {
+            Some(msg) => Ok(Some(json!({"type": "say", "message": msg}))),
+            None => Ok(Some(json!({"type": "move", "target": tar.to_string()}))),
+        },
+        Act::Attack => match kind_of(tar, uplink) {
+            Some(EntityKind::Monster(id)) => Ok(Some(json!({"type": "attack", "monster_id": id}))),
+            _ => Err(unknown_target(tar, "attack")),
+        },
+        Act::Gift => match kind_of(tar, uplink) {
+            Some(EntityKind::Player(name)) => {
+                Ok(Some(json!({"type": "open_trade", "player": name})))
+            }
+            _ => Err(unknown_target(tar, "gift")),
+        },
+        Act::Flee => Ok(Some(flee_from(tar, uplink))),
+    }
+}
+
+fn mission(packet: &Packet, uplink: &Uplink, variation: u64) -> Result<Option<Value>, Violation> {
+    let obj = packet.obj.ok_or(Violation::MissingRequired {
+        header: Header::D,
+        field: super::packet::Field::Obj,
+    })?;
+
+    let action = match obj {
+        Obj::None | Obj::Defend | Obj::Ambush => json!({"type": "wait"}),
+        Obj::Patrol | Obj::Search => waypoint(uplink, variation),
+        Obj::Escort => {
+            let tar = packet.tar.as_ref().ok_or(Violation::MissingRequired {
+                header: Header::D,
+                field: super::packet::Field::Tar,
+            })?;
+            json!({"type": "move", "target": tar.to_string()})
+        }
+        Obj::Raid | Obj::Charge | Obj::Exterminate => match nearest_hostile(packet, uplink) {
+            Some(id) => json!({"type": "attack", "monster_id": id}),
+            None => json!({"type": "wait"}),
+        },
+    };
+    Ok(Some(action))
+}
+
+/// A named target takes precedence; without one, the nearest hostile monster
+/// in the uplink is the objective's subject.
+fn nearest_hostile(packet: &Packet, uplink: &Uplink) -> Option<String> {
+    if let Some(tar) = packet.tar.as_ref() {
+        if let Some(EntityKind::Monster(id)) = kind_of(tar, uplink) {
+            return Some(id);
+        }
+    }
+    uplink.hostiles().find_map(|t| match &t.kind {
+        EntityKind::Monster(id) => Some(id.clone()),
+        _ => None,
+    })
+}
+
+fn kind_of(id: &EntityId, uplink: &Uplink) -> Option<EntityKind> {
+    uplink.find(id).map(|t| t.kind.clone())
+}
+
+fn unknown_target(id: &EntityId, verb: &str) -> Violation {
+    Violation::Malformed(format!(
+        "cannot {verb} `{id}`: not a tracked target of that kind"
+    ))
+}
+
+/// Walk directly away from the target. Without positions for both there is
+/// nothing to compute a heading from, so the agent holds instead of guessing.
+fn flee_from(tar: &EntityId, uplink: &Uplink) -> Value {
+    let (Some(from), Some(track)) = (uplink.subject_position.as_ref(), uplink.find(tar)) else {
+        return json!({"type": "wait"});
+    };
+    let (dx, dz) = (from.x - track.position.x, from.z - track.position.z);
+    let len = (dx * dx + dz * dz).sqrt();
+    if len < f32::EPSILON {
+        return json!({"type": "wait"});
+    }
+    json!({
+        "type": "move",
+        "x": round1(from.x + dx / len * FLEE_DISTANCE),
+        "z": round1(from.z + dz / len * FLEE_DISTANCE),
+    })
+}
+
+/// A patrol waypoint on a circle around the current position. The heading
+/// comes from `variation`, so a fixed seed patrols the same spot every turn
+/// and a varying one sweeps the area.
+fn waypoint(uplink: &Uplink, variation: u64) -> Value {
+    let Some(from) = uplink.subject_position.as_ref() else {
+        return json!({"type": "wait"});
+    };
+    let angle = shuffle::unit_fraction(variation) * std::f32::consts::TAU;
+    json!({
+        "type": "move",
+        "x": round1(from.x + angle.cos() * PATROL_RADIUS),
+        "z": round1(from.z + angle.sin() * PATROL_RADIUS),
+    })
+}
+
+fn round1(v: f32) -> f32 {
+    (v * 10.0).round() / 10.0
+}
+
+fn summarise(packet: &Packet) -> String {
+    let mut parts = vec![packet.h.as_str().to_string()];
+    if let Some(act) = packet.act {
+        parts.push(format!("ACT={}", act.code()));
+    }
+    if let Some(obj) = packet.obj {
+        parts.push(format!("OBJ={}", obj.code()));
+    }
+    if let Some(sta) = packet.sta {
+        parts.push(format!("STA={}", sta.code()));
+    }
+    if let Some(tar) = packet.tar.as_ref() {
+        parts.push(format!("TAR={tar}"));
+    }
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::encode::Track;
+    use crate::sidla::packet::{Iff, Loc, Sta};
+    use onlinerpg_shared::Position;
+
+    fn pos(x: f32, z: f32) -> Position {
+        Position { x, y: 0.0, z }
+    }
+
+    fn track(id: &str, kind: EntityKind, x: f32, z: f32, iff: Iff) -> Track {
+        Track {
+            id: EntityId::name(id),
+            kind,
+            position: pos(x, z),
+            sta: Sta::Idle,
+            iff,
+            rel: 0,
+            hp_pct: 100,
+        }
+    }
+
+    fn uplink() -> Uplink {
+        Uplink {
+            subject: EntityId::name("Mika"),
+            subject_position: Some(pos(0.0, 0.0)),
+            subject_sta: Sta::Idle,
+            subject_hp_pct: 100,
+            tracks: vec![
+                track(
+                    "Saori",
+                    EntityKind::Player("Saori".into()),
+                    3.0,
+                    0.0,
+                    Iff::Neutral,
+                ),
+                track(
+                    "slime_1",
+                    EntityKind::Monster("slime_1".into()),
+                    0.0,
+                    4.0,
+                    Iff::Hostile,
+                ),
+            ],
+            packets: Vec::new(),
+        }
+    }
+
+    fn first_action(packets: &[Packet]) -> Value {
+        let envelope = to_envelope(packets, &uplink(), 0).unwrap();
+        envelope["actions"][0].clone()
+    }
+
+    #[test]
+    fn talk_with_a_line_becomes_speech() {
+        let packet = Packet::engage(EntityId::name("Mika"), EntityId::name("Saori"), Act::Talk)
+            .with_msg("Long time, Saori.");
+        assert_eq!(
+            first_action(&[packet]),
+            json!({"type": "say", "message": "Long time, Saori."})
+        );
+    }
+
+    #[test]
+    fn talk_without_a_line_approaches_the_target() {
+        let packet = Packet::engage(EntityId::name("Mika"), EntityId::name("Saori"), Act::Talk);
+        assert_eq!(
+            first_action(&[packet]),
+            json!({"type": "move", "target": "Saori"})
+        );
+    }
+
+    #[test]
+    fn attack_resolves_the_target_to_a_monster_id() {
+        let packet = Packet::engage(
+            EntityId::name("Mika"),
+            EntityId::name("slime_1"),
+            Act::Attack,
+        );
+        assert_eq!(
+            first_action(&[packet]),
+            json!({"type": "attack", "monster_id": "slime_1"})
+        );
+    }
+
+    #[test]
+    fn attacking_something_that_is_not_a_monster_is_refused() {
+        for target in ["Saori", "a_monster_that_does_not_exist"] {
+            let packet =
+                Packet::engage(EntityId::name("Mika"), EntityId::name(target), Act::Attack);
+            assert!(to_envelope(&[packet], &uplink(), 0).is_err(), "{target}");
+        }
+    }
+
+    #[test]
+    fn a_gift_opens_a_trade_with_a_player() {
+        let packet = Packet::engage(EntityId::name("Mika"), EntityId::name("Saori"), Act::Gift);
+        assert_eq!(
+            first_action(&[packet]),
+            json!({"type": "open_trade", "player": "Saori"})
+        );
+    }
+
+    #[test]
+    fn fleeing_moves_directly_away_from_the_target() {
+        let packet = Packet::engage(EntityId::name("Mika"), EntityId::name("slime_1"), Act::Flee);
+        let action = first_action(&[packet]);
+        assert_eq!(action["type"], "move");
+        assert_eq!(action["x"].as_f64().unwrap(), 0.0);
+        assert_eq!(action["z"].as_f64().unwrap(), -(FLEE_DISTANCE as f64));
+    }
+
+    #[test]
+    fn an_aggressive_objective_picks_the_nearest_hostile() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Exterminate);
+        assert_eq!(
+            first_action(&[packet]),
+            json!({"type": "attack", "monster_id": "slime_1"})
+        );
+    }
+
+    #[test]
+    fn a_holding_objective_waits() {
+        for obj in [Obj::None, Obj::Defend, Obj::Ambush] {
+            let packet = Packet::mission(EntityId::name("Mika"), obj);
+            assert_eq!(first_action(&[packet]), json!({"type": "wait"}), "{obj:?}");
+        }
+    }
+
+    #[test]
+    fn a_patrol_waypoint_is_a_fixed_distance_out_and_repeatable() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Patrol);
+        let first = first_action(std::slice::from_ref(&packet));
+        assert_eq!(first_action(&[packet]), first);
+        let (x, z) = (
+            first["x"].as_f64().unwrap() as f32,
+            first["z"].as_f64().unwrap() as f32,
+        );
+        let d = (x * x + z * z).sqrt();
+        assert!(
+            (d - PATROL_RADIUS).abs() < 0.2,
+            "waypoint {x},{z} is {d} out"
+        );
+    }
+
+    #[test]
+    fn an_escort_objective_without_a_target_is_refused() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Escort);
+        assert!(to_envelope(&[packet], &uplink(), 0).is_err());
+    }
+
+    #[test]
+    fn the_subjects_own_death_report_triggers_a_respawn() {
+        let packet = Packet::ppli(
+            EntityId::name("Mika"),
+            Sta::Dead,
+            Loc::Coord([0.0, 0.0, 0.0]),
+        );
+        assert_eq!(first_action(&[packet]), json!({"type": "respawn"}));
+    }
+
+    #[test]
+    fn another_entitys_death_report_commands_nothing() {
+        let packets = [Packet::ppli(
+            EntityId::name("slime_1"),
+            Sta::Dead,
+            Loc::Coord([0.0, 0.0, 4.0]),
+        )];
+        assert_eq!(
+            to_envelope(&packets, &uplink(), 0),
+            Err(Violation::NoCommand)
+        );
+    }
+
+    #[test]
+    fn a_frame_of_pure_observation_commands_nothing() {
+        let packets = [Packet::track(
+            EntityId::name("Mika"),
+            EntityId::name("slime_1"),
+            Iff::Hostile,
+        )];
+        assert_eq!(
+            to_envelope(&packets, &uplink(), 0),
+            Err(Violation::NoCommand)
+        );
+    }
+
+    #[test]
+    fn packets_decode_in_order_into_one_envelope() {
+        let packets = [
+            Packet::track(
+                EntityId::name("Mika"),
+                EntityId::name("slime_1"),
+                Iff::Hostile,
+            ),
+            Packet::engage(EntityId::name("Mika"), EntityId::name("Saori"), Act::Talk)
+                .with_msg("Behind you."),
+            Packet::engage(
+                EntityId::name("Mika"),
+                EntityId::name("slime_1"),
+                Act::Attack,
+            ),
+        ];
+        let envelope = to_envelope(&packets, &uplink(), 0).unwrap();
+        let actions = envelope["actions"].as_array().unwrap();
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0]["type"], "say");
+        assert_eq!(actions[1]["type"], "attack");
+        assert!(envelope["thought"].as_str().unwrap().contains("ACT=2"));
+    }
+}

--- a/agent-client/src/sidla/encode.rs
+++ b/agent-client/src/sidla/encode.rs
@@ -1,0 +1,457 @@
+//! Uplink: `SharedState` to SIDLA packets, with no natural-language step.
+//!
+//! Every entity in sight contributes two packets — an A (PPLI) carrying where
+//! it is and how it is doing, and a B (Track) carrying how we identify it.
+//! Splitting them that way is what keeps each header's field set disjoint:
+//! position belongs to the entity reporting it, identification belongs to the
+//! observer.
+//!
+//! The frame is a pure function of the state snapshot. Entities are emitted in
+//! a stable order (distance, then id) so the same world produces byte-identical
+//! bytes, which is what makes a turn reproducible in the first place.
+
+use onlinerpg_shared::{Monster, MonsterState, Player, Position};
+
+use super::packet::{EntityId, Iff, Loc, Packet, Sta};
+use crate::state::{SharedState, NPC_SIGHT_RADIUS};
+
+/// Below this fraction of maximum health an entity reports `Panic` rather
+/// than its activity, so the frame carries the fact that matters most.
+pub const PANIC_HEALTH_FRACTION: f32 = 0.3;
+
+/// What an entity is, so a decoded target can be turned back into the right
+/// kind of game command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntityKind {
+    Monster(String),
+    Player(String),
+}
+
+/// One entity as the uplink saw it. Retained beside the packets so the
+/// downlink can resolve a target without a second pass over the world.
+#[derive(Debug, Clone)]
+pub struct Track {
+    pub id: EntityId,
+    pub kind: EntityKind,
+    pub position: Position,
+    pub sta: Sta,
+    pub iff: Iff,
+    pub rel: i32,
+    pub hp_pct: u8,
+}
+
+/// A complete uplink: the packets to send, plus the index needed to read the
+/// reply against the same snapshot.
+#[derive(Debug, Clone)]
+pub struct Uplink {
+    pub subject: EntityId,
+    pub subject_position: Option<Position>,
+    pub subject_sta: Sta,
+    pub subject_hp_pct: u8,
+    pub tracks: Vec<Track>,
+    pub packets: Vec<Packet>,
+}
+
+impl Uplink {
+    pub fn find(&self, id: &EntityId) -> Option<&Track> {
+        self.tracks.iter().find(|t| &t.id == id)
+    }
+
+    /// Tracks identified as hostile, nearest first. Ordering is inherited
+    /// from `tracks`, which is already sorted deterministically.
+    pub fn hostiles(&self) -> impl Iterator<Item = &Track> {
+        self.tracks.iter().filter(|t| t.iff == Iff::Hostile)
+    }
+}
+
+fn hp_pct(health: u32, max_health: u32) -> u8 {
+    if max_health == 0 {
+        return 0;
+    }
+    let pct = (health as f32 / max_health as f32 * 100.0).round();
+    pct.clamp(0.0, 100.0) as u8
+}
+
+fn coord(p: &Position) -> Loc {
+    Loc::Coord([
+        (p.x * 10.0).round() / 10.0,
+        (p.y * 10.0).round() / 10.0,
+        (p.z * 10.0).round() / 10.0,
+    ])
+}
+
+/// A monster's state maps onto the dictionary's activity codes; a badly hurt
+/// one reports `Panic` regardless of what it is doing.
+fn monster_sta(m: &Monster) -> Sta {
+    if m.health == 0 || m.state == MonsterState::Dead {
+        return Sta::Dead;
+    }
+    if (m.health as f32) < m.max_health as f32 * PANIC_HEALTH_FRACTION {
+        return Sta::Panic;
+    }
+    match m.state {
+        MonsterState::Idle => Sta::Idle,
+        MonsterState::Walk | MonsterState::Run => Sta::Moving,
+        MonsterState::Attack | MonsterState::Hit => Sta::Engaged,
+        MonsterState::Dead => Sta::Dead,
+    }
+}
+
+fn player_sta(p: &Player) -> Sta {
+    if p.health == 0 {
+        Sta::Dead
+    } else if (p.health as f32) < p.max_health as f32 * PANIC_HEALTH_FRACTION {
+        Sta::Panic
+    } else {
+        Sta::Idle
+    }
+}
+
+/// A monster that attacks on sight is hostile; one that only retaliates is
+/// neutral until provoked.
+fn monster_iff(m: &Monster) -> Iff {
+    if m.aggressive {
+        Iff::Hostile
+    } else {
+        Iff::Neutral
+    }
+}
+
+fn player_iff(p: &Player) -> Iff {
+    if p.is_official_npc {
+        Iff::Friend
+    } else {
+        Iff::Unknown
+    }
+}
+
+/// Affinity derived from identification. A placeholder: the game has no
+/// relationship store yet, so REL is a deterministic function of IFF rather
+/// than a remembered score. Swap this for a lookup when one exists — nothing
+/// else in the protocol needs to change.
+fn rel_from_iff(iff: Iff) -> i32 {
+    match iff {
+        Iff::Friend => 50,
+        Iff::Hostile => -100,
+        Iff::Neutral | Iff::Unknown => 0,
+    }
+}
+
+fn subject_sta(state: &SharedState, hostile_adjacent: bool) -> Sta {
+    let Some(p) = state.self_player.as_ref() else {
+        return Sta::Idle;
+    };
+    if p.health == 0 {
+        return Sta::Dead;
+    }
+    if (p.health as f32) < p.max_health as f32 * PANIC_HEALTH_FRACTION {
+        return Sta::Panic;
+    }
+    if state.trade_busy || state.self_fishing || hostile_adjacent {
+        return Sta::Engaged;
+    }
+    Sta::Idle
+}
+
+/// Distance at which a hostile counts as adjacent for the subject's own
+/// state report.
+const ENGAGED_RADIUS: f32 = 5.0;
+
+/// Encode the current world into an uplink frame.
+pub fn encode(state: &SharedState) -> Uplink {
+    let subject = state
+        .self_player
+        .as_ref()
+        .map(|p| EntityId::name(&p.name))
+        .unwrap_or_else(|| EntityId::name("self"));
+    let subject_position = state.self_player.as_ref().map(|p| p.position);
+    let sight_sq = NPC_SIGHT_RADIUS * NPC_SIGHT_RADIUS;
+
+    let mut scored: Vec<(f32, Track)> = Vec::new();
+
+    for p in state.nearby_players.values() {
+        if state.self_player_id.as_ref() == Some(&p.id) {
+            continue;
+        }
+        let d_sq = match subject_position.as_ref() {
+            Some(sp) => {
+                let d = p.position.dist_xz_sq(sp);
+                if d > sight_sq {
+                    continue;
+                }
+                d
+            }
+            None => 0.0,
+        };
+        let iff = player_iff(p);
+        scored.push((
+            d_sq,
+            Track {
+                id: EntityId::name(&p.name),
+                kind: EntityKind::Player(p.name.clone()),
+                position: p.position,
+                sta: player_sta(p),
+                iff,
+                rel: rel_from_iff(iff),
+                hp_pct: hp_pct(p.health, p.max_health),
+            },
+        ));
+    }
+
+    for m in state.nearby_monsters.values() {
+        let d_sq = match subject_position.as_ref() {
+            Some(sp) => {
+                let d = m.position.dist_xz_sq(sp);
+                if d > sight_sq {
+                    continue;
+                }
+                d
+            }
+            None => 0.0,
+        };
+        if m.state == MonsterState::Dead {
+            continue;
+        }
+        let iff = monster_iff(m);
+        scored.push((
+            d_sq,
+            Track {
+                id: EntityId::name(&m.id),
+                kind: EntityKind::Monster(m.id.clone()),
+                position: m.position,
+                sta: monster_sta(m),
+                iff,
+                rel: rel_from_iff(iff),
+                hp_pct: hp_pct(m.health, m.max_health),
+            },
+        ));
+    }
+
+    // Nearest first, ties broken by identifier: a HashMap iteration order must
+    // not be able to reorder the frame.
+    scored.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.id.cmp(&b.1.id)));
+    let tracks: Vec<Track> = scored.into_iter().map(|(_, t)| t).collect();
+
+    let hostile_adjacent = tracks.iter().any(|t| {
+        t.iff == Iff::Hostile && within(subject_position.as_ref(), &t.position, ENGAGED_RADIUS)
+    });
+    let subject_sta = subject_sta(state, hostile_adjacent);
+    let subject_hp_pct = state
+        .self_player
+        .as_ref()
+        .map(|p| hp_pct(p.health, p.max_health))
+        .unwrap_or(0);
+
+    let mut packets = Vec::with_capacity(tracks.len() * 2 + 1);
+    if let Some(pos) = subject_position.as_ref() {
+        packets
+            .push(Packet::ppli(subject.clone(), subject_sta, coord(pos)).with_hp(subject_hp_pct));
+    }
+    for t in &tracks {
+        packets.push(Packet::ppli(t.id.clone(), t.sta, coord(&t.position)).with_hp(t.hp_pct));
+    }
+    for t in &tracks {
+        packets.push(Packet::track(subject.clone(), t.id.clone(), t.iff).with_rel(t.rel));
+    }
+
+    Uplink {
+        subject,
+        subject_position,
+        subject_sta,
+        subject_hp_pct,
+        tracks,
+        packets,
+    }
+}
+
+fn within(from: Option<&Position>, to: &Position, radius: f32) -> bool {
+    match from {
+        Some(f) => to.dist_xz_sq(f) <= radius * radius,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::schema;
+    use crate::sidla::wire;
+    use crate::state::tests::{p, test_state};
+    use onlinerpg_shared::{CharacterClass, PlayerId};
+
+    fn player(id: u64, name: &str, pos: Position, official: bool) -> Player {
+        Player {
+            id: PlayerId::from(id),
+            name: name.to_string(),
+            position: pos,
+            rotation: 0.0,
+            level: 1,
+            health: 100,
+            max_health: 100,
+            class: CharacterClass::Knight,
+            gender: Default::default(),
+            is_official_npc: official,
+            torch_on: false,
+            floor_level: 0,
+            object_type: None,
+            main_hand: None,
+            object_id: None,
+            last_combat_at: 0,
+            client_kind: Default::default(),
+        }
+    }
+
+    fn monster(id: &str, pos: Position, aggressive: bool) -> Monster {
+        Monster {
+            id: id.to_string(),
+            monster_type: "slime".to_string(),
+            position: pos,
+            rotation: 0.0,
+            state: MonsterState::Idle,
+            owner_id: None,
+            health: 10,
+            max_health: 10,
+            floor_level: 0,
+            level_override: None,
+            aggressive,
+            last_attack_at: 0,
+            last_move_at: 0,
+            move_budget: 0.0,
+        }
+    }
+
+    fn populated() -> SharedState {
+        let (mut state, _rx) = test_state();
+        let me = player(1, "Mika", p(0.0, 0.0, 0.0), false);
+        state.self_player_id = Some(me.id);
+        state.self_player = Some(me);
+
+        let saori = player(2, "Saori", p(3.0, 0.0, 0.0), true);
+        state.nearby_players.insert(saori.id, saori);
+        state
+            .nearby_monsters
+            .insert("slime_2".into(), monster("slime_2", p(0.0, 0.0, 8.0), true));
+        state.nearby_monsters.insert(
+            "slime_1".into(),
+            monster("slime_1", p(0.0, 0.0, 4.0), false),
+        );
+        state
+    }
+
+    #[test]
+    fn every_emitted_packet_satisfies_the_schema() {
+        let uplink = encode(&populated());
+        for packet in &uplink.packets {
+            schema::validate(packet)
+                .unwrap_or_else(|e| panic!("uplink emitted an invalid packet: {e}\n{packet:?}"));
+        }
+    }
+
+    #[test]
+    fn each_entity_gets_one_ppli_and_one_track() {
+        let uplink = encode(&populated());
+        assert_eq!(uplink.tracks.len(), 3);
+        let ppli = uplink
+            .packets
+            .iter()
+            .filter(|p| p.h == crate::sidla::packet::Header::A)
+            .count();
+        let track = uplink
+            .packets
+            .iter()
+            .filter(|p| p.h == crate::sidla::packet::Header::B)
+            .count();
+        assert_eq!(ppli, 4, "three entities plus the subject");
+        assert_eq!(track, 3);
+    }
+
+    #[test]
+    fn the_frame_is_identical_across_repeated_encodings() {
+        let state = populated();
+        let first = wire::render_json(&encode(&state).packets);
+        for _ in 0..32 {
+            assert_eq!(wire::render_json(&encode(&state).packets), first);
+        }
+    }
+
+    #[test]
+    fn tracks_are_ordered_by_distance() {
+        let uplink = encode(&populated());
+        let names: Vec<String> = uplink.tracks.iter().map(|t| t.id.to_string()).collect();
+        assert_eq!(names, ["Saori", "slime_1", "slime_2"]);
+    }
+
+    #[test]
+    fn identification_follows_aggression_and_officialdom() {
+        let uplink = encode(&populated());
+        let iff = |name: &str| uplink.find(&EntityId::name(name)).map(|t| t.iff);
+        assert_eq!(iff("Saori"), Some(Iff::Friend));
+        assert_eq!(iff("slime_1"), Some(Iff::Neutral));
+        assert_eq!(iff("slime_2"), Some(Iff::Hostile));
+    }
+
+    #[test]
+    fn affinity_stays_inside_the_dictionary_range() {
+        let uplink = encode(&populated());
+        for t in &uplink.tracks {
+            assert!((-100..=100).contains(&t.rel), "{t:?}");
+        }
+    }
+
+    #[test]
+    fn a_dead_monster_is_left_out_of_the_frame() {
+        let mut state = populated();
+        state.nearby_monsters.get_mut("slime_1").unwrap().state = MonsterState::Dead;
+        let uplink = encode(&state);
+        assert!(uplink.find(&EntityId::name("slime_1")).is_none());
+    }
+
+    #[test]
+    fn an_entity_beyond_sight_is_left_out_of_the_frame() {
+        let mut state = populated();
+        let far = NPC_SIGHT_RADIUS * 2.0;
+        state.nearby_monsters.insert(
+            "slime_far".into(),
+            monster("slime_far", p(0.0, 0.0, far), true),
+        );
+        let uplink = encode(&state);
+        assert!(uplink.find(&EntityId::name("slime_far")).is_none());
+    }
+
+    #[test]
+    fn a_wounded_entity_reports_panic() {
+        let mut state = populated();
+        let m = state.nearby_monsters.get_mut("slime_1").unwrap();
+        m.health = 1;
+        let uplink = encode(&state);
+        assert_eq!(
+            uplink.find(&EntityId::name("slime_1")).map(|t| t.sta),
+            Some(Sta::Panic)
+        );
+    }
+
+    #[test]
+    fn the_subject_reports_engaged_with_a_hostile_at_its_side() {
+        let mut state = populated();
+        state.nearby_monsters.get_mut("slime_2").unwrap().position = p(1.0, 0.0, 1.0);
+        assert_eq!(encode(&state).subject_sta, Sta::Engaged);
+    }
+
+    #[test]
+    fn the_subject_reports_dead_at_zero_health() {
+        let mut state = populated();
+        state.self_player.as_mut().unwrap().health = 0;
+        assert_eq!(encode(&state).subject_sta, Sta::Dead);
+    }
+
+    #[test]
+    fn a_state_frame_costs_fewer_tokens_than_the_prose_it_replaces() {
+        let state = populated();
+        let prose = wire::estimate_tokens(&state.format_world_state());
+        let compact = wire::estimate_tokens(&wire::render_compact(&encode(&state).packets));
+        assert!(
+            compact < prose,
+            "compact {compact} tokens vs prose {prose} tokens"
+        );
+    }
+}

--- a/agent-client/src/sidla/fsm.rs
+++ b/agent-client/src/sidla/fsm.rs
@@ -1,0 +1,213 @@
+//! The fallback the protocol falls back to.
+//!
+//! A discarded packet must not leave the agent doing nothing — that is how a
+//! rejected turn becomes a frozen NPC. This module answers the same uplink
+//! with a valid packet derived from the world alone, so refusing a bad reply
+//! costs behaviour rather than removing it.
+//!
+//! The policy is a short ordered ladder with no randomness: the first rule
+//! that matches decides, ties break on identifier, and the result is a packet
+//! that passes `super::schema::validate` by construction.
+
+use super::encode::{Track, Uplink};
+use super::packet::{Act, Iff, Loc, Obj, Packet, Sta};
+
+/// Below this fraction of health the agent disengages instead of trading hits.
+pub const FLEE_HEALTH_PCT: u8 = 25;
+/// A hostile nearer than this is worth engaging without being told to.
+pub const ENGAGE_RADIUS: f32 = 20.0;
+
+/// Decide what to do from the world alone.
+///
+/// Ladder, in order: report death, run from a hostile while badly hurt, engage
+/// the nearest hostile in reach, then patrol.
+pub fn decide(uplink: &Uplink) -> Packet {
+    let subject = uplink.subject.clone();
+
+    if uplink.subject_sta == Sta::Dead {
+        let loc = uplink
+            .subject_position
+            .as_ref()
+            .map(|p| Loc::Coord([p.x, p.y, p.z]))
+            .unwrap_or_else(|| Loc::Zone("unknown".into()));
+        return Packet::ppli(subject, Sta::Dead, loc).with_hp(0);
+    }
+
+    if let Some(threat) = nearest_hostile_in_reach(uplink) {
+        if uplink.subject_hp_pct <= FLEE_HEALTH_PCT {
+            return Packet::engage(subject, threat.id.clone(), Act::Flee);
+        }
+        return Packet::engage(subject, threat.id.clone(), Act::Attack);
+    }
+
+    Packet::mission(subject, Obj::Patrol)
+}
+
+/// The nearest hostile within `ENGAGE_RADIUS`. `Uplink::tracks` is already
+/// sorted nearest-first with identifier tie-breaks, so the first match is the
+/// deterministic choice.
+fn nearest_hostile_in_reach(uplink: &Uplink) -> Option<&Track> {
+    let from = uplink.subject_position.as_ref()?;
+    uplink.tracks.iter().find(|t| {
+        t.iff == Iff::Hostile
+            && t.sta != Sta::Dead
+            && t.position.dist_xz_sq(from) <= ENGAGE_RADIUS * ENGAGE_RADIUS
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::encode::EntityKind;
+    use crate::sidla::packet::{EntityId, Header};
+    use crate::sidla::schema;
+    use onlinerpg_shared::Position;
+
+    fn pos(x: f32, z: f32) -> Position {
+        Position { x, y: 0.0, z }
+    }
+
+    fn track(id: &str, x: f32, z: f32, iff: Iff) -> Track {
+        Track {
+            id: EntityId::name(id),
+            kind: EntityKind::Monster(id.to_string()),
+            position: pos(x, z),
+            sta: Sta::Idle,
+            iff,
+            rel: 0,
+            hp_pct: 100,
+        }
+    }
+
+    fn uplink(sta: Sta, hp_pct: u8, tracks: Vec<Track>) -> Uplink {
+        Uplink {
+            subject: EntityId::name("Mika"),
+            subject_position: Some(pos(0.0, 0.0)),
+            subject_sta: sta,
+            subject_hp_pct: hp_pct,
+            tracks,
+            packets: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn every_decision_is_a_schema_valid_packet() {
+        let cases = [
+            uplink(Sta::Dead, 0, vec![]),
+            uplink(Sta::Idle, 100, vec![]),
+            uplink(
+                Sta::Idle,
+                100,
+                vec![track("slime_1", 0.0, 5.0, Iff::Hostile)],
+            ),
+            uplink(
+                Sta::Panic,
+                10,
+                vec![track("slime_1", 0.0, 5.0, Iff::Hostile)],
+            ),
+            uplink(
+                Sta::Idle,
+                100,
+                vec![track("townsfolk", 1.0, 0.0, Iff::Friend)],
+            ),
+        ];
+        for case in &cases {
+            let packet = decide(case);
+            schema::validate(&packet)
+                .unwrap_or_else(|e| panic!("fallback emitted an invalid packet: {e}"));
+        }
+    }
+
+    #[test]
+    fn death_is_reported_before_anything_else_is_considered() {
+        let packet = decide(&uplink(
+            Sta::Dead,
+            0,
+            vec![track("slime_1", 0.0, 1.0, Iff::Hostile)],
+        ));
+        assert_eq!(packet.h, Header::A);
+        assert_eq!(packet.sta, Some(Sta::Dead));
+    }
+
+    /// The uplink hands over tracks already sorted nearest-first, so the
+    /// ladder takes the first hostile it finds rather than re-measuring.
+    #[test]
+    fn a_healthy_agent_engages_the_first_hostile_in_the_frame() {
+        let packet = decide(&uplink(
+            Sta::Idle,
+            100,
+            vec![
+                track("slime_near", 0.0, 3.0, Iff::Hostile),
+                track("slime_far", 0.0, 15.0, Iff::Hostile),
+            ],
+        ));
+        assert_eq!(packet.h, Header::C);
+        assert_eq!(packet.act, Some(Act::Attack));
+        assert_eq!(packet.tar, Some(EntityId::name("slime_near")));
+    }
+
+    #[test]
+    fn a_badly_hurt_agent_flees_the_same_target_it_would_have_fought() {
+        let tracks = vec![track("slime_1", 0.0, 3.0, Iff::Hostile)];
+        let fought = decide(&uplink(Sta::Idle, 100, tracks.clone()));
+        let fled = decide(&uplink(Sta::Panic, FLEE_HEALTH_PCT, tracks));
+        assert_eq!(fought.act, Some(Act::Attack));
+        assert_eq!(fled.act, Some(Act::Flee));
+        assert_eq!(fought.tar, fled.tar);
+    }
+
+    #[test]
+    fn a_hostile_out_of_reach_is_not_engaged() {
+        let packet = decide(&uplink(
+            Sta::Idle,
+            100,
+            vec![track("slime_1", 0.0, ENGAGE_RADIUS + 5.0, Iff::Hostile)],
+        ));
+        assert_eq!(packet.h, Header::D);
+        assert_eq!(packet.obj, Some(Obj::Patrol));
+    }
+
+    #[test]
+    fn a_dead_hostile_is_not_engaged() {
+        let mut t = track("slime_1", 0.0, 3.0, Iff::Hostile);
+        t.sta = Sta::Dead;
+        let packet = decide(&uplink(Sta::Idle, 100, vec![t]));
+        assert_eq!(packet.obj, Some(Obj::Patrol));
+    }
+
+    #[test]
+    fn a_friend_is_never_a_target() {
+        let packet = decide(&uplink(
+            Sta::Idle,
+            100,
+            vec![
+                track("guard", 1.0, 0.0, Iff::Friend),
+                track("merchant", 2.0, 0.0, Iff::Neutral),
+            ],
+        ));
+        assert_eq!(packet.h, Header::D);
+    }
+
+    #[test]
+    fn an_empty_world_yields_a_patrol() {
+        let packet = decide(&uplink(Sta::Idle, 100, vec![]));
+        assert_eq!(packet.h, Header::D);
+        assert_eq!(packet.obj, Some(Obj::Patrol));
+    }
+
+    #[test]
+    fn the_same_world_always_yields_the_same_decision() {
+        let case = uplink(
+            Sta::Idle,
+            60,
+            vec![
+                track("slime_2", 0.0, 4.0, Iff::Hostile),
+                track("slime_1", 0.0, 4.0, Iff::Hostile),
+            ],
+        );
+        let first = decide(&case);
+        for _ in 0..64 {
+            assert_eq!(decide(&case), first);
+        }
+    }
+}

--- a/agent-client/src/sidla/mod.rs
+++ b/agent-client/src/sidla/mod.rs
@@ -1,0 +1,143 @@
+//! SIDLA — a data link protocol for agent control.
+//!
+//! An LLM asked "what do you do?" in prose answers in prose, and prose can say
+//! anything: an action that does not exist, a target that was never in sight,
+//! a field the situation forbids. The driver's own parser already meets this
+//! by dropping any reply it cannot read, which trades a hallucinated action
+//! for a frozen NPC.
+//!
+//! SIDLA narrows the channel instead. World state goes out as packets rather
+//! than sentences, decisions come back as packets, and every packet is checked
+//! against the field matrix its header declares before anything reaches the
+//! game. Three barriers stand in the way of a malformed decision:
+//!
+//! 1. Control fields deserialize from integers only, so a word where an enum
+//!    belongs fails to parse (`packet`).
+//! 2. Each header fixes which fields must, may and must not appear, so a
+//!    packet carrying a field outside its purpose is rejected whole
+//!    (`schema`).
+//! 3. A rejected packet is answered by a deterministic ladder over the same
+//!    world, so refusing a reply costs behaviour rather than removing it
+//!    (`fsm`).
+//!
+//! What reaches the game is therefore always a packet the schema admits. The
+//! guarantee is structural: it does not depend on the model's cooperation, and
+//! it holds for a model that returns nothing intelligible at all.
+//!
+//! Determinism follows from the same arrangement. The uplink is a pure
+//! function of the state snapshot, and the downlink is a pure function of the
+//! packets and that snapshot, so an unchanged world and an unchanged reply
+//! produce byte-identical commands. Where variety is wanted it is added
+//! afterwards by `shuffle`, seeded so a run stays reproducible.
+//!
+//! The layer sits behind `LlmBackend` (`backend`), so it works with every
+//! provider and changes nothing downstream — the driver keeps receiving the
+//! same action envelope it always did.
+//!
+//! Headers, after the J-series message families a tactical data link uses:
+//!
+//! | Header | Purpose | Required | Optional |
+//! | --- | --- | --- | --- |
+//! | A (PPLI) | own state and position | SUB, STA, LOC | HP |
+//! | B (Track) | observation and identification | SUB, TAR, IFF | REL |
+//! | C (Engage) | action and interaction | SUB, TAR, ACT | MSG |
+//! | D (Mission) | objective change | SUB, OBJ | TAR |
+//!
+//! `HP` and `MSG` are domain extensions, not part of the core dictionary: a
+//! game needs to know how hurt a target is, and a talking NPC needs somewhere
+//! to put the line it speaks. Both are confined to one header.
+
+mod backend;
+mod decode;
+mod encode;
+mod fsm;
+mod packet;
+mod schema;
+mod shuffle;
+mod wire;
+
+pub use backend::SidlaBackend;
+pub use wire::Wire;
+
+use serde::Deserialize;
+
+/// `[sidla]` configuration. Off unless asked for; a scenario designer opts a
+/// whole fleet or a single NPC into the protocol.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SidlaConfig {
+    /// Route this NPC's turns through the data link.
+    pub enabled: bool,
+    /// How the uplink frame is written. `compact` costs fewer tokens;
+    /// `json` is easier to read in a log.
+    pub wire: Wire,
+    /// Vary interchangeable objectives across turns, so an agent under greedy
+    /// decoding does not repeat one decision forever.
+    pub shuffle: bool,
+    /// Seed for that variation. A fixed seed replays a run exactly.
+    pub shuffle_seed: u64,
+    /// Log every uplink frame and rejected reply at debug level.
+    pub log_frames: bool,
+}
+
+impl Default for SidlaConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            wire: Wire::Compact,
+            shuffle: false,
+            shuffle_seed: 0x5344_4C41,
+            log_frames: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_harness_is_off_by_default() {
+        assert!(!SidlaConfig::default().enabled);
+    }
+
+    #[test]
+    fn an_empty_table_yields_the_defaults() {
+        let parsed: SidlaConfig = toml::from_str("").unwrap();
+        assert_eq!(parsed, SidlaConfig::default());
+    }
+
+    #[test]
+    fn config_reads_every_knob() {
+        let parsed: SidlaConfig = toml::from_str(
+            r#"
+            enabled = true
+            wire = "json"
+            shuffle = true
+            shuffle_seed = 99
+            log_frames = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            SidlaConfig {
+                enabled: true,
+                wire: Wire::Json,
+                shuffle: true,
+                shuffle_seed: 99,
+                log_frames: true,
+            }
+        );
+    }
+
+    #[test]
+    fn a_misspelled_key_is_reported_rather_than_ignored() {
+        assert!(toml::from_str::<SidlaConfig>("enabeld = true").is_err());
+    }
+
+    #[test]
+    fn an_unknown_wire_format_is_rejected() {
+        assert!(toml::from_str::<SidlaConfig>(r#"wire = "morse""#).is_err());
+    }
+}

--- a/agent-client/src/sidla/packet.rs
+++ b/agent-client/src/sidla/packet.rs
@@ -1,0 +1,480 @@
+//! SIDLA wire types: the header taxonomy, the integer-only field enums of
+//! the data dictionary, and the `Packet` these assemble into.
+//!
+//! Control fields deserialize from integers only. A natural-language token
+//! where an enum belongs (`"ACT": "attack"`) is a parse error, not a value —
+//! that is the first of the three structural barriers against hallucinated
+//! output, before the schema matrix in `super::schema` ever runs.
+
+use serde::{Deserialize, Serialize};
+
+/// Communication purpose. Each header fixes which fields may appear, so the
+/// header alone decides how a packet is read (see `super::schema`).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+pub enum Header {
+    /// PPLI: an entity reporting its own state and position.
+    #[default]
+    A,
+    /// Track: an observation of another entity, with identification.
+    B,
+    /// Engage: an action or interaction to carry out.
+    C,
+    /// Mission: a higher-level objective change.
+    D,
+}
+
+impl Header {
+    #[cfg(test)]
+    pub const ALL: [Header; 4] = [Header::A, Header::B, Header::C, Header::D];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Header::A => "A",
+            Header::B => "B",
+            Header::C => "C",
+            Header::D => "D",
+        }
+    }
+}
+
+/// Declares an enum whose only wire representation is its integer code.
+/// `Deserialize` goes through `i64`, so a string, float or bool in that
+/// position fails to parse instead of being coerced.
+macro_rules! code_enum {
+    ($(#[$meta:meta])* $name:ident { $($(#[$vmeta:meta])* $variant:ident = $code:expr),+ $(,)? }) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum $name {
+            $($(#[$vmeta])* $variant),+
+        }
+
+        impl $name {
+            #[cfg(test)]
+            pub const ALL: &'static [$name] = &[$($name::$variant),+];
+
+            pub fn code(self) -> i64 {
+                match self { $($name::$variant => $code),+ }
+            }
+
+            pub fn from_code(code: i64) -> Option<Self> {
+                match code {
+                    $($code => Some($name::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                s.serialize_i64(self.code())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+                let code = i64::deserialize(d)?;
+                Self::from_code(code).ok_or_else(|| {
+                    serde::de::Error::custom(format_args!(
+                        "{} has no value {code}",
+                        stringify!($name)
+                    ))
+                })
+            }
+        }
+    };
+}
+
+code_enum! {
+    /// IFF — identification friend or foe.
+    Iff {
+        Unknown = 0,
+        Friend = 1,
+        Hostile = 2,
+        Neutral = 3,
+    }
+}
+
+code_enum! {
+    /// STA — an entity's own reported state.
+    Sta {
+        Idle = 0,
+        Moving = 1,
+        Engaged = 2,
+        Panic = 3,
+        Dead = 4,
+    }
+}
+
+code_enum! {
+    /// ACT — the interaction to execute.
+    Act {
+        None = 0,
+        Talk = 1,
+        Attack = 2,
+        Gift = 3,
+        Flee = 4,
+    }
+}
+
+code_enum! {
+    /// OBJ — the standing objective a mission packet installs.
+    Obj {
+        None = 0,
+        Patrol = 1,
+        Search = 2,
+        Defend = 3,
+        Escort = 4,
+        Ambush = 5,
+        Raid = 6,
+        Charge = 7,
+        Exterminate = 8,
+    }
+}
+
+/// Inclusive bounds on REL, the affinity score.
+pub const REL_MIN: i32 = -100;
+pub const REL_MAX: i32 = 100;
+
+/// A packet field, named independently of the struct so the schema matrix can
+/// be indexed by it. Order follows the protocol's field specification table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Field {
+    Iff,
+    Sta,
+    Rel,
+    Act,
+    Sub,
+    Tar,
+    Obj,
+    Loc,
+    Hp,
+    Msg,
+}
+
+impl Field {
+    pub const ALL: [Field; 10] = [
+        Field::Iff,
+        Field::Sta,
+        Field::Rel,
+        Field::Act,
+        Field::Sub,
+        Field::Tar,
+        Field::Obj,
+        Field::Loc,
+        Field::Hp,
+        Field::Msg,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Field::Iff => "IFF",
+            Field::Sta => "STA",
+            Field::Rel => "REL",
+            Field::Act => "ACT",
+            Field::Sub => "SUB",
+            Field::Tar => "TAR",
+            Field::Obj => "OBJ",
+            Field::Loc => "LOC",
+            Field::Hp => "HP",
+            Field::Msg => "MSG",
+        }
+    }
+
+    pub fn is_present(self, packet: &Packet) -> bool {
+        match self {
+            Field::Iff => packet.iff.is_some(),
+            Field::Sta => packet.sta.is_some(),
+            Field::Rel => packet.rel.is_some(),
+            Field::Act => packet.act.is_some(),
+            Field::Sub => packet.sub.is_some(),
+            Field::Tar => packet.tar.is_some(),
+            Field::Obj => packet.obj.is_some(),
+            Field::Loc => packet.loc.is_some(),
+            Field::Hp => packet.hp.is_some(),
+            Field::Msg => packet.msg.is_some(),
+        }
+    }
+}
+
+/// SUB/TAR — an entity identifier. A name is the readable form the spec's
+/// worked examples use; a hash is the compact form for a large world. Both
+/// are accepted on the wire and compare as distinct identities.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EntityId {
+    Name(String),
+    Hash(u64),
+}
+
+impl EntityId {
+    pub fn name(s: impl Into<String>) -> Self {
+        EntityId::Name(s.into())
+    }
+}
+
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntityId::Name(n) => f.write_str(n),
+            EntityId::Hash(h) => write!(f, "{h}"),
+        }
+    }
+}
+
+/// LOC — a zone identifier or absolute coordinates.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Loc {
+    Zone(String),
+    Coord([f32; 3]),
+}
+
+/// A SIDLA data link packet. Every field but the header is optional at the
+/// type level; which ones are actually admissible is decided per header by
+/// `super::schema::validate`, so an invalid combination is representable but
+/// never accepted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Packet {
+    #[serde(rename = "H")]
+    pub h: Header,
+    #[serde(rename = "SUB", default, skip_serializing_if = "Option::is_none")]
+    pub sub: Option<EntityId>,
+    #[serde(rename = "TAR", default, skip_serializing_if = "Option::is_none")]
+    pub tar: Option<EntityId>,
+    #[serde(rename = "IFF", default, skip_serializing_if = "Option::is_none")]
+    pub iff: Option<Iff>,
+    #[serde(rename = "STA", default, skip_serializing_if = "Option::is_none")]
+    pub sta: Option<Sta>,
+    #[serde(rename = "REL", default, skip_serializing_if = "Option::is_none")]
+    pub rel: Option<i32>,
+    #[serde(rename = "ACT", default, skip_serializing_if = "Option::is_none")]
+    pub act: Option<Act>,
+    #[serde(rename = "OBJ", default, skip_serializing_if = "Option::is_none")]
+    pub obj: Option<Obj>,
+    #[serde(rename = "LOC", default, skip_serializing_if = "Option::is_none")]
+    pub loc: Option<Loc>,
+    /// Extension: health as a percentage, so a tracked entity's condition is
+    /// legible without adding a second numeric channel.
+    #[serde(rename = "HP", default, skip_serializing_if = "Option::is_none")]
+    pub hp: Option<u8>,
+    /// Extension: the spoken line carried by `ACT = Talk`. Dialogue is
+    /// payload, not control — no decision is read from this field.
+    #[serde(rename = "MSG", default, skip_serializing_if = "Option::is_none")]
+    pub msg: Option<String>,
+}
+
+impl Packet {
+    /// PPLI: `sub` reports being in state `sta` at `loc`.
+    pub fn ppli(sub: EntityId, sta: Sta, loc: Loc) -> Self {
+        Self {
+            h: Header::A,
+            sub: Some(sub),
+            sta: Some(sta),
+            loc: Some(loc),
+            ..Default::default()
+        }
+    }
+
+    /// Track: `sub` observes `tar` and identifies it as `iff`.
+    pub fn track(sub: EntityId, tar: EntityId, iff: Iff) -> Self {
+        Self {
+            h: Header::B,
+            sub: Some(sub),
+            tar: Some(tar),
+            iff: Some(iff),
+            ..Default::default()
+        }
+    }
+
+    /// Engage: `sub` performs `act` on `tar`.
+    pub fn engage(sub: EntityId, tar: EntityId, act: Act) -> Self {
+        Self {
+            h: Header::C,
+            sub: Some(sub),
+            tar: Some(tar),
+            act: Some(act),
+            ..Default::default()
+        }
+    }
+
+    /// Mission: `sub` adopts objective `obj`.
+    pub fn mission(sub: EntityId, obj: Obj) -> Self {
+        Self {
+            h: Header::D,
+            sub: Some(sub),
+            obj: Some(obj),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_hp(mut self, hp: u8) -> Self {
+        self.hp = Some(hp);
+        self
+    }
+
+    pub fn with_rel(mut self, rel: i32) -> Self {
+        self.rel = Some(rel);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_msg(mut self, msg: impl Into<String>) -> Self {
+        self.msg = Some(msg.into());
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_tar(mut self, tar: EntityId) -> Self {
+        self.tar = Some(tar);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The specification's worked example: one agent sights another it has
+    // history with, then acts on it. `Mika`/`Saori` are the specification's
+    // illustrative names; in play `SUB` and `TAR` carry engine identifiers.
+
+    #[test]
+    fn the_specs_track_example_round_trips() {
+        let json = r#"{"H":"B","SUB":"Mika","TAR":"Saori","IFF":2,"REL":-45}"#;
+        let packet: Packet = serde_json::from_str(json).unwrap();
+        assert_eq!(packet.h, Header::B);
+        assert_eq!(packet.sub, Some(EntityId::name("Mika")));
+        assert_eq!(packet.tar, Some(EntityId::name("Saori")));
+        assert_eq!(packet.iff, Some(Iff::Hostile));
+        assert_eq!(packet.rel, Some(-45));
+        assert_eq!(serde_json::to_string(&packet).unwrap(), json);
+    }
+
+    /// The example's follow-up engagement. Both actions are exercised: the
+    /// specification's drafts differ on whether the agent opens with talk or
+    /// with an attack, and the wire form has to carry either.
+    #[test]
+    fn the_specs_engage_example_round_trips_for_either_action() {
+        for (json, want) in [
+            (r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":1}"#, Act::Talk),
+            (
+                r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":2}"#,
+                Act::Attack,
+            ),
+        ] {
+            let packet: Packet = serde_json::from_str(json).unwrap();
+            assert_eq!(packet.act, Some(want));
+            assert_eq!(serde_json::to_string(&packet).unwrap(), json);
+        }
+    }
+
+    /// A real deployment names entities the way the engine does — a monster by
+    /// its instance id, a character by the name the server answers to.
+    #[test]
+    fn engine_identifiers_are_carried_verbatim() {
+        let json = r#"{"H":"C","SUB":"npc_guard_karl","TAR":"monster_slime_00c1","ACT":2}"#;
+        let packet: Packet = serde_json::from_str(json).unwrap();
+        assert_eq!(packet.sub, Some(EntityId::name("npc_guard_karl")));
+        assert_eq!(packet.tar, Some(EntityId::name("monster_slime_00c1")));
+        assert_eq!(serde_json::to_string(&packet).unwrap(), json);
+    }
+
+    #[test]
+    fn absent_fields_are_omitted_not_nulled() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Patrol);
+        assert_eq!(
+            serde_json::to_string(&packet).unwrap(),
+            r#"{"H":"D","SUB":"Mika","OBJ":1}"#
+        );
+    }
+
+    #[test]
+    fn a_natural_language_token_cannot_stand_in_for_an_enum() {
+        for json in [
+            r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":"attack"}"#,
+            r#"{"H":"B","SUB":"Mika","TAR":"Saori","IFF":"hostile"}"#,
+            r#"{"H":"A","SUB":"Mika","STA":"idle","LOC":"Cafe"}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<Packet>(json).is_err(),
+                "accepted prose: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn enum_codes_outside_the_dictionary_are_rejected() {
+        for json in [
+            r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":9}"#,
+            r#"{"H":"B","SUB":"Mika","TAR":"Saori","IFF":4}"#,
+            r#"{"H":"A","SUB":"Mika","STA":5,"LOC":"Cafe"}"#,
+            r#"{"H":"D","SUB":"Mika","OBJ":9}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<Packet>(json).is_err(),
+                "accepted out-of-dictionary code: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_float_is_not_an_enum_code() {
+        let json = r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":2.5}"#;
+        assert!(serde_json::from_str::<Packet>(json).is_err());
+    }
+
+    #[test]
+    fn an_unrecognised_header_is_rejected() {
+        let json = r#"{"H":"E","SUB":"Mika"}"#;
+        assert!(serde_json::from_str::<Packet>(json).is_err());
+    }
+
+    #[test]
+    fn an_invented_field_is_rejected() {
+        let json = r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":2,"SPELL":"fireball"}"#;
+        assert!(serde_json::from_str::<Packet>(json).is_err());
+    }
+
+    #[test]
+    fn loc_accepts_a_zone_or_coordinates() {
+        let zone: Packet =
+            serde_json::from_str(r#"{"H":"A","SUB":"Mika","STA":0,"LOC":"Trinity_Cafe"}"#).unwrap();
+        assert_eq!(zone.loc, Some(Loc::Zone("Trinity_Cafe".into())));
+
+        let coord: Packet =
+            serde_json::from_str(r#"{"H":"A","SUB":"Mika","STA":1,"LOC":[1.5,0.0,-2.5]}"#).unwrap();
+        assert_eq!(coord.loc, Some(Loc::Coord([1.5, 0.0, -2.5])));
+    }
+
+    #[test]
+    fn an_entity_may_be_a_name_or_a_hash() {
+        let packet: Packet =
+            serde_json::from_str(r#"{"H":"C","SUB":91827,"TAR":"Saori","ACT":2}"#).unwrap();
+        assert_eq!(packet.sub, Some(EntityId::Hash(91827)));
+        assert_eq!(packet.tar, Some(EntityId::name("Saori")));
+    }
+
+    #[test]
+    fn every_dictionary_code_maps_both_ways() {
+        for v in Iff::ALL {
+            assert_eq!(Iff::from_code(v.code()), Some(*v));
+        }
+        for v in Sta::ALL {
+            assert_eq!(Sta::from_code(v.code()), Some(*v));
+        }
+        for v in Act::ALL {
+            assert_eq!(Act::from_code(v.code()), Some(*v));
+        }
+        for v in Obj::ALL {
+            assert_eq!(Obj::from_code(v.code()), Some(*v));
+        }
+    }
+
+    #[test]
+    fn every_header_renders_as_its_own_letter() {
+        assert_eq!(Header::ALL.map(Header::as_str), ["A", "B", "C", "D"]);
+    }
+}

--- a/agent-client/src/sidla/schema.rs
+++ b/agent-client/src/sidla/schema.rs
@@ -1,0 +1,343 @@
+//! Masking control logic: the per-header field matrix and the validator that
+//! enforces it.
+//!
+//! Validation is total — every field of every header has a declared
+//! requirement, so there is no combination the matrix leaves undecided. A
+//! packet that fails is discarded rather than repaired, and the caller falls
+//! back to `super::fsm`.
+
+use super::packet::{Act, Field, Header, Packet, REL_MAX, REL_MIN};
+
+/// Whether a field may, must, or must not appear under a given header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rule {
+    Required,
+    Optional,
+    Forbidden,
+}
+
+/// Why a packet was rejected. Mirrors the exception classes the protocol
+/// defines: a missing mandatory field, a field the header forbids, a value
+/// outside its declared domain, and a packet that failed to decode at all
+/// (which covers prose where an enum belongs).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Violation {
+    MissingRequired {
+        header: Header,
+        field: Field,
+    },
+    ForbiddenField {
+        header: Header,
+        field: Field,
+    },
+    OutOfRange {
+        field: Field,
+        value: i64,
+        min: i64,
+        max: i64,
+    },
+    /// `MSG` present without `ACT = Talk`: dialogue with nothing to speak on.
+    DanglingPayload {
+        field: Field,
+    },
+    /// Failed to decode into a packet — bad JSON, unknown field, or a
+    /// non-integer in a control field.
+    Malformed(String),
+    /// Decoded and valid, but no packet in the frame commands anything.
+    NoCommand,
+}
+
+impl std::fmt::Display for Violation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Violation::MissingRequired { header, field } => {
+                write!(f, "header {} requires {}", header.as_str(), field.as_str())
+            }
+            Violation::ForbiddenField { header, field } => {
+                write!(f, "header {} forbids {}", header.as_str(), field.as_str())
+            }
+            Violation::OutOfRange {
+                field,
+                value,
+                min,
+                max,
+            } => write!(f, "{} = {value} outside {min}..={max}", field.as_str()),
+            Violation::DanglingPayload { field } => {
+                write!(f, "{} present without ACT = Talk", field.as_str())
+            }
+            Violation::Malformed(e) => write!(f, "malformed packet: {e}"),
+            Violation::NoCommand => f.write_str("frame carries no actionable packet"),
+        }
+    }
+}
+
+/// The requirement for `field` under `header`.
+///
+/// Core dictionary fields follow the protocol's header specification. The two
+/// extension fields are admitted only where they are meaningful: `HP` beside
+/// the position it qualifies, `MSG` beside the action it voices.
+pub fn rule(header: Header, field: Field) -> Rule {
+    use Field::*;
+    use Header::*;
+    use Rule::*;
+
+    match (header, field) {
+        // A (PPLI): who, in what state, where.
+        (A, Sub) | (A, Sta) | (A, Loc) => Required,
+        (A, Hp) => Optional,
+        (A, _) => Forbidden,
+
+        // B (Track): who saw whom, and how it is identified.
+        (B, Sub) | (B, Tar) | (B, Iff) => Required,
+        (B, Rel) => Optional,
+        (B, _) => Forbidden,
+
+        // C (Engage): who does what to whom.
+        (C, Sub) | (C, Tar) | (C, Act) => Required,
+        (C, Msg) => Optional,
+        (C, _) => Forbidden,
+
+        // D (Mission): who adopts which objective, optionally about whom.
+        (D, Sub) | (D, Obj) => Required,
+        (D, Tar) => Optional,
+        (D, _) => Forbidden,
+    }
+}
+
+/// Validate one packet against its header's field matrix and value domains.
+pub fn validate(packet: &Packet) -> Result<(), Violation> {
+    for field in Field::ALL {
+        let present = field.is_present(packet);
+        match rule(packet.h, field) {
+            Rule::Required if !present => {
+                return Err(Violation::MissingRequired {
+                    header: packet.h,
+                    field,
+                })
+            }
+            Rule::Forbidden if present => {
+                return Err(Violation::ForbiddenField {
+                    header: packet.h,
+                    field,
+                })
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(rel) = packet.rel {
+        if !(REL_MIN..=REL_MAX).contains(&rel) {
+            return Err(Violation::OutOfRange {
+                field: Field::Rel,
+                value: rel as i64,
+                min: REL_MIN as i64,
+                max: REL_MAX as i64,
+            });
+        }
+    }
+
+    if let Some(hp) = packet.hp {
+        if hp > 100 {
+            return Err(Violation::OutOfRange {
+                field: Field::Hp,
+                value: hp as i64,
+                min: 0,
+                max: 100,
+            });
+        }
+    }
+
+    if packet.msg.is_some() && packet.act != Some(Act::Talk) {
+        return Err(Violation::DanglingPayload { field: Field::Msg });
+    }
+
+    Ok(())
+}
+
+/// Parse a downlink frame and validate every packet in it. One bad packet
+/// condemns the frame: a partially trusted frame would leave the agent acting
+/// on half a decision.
+pub fn parse_frame(text: &str) -> Result<Vec<Packet>, Violation> {
+    let mut packets = Vec::new();
+    for line in super::wire::split_frame(text) {
+        let packet: Packet = serde_json::from_str(line)
+            .map_err(|e| Violation::Malformed(format!("{e} in `{line}`")))?;
+        validate(&packet)?;
+        packets.push(packet);
+    }
+    if packets.is_empty() {
+        return Err(Violation::Malformed("frame contained no packet".into()));
+    }
+    Ok(packets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::packet::{EntityId, Iff, Loc, Obj, Sta};
+
+    fn mika() -> EntityId {
+        EntityId::name("Mika")
+    }
+
+    fn saori() -> EntityId {
+        EntityId::name("Saori")
+    }
+
+    #[test]
+    fn the_matrix_decides_every_header_field_pair() {
+        for header in Header::ALL {
+            for field in Field::ALL {
+                let _ = rule(header, field);
+            }
+        }
+    }
+
+    #[test]
+    fn each_header_requires_exactly_its_specified_fields() {
+        let required = |h: Header| {
+            Field::ALL
+                .into_iter()
+                .filter(|f| rule(h, *f) == Rule::Required)
+                .map(Field::as_str)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(required(Header::A), ["STA", "SUB", "LOC"]);
+        assert_eq!(required(Header::B), ["IFF", "SUB", "TAR"]);
+        assert_eq!(required(Header::C), ["ACT", "SUB", "TAR"]);
+        assert_eq!(required(Header::D), ["SUB", "OBJ"]);
+    }
+
+    #[test]
+    fn rel_is_optional_on_track_and_forbidden_elsewhere() {
+        assert_eq!(rule(Header::B, Field::Rel), Rule::Optional);
+        for h in [Header::A, Header::C, Header::D] {
+            assert_eq!(rule(h, Field::Rel), Rule::Forbidden);
+        }
+    }
+
+    #[test]
+    fn tar_is_optional_on_mission_and_forbidden_on_ppli() {
+        assert_eq!(rule(Header::D, Field::Tar), Rule::Optional);
+        assert_eq!(rule(Header::A, Field::Tar), Rule::Forbidden);
+    }
+
+    #[test]
+    fn well_formed_packets_of_every_header_pass() {
+        let packets = [
+            Packet::ppli(mika(), Sta::Idle, Loc::Zone("Trinity_Cafe".into())),
+            Packet::track(mika(), saori(), Iff::Hostile).with_rel(-45),
+            Packet::engage(mika(), saori(), Act::Talk).with_msg("Long time."),
+            Packet::mission(mika(), Obj::Patrol).with_tar(saori()),
+        ];
+        for packet in packets {
+            validate(&packet).unwrap_or_else(|e| panic!("rejected valid packet: {e}"));
+        }
+    }
+
+    #[test]
+    fn an_engage_packet_without_act_is_discarded() {
+        let mut packet = Packet::engage(mika(), saori(), Act::Attack);
+        packet.act = None;
+        assert_eq!(
+            validate(&packet),
+            Err(Violation::MissingRequired {
+                header: Header::C,
+                field: Field::Act
+            })
+        );
+    }
+
+    #[test]
+    fn a_ppli_packet_carrying_a_target_is_treated_as_contaminated() {
+        let packet = Packet::ppli(mika(), Sta::Idle, Loc::Zone("Cafe".into())).with_tar(saori());
+        assert_eq!(
+            validate(&packet),
+            Err(Violation::ForbiddenField {
+                header: Header::A,
+                field: Field::Tar
+            })
+        );
+    }
+
+    #[test]
+    fn an_engage_packet_may_not_smuggle_a_position() {
+        let mut packet = Packet::engage(mika(), saori(), Act::Attack);
+        packet.loc = Some(Loc::Coord([1.0, 0.0, 1.0]));
+        assert_eq!(
+            validate(&packet),
+            Err(Violation::ForbiddenField {
+                header: Header::C,
+                field: Field::Loc
+            })
+        );
+    }
+
+    #[test]
+    fn affinity_beyond_its_bounds_is_rejected() {
+        for rel in [-101, 101, i32::MAX] {
+            let packet = Packet::track(mika(), saori(), Iff::Neutral).with_rel(rel);
+            assert!(matches!(
+                validate(&packet),
+                Err(Violation::OutOfRange {
+                    field: Field::Rel,
+                    ..
+                })
+            ));
+        }
+        for rel in [-100, 0, 100] {
+            let packet = Packet::track(mika(), saori(), Iff::Neutral).with_rel(rel);
+            assert_eq!(validate(&packet), Ok(()));
+        }
+    }
+
+    #[test]
+    fn health_above_full_is_rejected() {
+        let packet = Packet::ppli(mika(), Sta::Idle, Loc::Zone("Cafe".into())).with_hp(120);
+        assert!(matches!(
+            validate(&packet),
+            Err(Violation::OutOfRange {
+                field: Field::Hp,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn dialogue_without_a_talk_action_is_rejected() {
+        let packet = Packet::engage(mika(), saori(), Act::Attack).with_msg("hello");
+        assert_eq!(
+            validate(&packet),
+            Err(Violation::DanglingPayload { field: Field::Msg })
+        );
+    }
+
+    #[test]
+    fn a_frame_is_condemned_by_its_worst_packet() {
+        let frame = concat!(
+            r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":1}"#,
+            "\n",
+            r#"{"H":"A","SUB":"Mika","STA":0,"LOC":"Cafe","TAR":"Saori"}"#,
+        );
+        assert!(parse_frame(frame).is_err());
+    }
+
+    #[test]
+    fn a_valid_multi_packet_frame_parses_in_order() {
+        let frame = concat!(
+            r#"{"H":"B","SUB":"Mika","TAR":"Saori","IFF":2,"REL":-45}"#,
+            "\n",
+            r#"{"H":"C","SUB":"Mika","TAR":"Saori","ACT":1}"#,
+        );
+        let packets = parse_frame(frame).unwrap();
+        assert_eq!(packets.len(), 2);
+        assert_eq!(packets[0].h, Header::B);
+        assert_eq!(packets[1].act, Some(Act::Talk));
+    }
+
+    #[test]
+    fn an_empty_frame_is_not_a_valid_decision() {
+        assert!(parse_frame("").is_err());
+        assert!(parse_frame("   \n \n").is_err());
+    }
+}

--- a/agent-client/src/sidla/shuffle.rs
+++ b/agent-client/src/sidla/shuffle.rs
@@ -1,0 +1,142 @@
+//! Integer shuffling: the sanctioned source of behavioural variety.
+//!
+//! Greedy decoding makes the agent repeat itself given the same world. Rather
+//! than reintroduce sampling inside inference — which would take determinism
+//! back — variety is added here, after validation, by permuting an enum value
+//! among others that are interchangeable for the situation.
+//!
+//! The mixer is SplitMix64: same seed, same turn, same result. A run is still
+//! reproducible; it is only reproducible as a sequence rather than as a single
+//! repeated decision.
+
+use super::packet::{Obj, Packet};
+
+/// One round of SplitMix64.
+pub fn mix(mut z: u64) -> u64 {
+    z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut x = z;
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^ (x >> 31)
+}
+
+/// A value in `[0, 1)` derived from `seed`.
+pub fn unit_fraction(seed: u64) -> f32 {
+    (mix(seed) >> 40) as f32 / (1u64 << 24) as f32
+}
+
+fn pick<T: Copy>(options: &[T], seed: u64) -> T {
+    options[(mix(seed) % options.len() as u64) as usize]
+}
+
+/// Objectives that read as the same intent — a patrolling guard may sweep or
+/// search without contradicting its orders. Nothing that changes who gets hurt
+/// is ever substituted.
+const IDLE_OBJECTIVES: [Obj; 2] = [Obj::Patrol, Obj::Search];
+
+/// Vary an already-valid packet. Only the idle objectives are permuted:
+/// substituting an `ACT` would change what the agent does to whom, which is
+/// the planner's decision and not this layer's to make.
+pub fn vary(packet: &Packet, seed: u64) -> Packet {
+    let mut out = packet.clone();
+    if let Some(obj) = packet.obj {
+        if IDLE_OBJECTIVES.contains(&obj) {
+            out.obj = Some(pick(&IDLE_OBJECTIVES, seed));
+        }
+    }
+    out
+}
+
+/// Seed for turn `turn` of a run started with `seed`.
+pub fn turn_seed(seed: u64, turn: u64) -> u64 {
+    mix(seed ^ turn.wrapping_mul(0x2545_F491_4F6C_DD1D))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::packet::{Act, EntityId, Iff};
+
+    #[test]
+    fn the_same_seed_always_mixes_to_the_same_value() {
+        for seed in [0, 1, 42, u64::MAX] {
+            assert_eq!(mix(seed), mix(seed));
+        }
+    }
+
+    #[test]
+    fn different_seeds_diverge() {
+        assert_ne!(mix(1), mix(2));
+        assert_ne!(turn_seed(7, 1), turn_seed(7, 2));
+    }
+
+    #[test]
+    fn unit_fractions_stay_in_range_and_spread_out() {
+        let mut low = 0;
+        let mut high = 0;
+        for turn in 0..512u64 {
+            let f = unit_fraction(turn_seed(9, turn));
+            assert!((0.0..1.0).contains(&f), "{f}");
+            if f < 0.5 {
+                low += 1;
+            } else {
+                high += 1;
+            }
+        }
+        assert!(low > 150 && high > 150, "low {low}, high {high}");
+    }
+
+    #[test]
+    fn an_idle_objective_may_be_substituted_for_its_equivalent() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Patrol);
+        let seen: std::collections::HashSet<Obj> = (0..64)
+            .map(|turn| vary(&packet, turn_seed(3, turn)).obj.unwrap())
+            .collect();
+        assert_eq!(seen.len(), 2, "expected both idle objectives, got {seen:?}");
+        assert!(seen.iter().all(|o| IDLE_OBJECTIVES.contains(o)));
+    }
+
+    #[test]
+    fn variation_is_reproducible_for_a_given_turn() {
+        let packet = Packet::mission(EntityId::name("Mika"), Obj::Patrol);
+        for turn in 0..16u64 {
+            let seed = turn_seed(11, turn);
+            assert_eq!(vary(&packet, seed), vary(&packet, seed));
+        }
+    }
+
+    #[test]
+    fn a_committing_objective_is_never_substituted() {
+        for obj in [Obj::Exterminate, Obj::Escort, Obj::Defend, Obj::None] {
+            let packet = Packet::mission(EntityId::name("Mika"), obj);
+            for turn in 0..32u64 {
+                assert_eq!(vary(&packet, turn_seed(5, turn)).obj, Some(obj));
+            }
+        }
+    }
+
+    #[test]
+    fn an_engagement_is_never_rewritten() {
+        let packet = Packet::engage(
+            EntityId::name("Mika"),
+            EntityId::name("slime_1"),
+            Act::Attack,
+        );
+        for turn in 0..32u64 {
+            assert_eq!(vary(&packet, turn_seed(5, turn)), packet);
+        }
+    }
+
+    #[test]
+    fn an_observation_is_never_rewritten() {
+        let packet = Packet::track(
+            EntityId::name("Mika"),
+            EntityId::name("slime_1"),
+            Iff::Hostile,
+        )
+        .with_rel(-100);
+        for turn in 0..32u64 {
+            assert_eq!(vary(&packet, turn_seed(5, turn)), packet);
+        }
+    }
+}

--- a/agent-client/src/sidla/wire.rs
+++ b/agent-client/src/sidla/wire.rs
@@ -1,0 +1,259 @@
+//! Frame serialisation. Two renderings of the same packets: canonical JSON,
+//! and a positional form that drops the key names once both ends agree on the
+//! field order a header implies.
+//!
+//! The protocol is deliberately format-agnostic — only the header/field
+//! contract is fixed — so `Wire` is a presentation choice, not a change of
+//! meaning. `split_frame` reads back either shape of JSON an LLM emits: one
+//! object per line, an array, or objects run together, with or without
+//! markdown fences.
+
+use super::packet::{Header, Loc, Packet};
+
+/// How an uplink frame is written out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Wire {
+    /// One JSON object per line. Self-describing, and what the downlink
+    /// always uses.
+    #[default]
+    Json,
+    /// Pipe-separated positional fields. Same information, fewer tokens.
+    Compact,
+}
+
+pub fn render(packets: &[Packet], wire: Wire) -> String {
+    match wire {
+        Wire::Json => render_json(packets),
+        Wire::Compact => render_compact(packets),
+    }
+}
+
+pub fn render_json(packets: &[Packet]) -> String {
+    packets
+        .iter()
+        .map(|p| serde_json::to_string(p).unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn render_compact(packets: &[Packet]) -> String {
+    packets
+        .iter()
+        .map(compact_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact_line(p: &Packet) -> String {
+    let sub = p.sub.as_ref().map(|e| e.to_string()).unwrap_or_default();
+    let tar = p.tar.as_ref().map(|e| e.to_string()).unwrap_or_default();
+    let mut cells: Vec<String> = vec![p.h.as_str().to_string(), sub];
+
+    match p.h {
+        Header::A => {
+            cells.push(code_cell(p.sta.map(|v| v.code())));
+            cells.push(p.loc.as_ref().map(render_loc).unwrap_or_default());
+            if let Some(hp) = p.hp {
+                cells.push(hp.to_string());
+            }
+        }
+        Header::B => {
+            cells.push(tar);
+            cells.push(code_cell(p.iff.map(|v| v.code())));
+            if let Some(rel) = p.rel {
+                cells.push(rel.to_string());
+            }
+        }
+        Header::C => {
+            cells.push(tar);
+            cells.push(code_cell(p.act.map(|v| v.code())));
+            if let Some(ref msg) = p.msg {
+                cells.push(msg.replace('|', "/").replace('\n', " "));
+            }
+        }
+        Header::D => {
+            cells.push(code_cell(p.obj.map(|v| v.code())));
+            if !tar.is_empty() {
+                cells.push(tar);
+            }
+        }
+    }
+    cells.join("|")
+}
+
+fn code_cell(code: Option<i64>) -> String {
+    code.map(|c| c.to_string()).unwrap_or_default()
+}
+
+fn render_loc(loc: &Loc) -> String {
+    match loc {
+        Loc::Zone(z) => z.clone(),
+        Loc::Coord([x, y, z]) => format!("{x:.1},{y:.1},{z:.1}"),
+    }
+}
+
+/// Slice out the top-level JSON objects of a frame, ignoring anything between
+/// them. Scans with a brace depth counter so braces inside strings and
+/// escaped quotes do not split an object.
+pub fn split_frame(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut start = None;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' if depth > 0 => in_string = true,
+            b'{' => {
+                if depth == 0 {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b'}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(s) = start.take() {
+                        spans.push(&text[s..=i]);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// Rough token count, used only to compare two renderings of the same content.
+/// Four characters per token is the usual English/JSON approximation.
+#[cfg(test)]
+pub fn estimate_tokens(text: &str) -> usize {
+    text.len().div_ceil(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sidla::packet::{Act, EntityId, Iff, Obj, Sta};
+
+    fn mika() -> EntityId {
+        EntityId::name("Mika")
+    }
+
+    fn saori() -> EntityId {
+        EntityId::name("Saori")
+    }
+
+    #[test]
+    fn newline_separated_objects_split() {
+        let frame = "{\"H\":\"A\"}\n{\"H\":\"B\"}";
+        assert_eq!(split_frame(frame), ["{\"H\":\"A\"}", "{\"H\":\"B\"}"]);
+    }
+
+    #[test]
+    fn a_markdown_fenced_array_splits() {
+        let frame = "```json\n[{\"H\":\"A\"},\n {\"H\":\"C\"}]\n```";
+        assert_eq!(split_frame(frame), ["{\"H\":\"A\"}", "{\"H\":\"C\"}"]);
+    }
+
+    #[test]
+    fn prose_around_the_packets_is_ignored() {
+        let frame = "Sure! Here you go:\n{\"H\":\"C\"}\nHope that helps.";
+        assert_eq!(split_frame(frame), ["{\"H\":\"C\"}"]);
+    }
+
+    #[test]
+    fn a_brace_inside_a_string_does_not_split_the_object() {
+        let frame = r#"{"H":"C","MSG":"a { brace \" and more }"}"#;
+        assert_eq!(split_frame(frame), [frame]);
+    }
+
+    #[test]
+    fn a_frame_with_no_object_yields_nothing() {
+        assert!(split_frame("I would rather not.").is_empty());
+    }
+
+    #[test]
+    fn compact_drops_the_key_names() {
+        let packets = [
+            Packet::ppli(mika(), Sta::Moving, Loc::Coord([12.34, 0.0, -4.56])).with_hp(80),
+            Packet::track(mika(), saori(), Iff::Hostile).with_rel(-45),
+            Packet::engage(mika(), saori(), Act::Talk).with_msg("Long time."),
+            Packet::mission(mika(), Obj::Patrol).with_tar(saori()),
+        ];
+        assert_eq!(
+            render_compact(&packets),
+            concat!(
+                "A|Mika|1|12.3,0.0,-4.6|80\n",
+                "B|Mika|Saori|2|-45\n",
+                "C|Mika|Saori|1|Long time.\n",
+                "D|Mika|1|Saori",
+            )
+        );
+    }
+
+    #[test]
+    fn compact_is_cheaper_than_json_for_the_same_packets() {
+        let packets: Vec<Packet> = (0..8)
+            .map(|i| {
+                Packet::ppli(
+                    EntityId::name(format!("slime_{i}")),
+                    Sta::Idle,
+                    Loc::Coord([i as f32, 0.0, -(i as f32)]),
+                )
+                .with_hp(100)
+            })
+            .collect();
+        let json = estimate_tokens(&render_json(&packets));
+        let compact = estimate_tokens(&render_compact(&packets));
+        assert!(compact * 2 <= json, "json {json}, compact {compact}");
+    }
+
+    /// Where the token saving actually is. The uplink is only modestly cheaper
+    /// than `format_world_state`, which is already terse; the reply is where a
+    /// prose envelope costs several times what a packet does, because the model
+    /// no longer narrates its reasoning to reach a decision.
+    #[test]
+    fn a_packet_reply_costs_a_fraction_of_a_prose_envelope() {
+        let envelope = concat!(
+            "{\n",
+            "  \"thought\": \"A slime is close and I still have most of my health, so I \
+             will engage it before it reaches Saori.\",\n",
+            "  \"actions\": [{\"type\": \"attack\", \"monster_id\": \"monster_slime_0003\"}],\n",
+            "  \"memory_update\": \"Fought a slime near the cafe while Saori was nearby.\"\n",
+            "}",
+        );
+        let packet = Packet::engage(
+            EntityId::name("Mika"),
+            EntityId::name("monster_slime_0003"),
+            Act::Attack,
+        );
+        let prose = estimate_tokens(envelope);
+        let wire = estimate_tokens(&render_json(&[packet]));
+        assert!(
+            wire * 3 <= prose,
+            "packet {wire} tokens vs envelope {prose} tokens"
+        );
+    }
+
+    #[test]
+    fn a_pipe_in_dialogue_cannot_forge_a_field() {
+        let packet = Packet::engage(mika(), saori(), Act::Talk).with_msg("a|b\nc");
+        let line = render_compact(&[packet]);
+        assert_eq!(line, "C|Mika|Saori|1|a/b c");
+        assert_eq!(line.lines().count(), 1);
+    }
+}


### PR DESCRIPTION
EN
---
A header-based packet protocol for the agent decision channel, behind the `sidla` cargo feature. A default build compiles none of it.

Today `driver/execute.rs` drops any reply it cannot parse, which trades a hallucinated action for an NPC that stands still for a turn. This narrows the channel instead: world state goes out as packets, decisions come back as packets, and each packet is validated against the field matrix its header declares before anything reaches the game.

Three barriers, none of which need the model to cooperate:
- control fields deserialize from integers only, so prose where an enum belongs fails to parse
- each header fixes its required/optional/forbidden fields, so a packet outside its purpose is rejected whole
- a rejected packet is answered by a deterministic ladder over the same world, so refusing a reply costs behaviour rather than removing it

Sits behind `driver::LlmBackend` and emits the same `{thought, actions[]}` JSON the driver already parses, so `driver/*` is untouched. `experimental_layers` in orchestrator.rs is the single switch point; the core diff is 45 lines across three files, all `#[cfg(feature = "sidla")]`.

Measured: 1,000 encodings of one world give 1 distinct frame; the reply costs 15 tokens against 66 for a prose envelope; a corpus of 21 malformed replies reaches the game 0 times and loses 0 turns. The uplink saving is smaller than expected (-6% to -22%) and is documented as such — `format_world_state` is already terse, and the JSON wire is dearer than prose, so `compact` is the setting that pays.

99 tests. Design notes, dictionary and known limits in agent-client/src/sidla/README.md.

Reference: SIDLA, KR 10-2026-0065736, filed 2026-04-11. IPC A63F 13/45; CPC A63F 2300/51, G06N 3/0455, H04L 49/9057, H04L 69/26. Contributed by the applicant.

NOTE: Updated for `ad7268c` commit

KO
---
에이전트 의사결정 채널을 위한 헤더 기반 패킷 프로토콜입니다. `sidla` cargo 피처 뒤에 있으며, 기본 빌드에는 컴파일되지 않습니다.

현재 `driver/execute.rs`는 파싱 실패한 응답을 폐기하는데, 이는 환각 행동 대신 한 턴 동안 멈춘 NPC를 얻는 거래입니다. 이 변경은 대신 채널 자체를 좁힙니다. 월드
상태는 패킷으로 나가고, 의사결정도 패킷으로 돌아오며, 각 패킷은 게임에 도달하기
전에 자신의 헤더가 선언한 필드 매트릭스로 검증됩니다.

모델의 협조를 필요로 하지 않는 세 개의 장벽:
- 제어 필드는 정수만 역직렬화하므로, 열거형 자리의 자연어는 파싱 자체가 실패함
- 각 헤더가 필수·선택·금지 필드를 고정하므로, 목적을 벗어난 패킷은 통째로 폐기됨
- 폐기된 패킷은 동일 월드에 대한 결정론적 판정 계단으로 응답하므로, 응답 거부의 대가는 행동의 소실이 아니라 행동의 대체임

`driver::LlmBackend` 뒤에 위치하며 드라이버가 이미 파싱하는
`{thought, actions[]}` JSON을 그대로 생성하므로 `driver/*`는 손대지 않았습니다. orchestrator.rs의 `experimental_layers`가 유일한 스위치 지점이고, 코어 변경은 3개 파일 45줄이며 전부 `#[cfg(feature = "sidla")]`입니다.

실측: 동일 월드 1,000회 인코딩 → 프레임 1종. 응답 토큰 15 vs 자연어 봉투 66. 비정상 응답 21종 → 게임 도달 0건, 턴 소실 0건. 업링크 절감은 예상보다 작으며
(-6% ~ -22%) 그대로 문서화했습니다. `format_world_state`가 이미 간결하고 JSON 와이어는 자연어보다 비싸므로, 이득이 있는 설정은 `compact`입니다.

테스트 99개. 설계 메모·데이터 사전·알려진 한계는
agent-client/src/sidla/README.md 참조.

참조: SIDLA, KR 10-2026-0065736, 2026-04-11 출원. IPC A63F 13/45; CPC A63F 2300/51, G06N 3/0455, H04L 49/9057, H04L 69/26. 출원인 기여.

NOTE: `ad7268c` 커밋 대응