### PR TITLE
Add on-device chat translation with auto-detected source language

### DIFF
--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -83,7 +83,9 @@
 
   const TRANSLATE_OFF = 'off'
 
-  function handleTranslateLangChange(event: Event & { currentTarget: HTMLSelectElement }) {
+  function handleTranslateLangChange(
+    event: Event & { currentTarget: HTMLSelectElement }
+  ) {
     const value = event.currentTarget.value
     if (value === TRANSLATE_OFF) {
       translationEnabled.set(false)

--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -324,7 +324,7 @@
         onchange={handleTranslateLangChange}
         title="Translate chat"
       >
-        <option value={TRANSLATE_OFF}>Off</option>
+        <option value={TRANSLATE_OFF}>Default (Off)</option>
         {#each TRANSLATION_LANGUAGES as lang (lang.code)}
           <option value={lang.code}>{lang.label}</option>
         {/each}

--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { gameStore } from '../stores/gameStore'
   import { networkManager } from '../network/socket'
   import { handleCommand, visibleCommandNames } from '../chat-commands'
   import { chatInputKeyIntent } from '../chat-input-keys'
   import { chatFocusRequest } from '../stores/npcMenuStore'
+  import {
+    translationEnabled,
+    translationTargetLanguage,
+    TRANSLATION_LANGUAGES,
+  } from '../stores/translationSettings'
+  import {
+    translateChatText,
+    isTranslatorApiSupported,
+  } from '../translation/chatTranslator'
 
   type Tab = 'say' | 'combat'
   const TRANSCRIPT_FADE_DELAY_MS = 20_000
@@ -12,6 +22,76 @@
   let chatMessages = $derived($gameStore.chatMessages)
   let combatMessages = $derived($gameStore.combatMessages)
   let isConnected = $derived($gameStore.isConnected)
+
+  // Translated text per message id, for the active target language only —
+  // cleared and retranslated from scratch whenever the target changes. Source
+  // is auto-detected per message inside translateChatText.
+  let translations = new SvelteMap<number, string>()
+  // Ids currently awaiting a translation result — a first-time language pair
+  // can mean a model download, so this can stay true for a while.
+  let pendingTranslation = new SvelteSet<number>()
+  let translatedTarget = ''
+
+  $effect(() => {
+    const enabled = $translationEnabled
+    const target = $translationTargetLanguage
+    // Both arrays share one id counter (see gameStore's nextMessageId), so a
+    // single cache keyed by id safely covers chat and combat together.
+    const entries = [...chatMessages, ...combatMessages]
+
+    if (!enabled || !isTranslatorApiSupported()) {
+      if (translations.size) translations.clear()
+      if (pendingTranslation.size) pendingTranslation.clear()
+      translatedTarget = ''
+      return
+    }
+
+    if (target !== translatedTarget) {
+      translations.clear()
+      pendingTranslation.clear()
+      translatedTarget = target
+    }
+
+    const liveIds = new Set(entries.map((e) => e.id))
+    for (const id of translations.keys()) {
+      if (!liveIds.has(id)) translations.delete(id)
+    }
+    for (const id of pendingTranslation) {
+      if (!liveIds.has(id)) pendingTranslation.delete(id)
+    }
+
+    for (const entry of entries) {
+      if (translations.has(entry.id) || !entry.text) continue
+      if (pendingTranslation.has(entry.id)) continue
+      pendingTranslation.add(entry.id)
+      translateChatText(entry.text, target)
+        .then((translated) => translations.set(entry.id, translated))
+        .catch(() => {
+          // Leave untranslated — the template falls back to the original text.
+        })
+        .finally(() => pendingTranslation.delete(entry.id))
+    }
+  })
+
+  function displayText(entry: { id: number; text: string }): string {
+    return translations.get(entry.id) ?? entry.text
+  }
+
+  function isTranslating(entry: { id: number }): boolean {
+    return pendingTranslation.has(entry.id)
+  }
+
+  const TRANSLATE_OFF = 'off'
+
+  function handleTranslateLangChange(event: Event & { currentTarget: HTMLSelectElement }) {
+    const value = event.currentTarget.value
+    if (value === TRANSLATE_OFF) {
+      translationEnabled.set(false)
+    } else {
+      translationTargetLanguage.set(value)
+      translationEnabled.set(true)
+    }
+  }
   let messageInput = $state('')
   let chatContainer = $state<HTMLDivElement>()
   let transcriptVisible = $state(true)
@@ -178,9 +258,12 @@
               class:local={entry.sender === 'local'}
               class:remote={entry.sender === 'remote'}>{entry.name}:</span
             >
-            {entry.text}
+            {displayText(entry)}
           {:else}
-            <span class="system">{entry.text}</span>
+            <span class="system">{displayText(entry)}</span>
+          {/if}
+          {#if isTranslating(entry)}
+            <span class="translating-hint">translating…</span>
           {/if}
         </div>
       {/each}
@@ -195,10 +278,13 @@
             >
             <span
               class:hit={entry.hit === true}
-              class:miss={entry.hit === false}>{entry.text}</span
+              class:miss={entry.hit === false}>{displayText(entry)}</span
             >
           {:else}
-            {entry.text}
+            {displayText(entry)}
+          {/if}
+          {#if isTranslating(entry)}
+            <span class="translating-hint">translating…</span>
           {/if}
         </div>
       {/each}
@@ -231,6 +317,19 @@
         disabled={!isConnected}
       />
     </div>
+    {#if isTranslatorApiSupported()}
+      <select
+        class="translate-lang-select"
+        value={$translationEnabled ? $translationTargetLanguage : TRANSLATE_OFF}
+        onchange={handleTranslateLangChange}
+        title="Translate chat"
+      >
+        <option value={TRANSLATE_OFF}>Off</option>
+        {#each TRANSLATION_LANGUAGES as lang (lang.code)}
+          <option value={lang.code}>{lang.label}</option>
+        {/each}
+      </select>
+    {/if}
     <button
       onclick={sendMessage}
       disabled={!isConnected || !messageInput.trim()}
@@ -360,6 +459,14 @@
     font-style: italic;
   }
 
+  .translating-hint {
+    margin-left: 6px;
+    color: #718096;
+    font-size: 10px;
+    font-style: italic;
+    opacity: 0.8;
+  }
+
   .message.whisper {
     color: #b794f4;
   }
@@ -451,6 +558,18 @@
     opacity: 0.5;
   }
 
+  .translate-lang-select {
+    margin: 2px 0;
+    padding: 0 6px;
+    border: none;
+    border-radius: 4px;
+    background: #2d3748;
+    color: #e2e8f0;
+    font-size: 11px;
+    max-width: 90px;
+    cursor: pointer;
+  }
+
   .chat-input button {
     margin: 2px;
     padding: 8px 15px;
@@ -535,6 +654,11 @@
       margin: 2px;
       padding: 4px 8px;
       font-size: 11px;
+    }
+
+    .translate-lang-select {
+      max-width: 56px;
+      font-size: 10px;
     }
   }
 </style>

--- a/client/src/lib/managers/inputHandler.test.ts
+++ b/client/src/lib/managers/inputHandler.test.ts
@@ -36,9 +36,7 @@ function groundScene() {
   return { camera, ground }
 }
 
-function contextWith(
-  overrides: Partial<RaycastContext> = {}
-): RaycastContext {
+function contextWith(overrides: Partial<RaycastContext> = {}): RaycastContext {
   const { camera, ground } = groundScene()
   return {
     camera,

--- a/client/src/lib/stores/translationSettings.ts
+++ b/client/src/lib/stores/translationSettings.ts
@@ -1,0 +1,48 @@
+import { writable } from 'svelte/store'
+
+export interface TranslationLanguage {
+  code: string
+  label: string
+}
+
+// Chrome's Translator API accepts BCP-47 tags; this list is just the
+// languages exposed in the settings UI, not an API restriction.
+export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
+  { code: 'en', label: 'English' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'zh', label: 'Chinese (Simplified)' },
+  { code: 'zh-Hant', label: 'Chinese (Traditional)' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'it', label: 'Italian' },
+  { code: 'vi', label: 'Vietnamese' },
+  { code: 'th', label: 'Thai' },
+  { code: 'id', label: 'Indonesian' },
+  { code: 'hi', label: 'Hindi' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'tr', label: 'Turkish' },
+  { code: 'pl', label: 'Polish' },
+  { code: 'nl', label: 'Dutch' },
+]
+
+const STORAGE_KEY_ENABLED = 'onlinerpg_translationEnabled'
+const STORAGE_KEY_TARGET = 'onlinerpg_translationTargetLanguage'
+const DEFAULT_TARGET = 'en'
+
+export const translationEnabled = writable<boolean>(
+  localStorage.getItem(STORAGE_KEY_ENABLED) === 'true'
+)
+export const translationTargetLanguage = writable<string>(
+  localStorage.getItem(STORAGE_KEY_TARGET) ?? DEFAULT_TARGET
+)
+
+translationEnabled.subscribe((v) => {
+  localStorage.setItem(STORAGE_KEY_ENABLED, String(v))
+})
+translationTargetLanguage.subscribe((v) => {
+  localStorage.setItem(STORAGE_KEY_TARGET, v)
+})

--- a/client/src/lib/translation/chatTranslator.ts
+++ b/client/src/lib/translation/chatTranslator.ts
@@ -1,0 +1,64 @@
+// Wraps Chrome's built-in Translator + LanguageDetector APIs. Source language
+// is auto-detected per message (chat has many speakers, not one fixed
+// source); instances are cached so repeat language pairs/detection don't each
+// pay model-load cost.
+
+export function isTranslatorApiSupported(): boolean {
+  return typeof Translator !== 'undefined' && typeof LanguageDetector !== 'undefined'
+}
+
+const translators = new Map<string, Promise<TranslatorInstance>>()
+let detector: Promise<LanguageDetectorInstance> | null = null
+
+async function getTranslator(
+  sourceLanguage: string,
+  targetLanguage: string
+): Promise<TranslatorInstance> {
+  const key = `${sourceLanguage}:${targetLanguage}`
+  const cached = translators.get(key)
+  if (cached) return cached
+
+  const created = (async () => {
+    const availability = await Translator!.availability({
+      sourceLanguage,
+      targetLanguage,
+    })
+    if (availability === 'unavailable') {
+      throw new Error(`Translator unavailable for ${key}`)
+    }
+    // 'downloadable'/'downloading' resolve once create()'s model download finishes.
+    return Translator!.create({ sourceLanguage, targetLanguage })
+  })()
+  translators.set(key, created)
+  created.catch(() => translators.delete(key))
+  return created
+}
+
+async function getDetector(): Promise<LanguageDetectorInstance> {
+  if (detector) return detector
+  detector = (async () => {
+    const availability = await LanguageDetector!.availability()
+    if (availability === 'unavailable') {
+      throw new Error('LanguageDetector unavailable')
+    }
+    return LanguageDetector!.create()
+  })()
+  detector.catch(() => (detector = null))
+  return detector
+}
+
+/** Returns null when detection is inconclusive ('und') — caller should skip translation. */
+async function detectLanguage(text: string): Promise<string | null> {
+  const [top] = await (await getDetector()).detect(text)
+  return top && top.detectedLanguage !== 'und' ? top.detectedLanguage : null
+}
+
+export async function translateChatText(
+  text: string,
+  targetLanguage: string
+): Promise<string> {
+  const sourceLanguage = await detectLanguage(text)
+  if (!sourceLanguage || sourceLanguage === targetLanguage) return text
+  const translator = await getTranslator(sourceLanguage, targetLanguage)
+  return translator.translate(text)
+}

--- a/client/src/lib/translation/chatTranslator.ts
+++ b/client/src/lib/translation/chatTranslator.ts
@@ -4,7 +4,9 @@
 // pay model-load cost.
 
 export function isTranslatorApiSupported(): boolean {
-  return typeof Translator !== 'undefined' && typeof LanguageDetector !== 'undefined'
+  return (
+    typeof Translator !== 'undefined' && typeof LanguageDetector !== 'undefined'
+  )
 }
 
 const translators = new Map<string, Promise<TranslatorInstance>>()

--- a/client/src/lib/types/translator-api.d.ts
+++ b/client/src/lib/types/translator-api.d.ts
@@ -1,0 +1,40 @@
+// Minimal typings for Chrome's built-in Translator API (not yet in lib.dom.d.ts).
+type TranslatorAvailability =
+  | 'unavailable'
+  | 'downloadable'
+  | 'downloading'
+  | 'available'
+
+interface TranslatorLanguagePair {
+  sourceLanguage: string
+  targetLanguage: string
+}
+
+interface TranslatorInstance {
+  translate(text: string): Promise<string>
+  destroy(): void
+}
+
+interface TranslatorApi {
+  availability(pair: TranslatorLanguagePair): Promise<TranslatorAvailability>
+  create(pair: TranslatorLanguagePair): Promise<TranslatorInstance>
+}
+
+declare const Translator: TranslatorApi | undefined
+
+interface LanguageDetectionResult {
+  detectedLanguage: string
+  confidence: number
+}
+
+interface LanguageDetectorInstance {
+  detect(text: string): Promise<LanguageDetectionResult[]>
+  destroy(): void
+}
+
+interface LanguageDetectorApi {
+  availability(): Promise<TranslatorAvailability>
+  create(): Promise<LanguageDetectorInstance>
+}
+
+declare const LanguageDetector: LanguageDetectorApi | undefined


### PR DESCRIPTION
Hi OpenMMO players and contributors,

I really enjoy chatting with people in OpenMMO. However, I’m not familiar with Hangul, so I sometimes use Google Translate in the browser. Unfortunately, it doesn’t work very well for chat messages and often misses words.

<img width="400" alt="Xnip2026-07-28_23-28-06" src="https://github.com/user-attachments/assets/c01572f4-0018-4cf9-8629-5d00d34bb920" />

To improve the experience, I integrated Chrome’s built-in Translator and Language Detector APIs into the web client. The reason is the most of browser in the market are Chromium based and I also tested on Edge and it works well.

**Two Players chating with different language**

<img width="3812" height="1672" alt="Xnip2026-07-29_00-08-54" src="https://github.com/user-attachments/assets/bbc2f91a-a8d7-4213-911c-9aa4157c0e54" />

**Microsoft Edge**

<img width="2736" height="2146" alt="Xnip2026-07-29_00-55-07" src="https://github.com/user-attachments/assets/50055502-f003-4393-9d83-c0d8b64176ab" />

I placed the language selector next to the chat window so players can switch languages in real time. Initially, I considered adding it to the settings panel, but I decided against that because it could be mistaken for a system-wide language setting.

The goal of this feature is to translate chat messages only, not the entire interface. Many in-game terms, such as item names and monster names, require carefully maintained translations. Chat messages do not need the same level of accuracy, so I intentionally limited the feature’s scope to chat.

Switching languages can sometimes take longer than expected, so I also added a translating indicator to provide better feedback to users.

<img width="400" alt="Xnip2026-07-29_00-12-51" src="https://github.com/user-attachments/assets/f0271227-5075-468c-b6de-b0366c5d2293" />

<img width="400" alt="Xnip2026-07-29_00-13-00" src="https://github.com/user-attachments/assets/ee66aac2-b025-4312-b63a-a0a29b934181" />

For browsers that do not support the Translator API, the language selector is hidden.

**Safari**

<img width="2502" height="2058" alt="Xnip2026-07-29_00-56-21" src="https://github.com/user-attachments/assets/24ef9aa7-119f-480e-9483-7b5efd6ba26e" />

