### PR TITLE
Add party system: invite, accept, leave (#58 step 1)

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -103,6 +103,20 @@ Available action types (use EXACTLY these field names):
   their ids. You walk to it first, and smashing opens its cell for movement:
   {"type": "break_prop", "prop_id": 3}
 
+- Invite a player to your party by name. Works at any distance, like a
+  whisper; they get 30 seconds to answer. Your roster shows in the world
+  state ("Your party: ..."):
+  {"type": "party_invite", "player": "darkcocoa"}
+
+- Answer a party invite (the [PartyInvite] event). Accepting puts you in
+  their party; a party hunts and travels together. With several invites
+  pending, name the inviter — bare answers the oldest:
+  {"type": "party_accept"}
+  {"type": "party_decline", "player": "darkcocoa"}
+
+- Leave your current party:
+  {"type": "party_leave"}
+
 IMPORTANT:
 - For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -86,6 +86,28 @@ pub(super) enum AgentAction {
         #[serde(alias = "target", alias = "player_name", alias = "target_player")]
         player: String,
     },
+    /// Invite a player to your party by name. Works at any distance, like a
+    /// whisper.
+    #[serde(rename = "party_invite", alias = "invite_party", alias = "invite")]
+    PartyInvite {
+        #[serde(alias = "target", alias = "player_name", alias = "target_player")]
+        player: String,
+    },
+    /// Accept a pending party invite — the oldest, or the named inviter's.
+    #[serde(rename = "party_accept", alias = "accept_party", alias = "join_party")]
+    PartyAccept {
+        #[serde(default, alias = "target", alias = "player_name", alias = "inviter")]
+        player: Option<String>,
+    },
+    /// Decline a pending party invite — the oldest, or the named inviter's.
+    #[serde(rename = "party_decline", alias = "decline_party")]
+    PartyDecline {
+        #[serde(default, alias = "target", alias = "player_name", alias = "inviter")]
+        player: Option<String>,
+    },
+    /// Leave your current party.
+    #[serde(rename = "party_leave", alias = "leave_party")]
+    PartyLeave,
     /// Use an item from the bag: gear is equipped (or taken off if already
     /// worn), consumables are drunk or read. Mirrors the web quickslot.
     #[serde(rename = "use", alias = "use_item", alias = "equip")]
@@ -357,6 +379,13 @@ pub(super) fn action_to_command(
             })
         }
         AgentAction::StopFishing => Some(ClientMessage::FishingStop),
+        AgentAction::PartyInvite { player } => Some(ClientMessage::PartyInvite {
+            target_name: player.clone(),
+        }),
+        AgentAction::PartyLeave => Some(ClientMessage::PartyLeave),
+        // Answering needs the stored invite; handled in
+        // `execute::handle_response`.
+        AgentAction::PartyAccept { .. } | AgentAction::PartyDecline { .. } => None,
         // Need player-name → id resolution from SharedState; handled in
         // `execute::handle_response`, not here.
         AgentAction::OfferDeal { .. } => None,
@@ -434,6 +463,48 @@ mod tests {
         assert_eq!(target, None);
         assert_eq!(x, Some(10.0));
         assert_eq!(z, Some(-5.0));
+    }
+
+    #[test]
+    fn party_actions_parse_with_aliases() {
+        let action = parse_single_action(
+            r#"{"actions": [{"type": "party_invite", "player": "darkcocoa"}]}"#,
+        );
+        let AgentAction::PartyInvite { player } = action else {
+            panic!("expected PartyInvite");
+        };
+        assert_eq!(player, "darkcocoa");
+
+        for (json, expected) in [
+            (
+                r#"{"actions": [{"type": "party_accept"}]}"#,
+                AgentAction::PartyAccept { player: None },
+            ),
+            (
+                r#"{"actions": [{"type": "join_party"}]}"#,
+                AgentAction::PartyAccept { player: None },
+            ),
+            (
+                r#"{"actions": [{"type": "party_decline"}]}"#,
+                AgentAction::PartyDecline { player: None },
+            ),
+            (
+                r#"{"actions": [{"type": "leave_party"}]}"#,
+                AgentAction::PartyLeave,
+            ),
+        ] {
+            assert!(
+                matches!((parse_single_action(json), &expected), (a, e) if std::mem::discriminant(&a) == std::mem::discriminant(e)),
+                "{json}"
+            );
+        }
+
+        let action =
+            parse_single_action(r#"{"actions": [{"type": "party_decline", "player": "Mallory"}]}"#);
+        let AgentAction::PartyDecline { player } = action else {
+            panic!("expected PartyDecline");
+        };
+        assert_eq!(player.as_deref(), Some("Mallory"));
     }
 
     #[test]

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -231,6 +231,32 @@ pub(super) async fn handle_response(
             continue;
         }
 
+        // Party answers need the stored invite: the inviter may be outside
+        // the AOI, where name resolution finds nobody.
+        if let AgentAction::PartyAccept { player } | AgentAction::PartyDecline { player } = action {
+            let accept = matches!(action, AgentAction::PartyAccept { .. });
+            let mut s = state.lock().await;
+            let idx = match player.as_deref() {
+                Some(name) => s
+                    .pending_party_invites
+                    .iter()
+                    .position(|(_, n)| n.eq_ignore_ascii_case(name)),
+                None => (!s.pending_party_invites.is_empty()).then_some(0),
+            };
+            let Some(idx) = idx else {
+                s.push_agent_event("[PartyFailed] No pending party invite to answer.".to_string());
+                continue;
+            };
+            let (inviter_id, inviter_name) = s.pending_party_invites.remove(idx);
+            let cmd = onlinerpg_shared::ClientMessage::PartyRespond { inviter_id, accept };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send party response: {e}");
+            } else if !accept {
+                s.push_agent_event(format!("[Party] You declined {inviter_name}'s invite."));
+            }
+            continue;
+        }
+
         // Use an item: worn gear comes off, anything else is equipped or
         // consumed out of the bag. Lighting a torch is equipping one.
         if let AgentAction::Use { item } = action {

--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -422,6 +422,23 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
             crate::shop_info::format_price(*npc_gold),
         )),
         ServerMessage::TradeError { message } => Some(format!("[TradeError] {message}")),
+        ServerMessage::PartyInviteReceived { inviter_name, .. } => Some(format!(
+            "[PartyInvite] {inviter_name} invited you to their party. Accept with \
+             {{\"action\":\"party_accept\"}} or decline with party_decline."
+        )),
+        ServerMessage::PartyInviteResult { message, .. } => Some(format!("[Party] {message}")),
+        ServerMessage::PartyState { members, .. } => Some(if members.is_empty() {
+            "[Party] You are no longer in a party.".to_string()
+        } else {
+            format!(
+                "[Party] Members: {}",
+                members
+                    .iter()
+                    .map(|m| m.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }),
         // Fishing: only the endings reach the LLM (reflexes answered the
         // rest). Word the outcome so the model knows what it can do next.
         ServerMessage::FishingEnded { player_id, outcome } => {

--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -436,6 +436,9 @@ pub fn msg_name(msg: &onlinerpg_shared::ServerMessage) -> &'static str {
         ServerMessage::DealResult { .. } => "DealResult",
         ServerMessage::TradeNotice { .. } => "TradeNotice",
         ServerMessage::TradeBusy { .. } => "TradeBusy",
+        ServerMessage::PartyInviteReceived { .. } => "PartyInviteReceived",
+        ServerMessage::PartyInviteResult { .. } => "PartyInviteResult",
+        ServerMessage::PartyState { .. } => "PartyState",
     }
 }
 

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -341,6 +341,12 @@ pub struct SharedState {
     /// Last stance the fight reflex sent, so each `FishingFight` beat only
     /// resends on change.
     pub fishing_stance: Option<onlinerpg_shared::fishing::FishingAction>,
+    /// Unanswered party invites, oldest first (capped; a flood can't swap
+    /// the invite out from under an in-flight `party_accept`).
+    pub pending_party_invites: Vec<(PlayerId, String)>,
+    /// Current party roster from `PartyState`; empty = not in a party.
+    pub party_members: Vec<onlinerpg_shared::messages::PartyMember>,
+    pub party_leader: Option<PlayerId>,
     /// Known nearby players
     pub nearby_players: HashMap<PlayerId, Player>,
     /// Per-merchant list of units we sold this session, repurchasable at the
@@ -425,6 +431,9 @@ impl SharedState {
             trade_busy: false,
             self_fishing: false,
             fishing_stance: None,
+            pending_party_invites: Vec::new(),
+            party_members: Vec::new(),
+            party_leader: None,
             nearby_players: HashMap::new(),
             merchant_buyback: HashMap::new(),
             nearby_monsters: HashMap::new(),
@@ -893,6 +902,12 @@ impl SharedState {
             // Routine: feedback on our own command (/who output, whisper
             // errors) — worth seeing, not worth an immediate wakeup.
             ServerMessage::SystemMessage { .. } => EventUrgency::Routine,
+            // Urgent: an invite to answer while it is live, or the verdict
+            // on our own invite.
+            ServerMessage::PartyInviteReceived { .. } | ServerMessage::PartyInviteResult { .. } => {
+                EventUrgency::Urgent
+            }
+            ServerMessage::PartyState { .. } => EventUrgency::Routine,
             // Urgent: kicked
             ServerMessage::Kicked { .. } => EventUrgency::Urgent,
 
@@ -1283,6 +1298,26 @@ impl SharedState {
             }
             ServerMessage::TradeBusy { busy } => {
                 self.trade_busy = *busy;
+            }
+            ServerMessage::PartyInviteReceived {
+                inviter_id,
+                ref inviter_name,
+            } => {
+                let queue = &mut self.pending_party_invites;
+                if queue.len() < 3 && !queue.iter().any(|(id, _)| id == inviter_id) {
+                    queue.push((*inviter_id, inviter_name.clone()));
+                }
+            }
+            ServerMessage::PartyState {
+                leader_id,
+                ref members,
+            } => {
+                self.party_leader = (!members.is_empty()).then_some(*leader_id);
+                self.party_members = members.clone();
+                // Joining a party settles whichever invite led to it.
+                if !members.is_empty() {
+                    self.pending_party_invites.clear();
+                }
             }
             ServerMessage::InventoryState { ref inventory }
             | ServerMessage::InventoryUpdated { ref inventory } => {
@@ -1901,6 +1936,26 @@ impl SharedState {
                 .collect();
             worn.sort();
             lines.push(format!("You are wearing: {}", worn.join(", ")));
+        }
+
+        if !self.party_members.is_empty() {
+            let names: Vec<String> = self
+                .party_members
+                .iter()
+                .map(|m| {
+                    if Some(m.id) == self.party_leader {
+                        format!("{} (leader)", m.name)
+                    } else {
+                        m.name.clone()
+                    }
+                })
+                .collect();
+            lines.push(format!("Your party: {}", names.join(", ")));
+        }
+        for (_, name) in &self.pending_party_invites {
+            lines.push(format!(
+                "Pending party invite from {name} — answer with party_accept or party_decline"
+            ));
         }
 
         // Nearby players (exclude self and humans beyond the sight radius)

--- a/client/src/lib/chat-commands.ts
+++ b/client/src/lib/chat-commands.ts
@@ -56,6 +56,7 @@ const COMMANDS: Record<string, Command> = {
   '/whisper': { desc: 'Send a private message: /whisper <player> <message>' },
   '/block': { desc: 'Block whispers from a player: /block <player>' },
   '/unblock': { desc: 'Unblock a player: /unblock <player>' },
+  '/party': { desc: 'Invite a player to your party: /party <player>' },
   '/give': { desc: 'Give yourself an item: /give <item_id>', admin: true },
   '/notice': {
     desc: 'Set the server banner, or clear it with a bare /notice',

--- a/client/src/lib/components/GameHud.svelte
+++ b/client/src/lib/components/GameHud.svelte
@@ -12,6 +12,8 @@
   import TradeWindow from './TradeWindow.svelte'
   import FishingPrompt from './FishingPrompt.svelte'
   import TradeOfferToast from './TradeOfferToast.svelte'
+  import PartyInviteToast from './PartyInviteToast.svelte'
+  import PartyPanel from './PartyPanel.svelte'
   import NpcContextMenu from './NpcContextMenu.svelte'
   import DragGhost from './DragGhost.svelte'
   import LoadingDialog from './LoadingDialog.svelte'
@@ -96,6 +98,8 @@
     />
     <TradeWindow />
     <TradeOfferToast />
+    <PartyInviteToast />
+    <PartyPanel />
     <NpcContextMenu />
     <FishingPrompt />
   {/if}

--- a/client/src/lib/components/PartyInviteToast.svelte
+++ b/client/src/lib/components/PartyInviteToast.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import {
+    pendingPartyInvites,
+    type PendingPartyInvite,
+  } from '../stores/partyStore'
+  import { networkManager } from '../network/socket'
+
+  /** Mirrors the server-side invite TTL. */
+  const INVITE_TTL_MS = 30_000
+
+  /** Oldest first — the queue keeps a flood from swapping the name under
+   *  the user's click or burying an earlier legitimate invite. */
+  const invite = $derived($pendingPartyInvites[0] ?? null)
+  const queued = $derived(Math.max(0, $pendingPartyInvites.length - 1))
+
+  function dismiss(invite: PendingPartyInvite) {
+    pendingPartyInvites.update((queue) => queue.filter((i) => i !== invite))
+  }
+
+  function respond(invite: PendingPartyInvite, accept: boolean) {
+    networkManager.sendPartyRespond(invite.inviterId, accept)
+    dismiss(invite)
+  }
+
+  $effect(() => {
+    if (!invite) return
+    const timer = setTimeout(
+      () => dismiss(invite),
+      Math.max(0, invite.offeredAt + INVITE_TTL_MS - Date.now())
+    )
+    return () => clearTimeout(timer)
+  })
+</script>
+
+{#if invite}
+  <div class="party-invite" role="alertdialog" aria-label="Party invite">
+    <span class="invite-text">
+      <strong>{invite.inviterName}</strong> invites you to a party
+      {#if queued > 0}<span class="queued">(+{queued} waiting)</span>{/if}
+    </span>
+    <button class="accept-btn" onclick={() => respond(invite, true)}>
+      Join
+    </button>
+    <button class="decline-btn" onclick={() => respond(invite, false)}>
+      Decline
+    </button>
+  </div>
+{/if}
+
+<style>
+  .party-invite {
+    position: fixed;
+    left: 50%;
+    top: 20%;
+    transform: translateX(-50%);
+    z-index: 44;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    background: rgba(6, 10, 14, 0.88);
+    backdrop-filter: blur(4px);
+    color: #e6edf3;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    pointer-events: auto;
+  }
+
+  .invite-text strong {
+    color: #7ec8ff;
+  }
+
+  .queued {
+    color: #9fb2c3;
+  }
+
+  .accept-btn,
+  .decline-btn {
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition:
+      background 150ms ease,
+      color 150ms ease;
+  }
+
+  .accept-btn {
+    background: rgba(60, 90, 60, 0.85);
+    color: #d6f0d6;
+    border: 1px solid rgba(140, 220, 140, 0.35);
+  }
+
+  .accept-btn:hover {
+    background: rgba(80, 120, 80, 0.95);
+    color: #fff;
+  }
+
+  .decline-btn {
+    background: none;
+    color: #9fb2c3;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+  }
+
+  .decline-btn:hover {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  @media (pointer: coarse) {
+    .accept-btn,
+    .decline-btn {
+      min-height: 32px;
+    }
+  }
+</style>

--- a/client/src/lib/components/PartyPanel.svelte
+++ b/client/src/lib/components/PartyPanel.svelte
@@ -19,9 +19,11 @@
     </div>
     {#each roster.members as member (member.id)}
       <div class="member">
-        {#if member.id === roster.leaderId}
-          <span class="leader-star" title="Leader">★</span>
-        {/if}
+        <span class="role-slot">
+          {#if member.id === roster.leaderId}
+            <span class="leader-crown" title="Leader">♛</span>
+          {/if}
+        </span>
         {member.name}
       </div>
     {/each}
@@ -34,8 +36,8 @@
     left: 10px;
     top: 30%;
     z-index: 30;
-    min-width: 110px;
-    padding: 6px 10px 8px;
+    min-width: 132px;
+    padding: 8px 12px 10px;
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 8px;
     background: rgba(6, 10, 14, 0.7);
@@ -50,7 +52,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    margin-bottom: 4px;
+    margin-bottom: 6px;
   }
 
   .party-title {
@@ -75,11 +77,21 @@
   }
 
   .member {
-    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    line-height: 1.7;
     white-space: nowrap;
   }
 
-  .leader-star {
+  /* Fixed slot whether or not a crown is shown, so names align. */
+  .role-slot {
+    width: 12px;
+    text-align: center;
+    flex: none;
+  }
+
+  .leader-crown {
     color: #f0c040;
   }
 </style>

--- a/client/src/lib/components/PartyPanel.svelte
+++ b/client/src/lib/components/PartyPanel.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { partyRoster } from '../stores/partyStore'
+  import { networkManager } from '../network/socket'
+
+  const roster = $derived($partyRoster)
+</script>
+
+{#if roster}
+  <div class="party-panel" aria-label="Party">
+    <div class="party-header">
+      <span class="party-title">Party</span>
+      <button
+        class="leave-btn"
+        title="Leave party"
+        onclick={() => networkManager.sendPartyLeave()}
+      >
+        Leave
+      </button>
+    </div>
+    {#each roster.members as member (member.id)}
+      <div class="member">
+        {#if member.id === roster.leaderId}
+          <span class="leader-star" title="Leader">★</span>
+        {/if}
+        {member.name}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .party-panel {
+    position: fixed;
+    left: 10px;
+    top: 30%;
+    z-index: 30;
+    min-width: 110px;
+    padding: 6px 10px 8px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    background: rgba(6, 10, 14, 0.7);
+    color: #e6edf3;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    pointer-events: auto;
+  }
+
+  .party-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 4px;
+  }
+
+  .party-title {
+    color: #7ec8ff;
+    font-weight: 700;
+  }
+
+  .leave-btn {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 4px;
+    padding: 1px 6px;
+    color: #9fb2c3;
+    font-family: inherit;
+    font-size: 10px;
+    cursor: pointer;
+  }
+
+  .leave-btn:hover {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  .member {
+    line-height: 1.5;
+    white-space: nowrap;
+  }
+
+  .leader-star {
+    color: #f0c040;
+  }
+</style>

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -47,6 +47,11 @@ import {
   pendingTradeOffer,
   type BuybackEntry,
 } from '../stores/tradeStore'
+import {
+  partyRoster,
+  pendingPartyInvites,
+  MAX_PENDING_PARTY_INVITES,
+} from '../stores/partyStore'
 import { editorTreeDataManager } from '../stores/editorStore'
 import type { MonsterData } from '../types/Monster'
 import { requestCameraReset } from '../stores/cameraStore'
@@ -429,7 +434,46 @@ export function handleServerMessage(
       addChatMessage({ text: data.message, sender: 'system' })
       break
 
+    case 'PartyInviteReceived':
+      pendingPartyInvites.update((queue) =>
+        queue.length >= MAX_PENDING_PARTY_INVITES ||
+        queue.some((invite) => invite.inviterId === data.inviter_id)
+          ? queue
+          : [
+              ...queue,
+              {
+                inviterId: data.inviter_id,
+                inviterName: data.inviter_name,
+                offeredAt: Date.now(),
+              },
+            ]
+      )
+      break
+
+    case 'PartyInviteResult':
+      addChatMessage({ text: data.message, sender: 'system' })
+      break
+
+    case 'PartyState':
+      partyRoster.set(
+        data.members.length > 0
+          ? {
+              leaderId: data.leader_id,
+              members: data.members as { id: number; name: string }[],
+            }
+          : null
+      )
+      if (data.members.length > 0) {
+        pendingPartyInvites.set([])
+      }
+      break
+
     case 'GameState':
+      // A join snapshot starts a fresh session: any party membership died
+      // with the old one (in-memory, disconnect = leave), and the server
+      // cannot re-send what no longer exists.
+      partyRoster.set(null)
+      pendingPartyInvites.set([])
       gameStore.update((state) => {
         state.otherPlayers.clear()
         remotePlayerManager.reset()

--- a/client/src/lib/network/networkTypes.ts
+++ b/client/src/lib/network/networkTypes.ts
@@ -148,6 +148,8 @@ export type ClientMessage =
   | { FishingCast: { position: Position } }
   | { FishingRespond: { action: FishingAction } }
   | 'FishingStop'
+  | { PartyRespond: { inviter_id: number; accept: boolean } }
+  | 'PartyLeave'
   | { OpenDungeonChest: { entrance_id: string } }
   | {
       BreakDungeonProp: { entrance_id: string; depth: number; prop_id: number }

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -605,6 +605,15 @@ class NetworkManager {
     this.sendMessage({ CloseShop: { merchant_player_id: merchantPlayerId } })
   }
 
+  /** Answer a party invite (ServerMessage::PartyInviteReceived). */
+  sendPartyRespond(inviterId: number, accept: boolean) {
+    this.sendMessage({ PartyRespond: { inviter_id: inviterId, accept } })
+  }
+
+  sendPartyLeave() {
+    this.sendMessage('PartyLeave')
+  }
+
   sendBuyItem(merchantPlayerId: number, itemDefId: string) {
     this.sendMessage({
       BuyItem: { merchant_player_id: merchantPlayerId, item_def_id: itemDefId },

--- a/client/src/lib/stores/gameStore.ts
+++ b/client/src/lib/stores/gameStore.ts
@@ -4,6 +4,7 @@ import type { Vector3 } from 'three'
 import type { CharacterClass, Gender } from '../network/networkTypes'
 import { resetInventoryStore } from './inventoryStore'
 import { resetSkillsStore } from './skillsStore'
+import { partyRoster, pendingPartyInvites } from './partyStore'
 import { resetFishingStore } from './fishingStore'
 import { groundItemManager } from '../managers/groundItemManager'
 
@@ -114,6 +115,8 @@ export const resetGameStore = () => {
   resetInventoryStore()
   resetSkillsStore()
   resetFishingStore()
+  partyRoster.set(null)
+  pendingPartyInvites.set([])
   groundItemManager.reset()
 }
 

--- a/client/src/lib/stores/partyStore.ts
+++ b/client/src/lib/stores/partyStore.ts
@@ -1,0 +1,29 @@
+import { writable } from 'svelte/store'
+
+/** One member as listed in ServerMessage::PartyState. */
+export interface PartyMemberEntry {
+  id: number
+  name: string
+}
+
+/** The player's party roster, driven by PartyState snapshots; null when not
+ *  in a party (the server sends an empty roster to clear it). */
+export interface PartyRoster {
+  leaderId: number
+  members: PartyMemberEntry[]
+}
+
+export const partyRoster = writable<PartyRoster | null>(null)
+
+/** A party invite the player hasn't answered yet. */
+export interface PendingPartyInvite {
+  inviterId: number
+  inviterName: string
+  offeredAt: number
+}
+
+/** Unanswered invites, oldest first — the toast shows the head, so a flood
+ *  can neither swap the name under a click nor bury a legitimate invite. */
+export const pendingPartyInvites = writable<PendingPartyInvite[]>([])
+
+export const MAX_PENDING_PARTY_INVITES = 3

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1428,6 +1428,26 @@ async fn handle_client_message(
             }
         }
 
+        ClientMessage::PartyInvite { target_name } => {
+            if let Some(id) = &state.player_id {
+                game_state.invite_to_party(id, &target_name).await;
+            }
+        }
+
+        ClientMessage::PartyRespond { inviter_id, accept } => {
+            if let Some(id) = &state.player_id {
+                game_state
+                    .respond_to_party_invite(id, &inviter_id, accept)
+                    .await;
+            }
+        }
+
+        ClientMessage::PartyLeave => {
+            if let Some(id) = &state.player_id {
+                game_state.leave_party(id).await;
+            }
+        }
+
         ClientMessage::BuyItem {
             merchant_player_id,
             item_def_id,

--- a/server/src/game_state/chat.rs
+++ b/server/src/game_state/chat.rs
@@ -96,17 +96,27 @@ pub(crate) fn parse_notice_command(message: &str) -> Option<Option<&str>> {
     Some(Some(rest).filter(|rest| !rest.is_empty()))
 }
 
+/// `/party <name>` invites; bare `/party` reports the roster.
+pub(crate) fn parse_party_command(message: &str) -> Option<Option<&str>> {
+    let rest = strip_command(message, "/party")?;
+    Some((!rest.is_empty()).then_some(rest))
+}
+
 /// How a player-typed name resolved: names are UNIQUE only case-sensitively,
 /// so an exact match wins and the case-insensitive convenience applies only
 /// while unambiguous. Shared by whisper and `/unblock`; `/block` applies the
 /// same rule in SQL (`AuthService::resolve_character_name`).
-enum NameMatch<T> {
+pub(crate) enum NameMatch<T> {
     None,
     Unique(T),
     Ambiguous,
 }
 
-fn match_name<T, I>(candidates: I, name_of: impl Fn(&T) -> &str, query: &str) -> NameMatch<T>
+pub(crate) fn match_name<T, I>(
+    candidates: I,
+    name_of: impl Fn(&T) -> &str,
+    query: &str,
+) -> NameMatch<T>
 where
     I: Iterator<Item = T> + Clone,
 {
@@ -173,6 +183,17 @@ impl super::GameState {
 
         if let Some((target_name, whisper)) = parse_whisper_command(&message) {
             self.send_whisper(player_id, target_name, whisper).await;
+            return;
+        }
+
+        if let Some(target) = parse_party_command(&message) {
+            match target {
+                Some(name) => self.invite_to_party(player_id, name).await,
+                None => {
+                    let status = self.describe_party(player_id).await;
+                    self.send_system_message(player_id, status).await;
+                }
+            }
             return;
         }
 

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -65,6 +65,7 @@ pub(crate) use deals::band_invariant_holds;
 mod dungeon;
 mod inventory;
 mod monster;
+mod party;
 mod passability;
 mod player;
 pub(crate) use player::{restored_floor_level, MoveCommand};
@@ -195,6 +196,8 @@ pub struct GameState {
     /// counts down on `tick_shop_holds` so a player can't pin an NPC forever
     /// by keeping the window open. See `register_shop_open`/`close_shop`.
     open_shops: Arc<RwLock<HashMap<PlayerId, HashMap<PlayerId, u8>>>>,
+    /// Live parties and pending invites (in-memory; a disconnect is a leave).
+    parties: Arc<RwLock<party::Parties>>,
     /// (character_id, merchant npc name) → units that character sold to
     /// that merchant, repurchasable at the recorded payout. Keyed by
     /// character (not the per-session player id) so the list survives a
@@ -277,6 +280,7 @@ impl GameState {
             dungeons: Arc::new(RwLock::new(HashMap::new())),
             dungeon_monsters: Arc::new(RwLock::new(HashMap::new())),
             open_shops: Arc::new(RwLock::new(HashMap::new())),
+            parties: Arc::new(RwLock::new(party::Parties::default())),
             buybacks: Arc::new(RwLock::new(HashMap::new())),
             blocked_names: Arc::new(RwLock::new(HashMap::new())),
             chest_opens: Arc::new(RwLock::new(HashMap::new())),

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -1,0 +1,501 @@
+use super::chat::{match_name, NameMatch};
+use crate::types::{PlayerId, ServerMessage};
+use onlinerpg_shared::messages::PartyMember;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tracing::info;
+
+pub(crate) const PARTY_MAX_MEMBERS: usize = 8;
+
+/// How long a party invite stays acceptable.
+pub(crate) const PARTY_INVITE_TTL: Duration = Duration::from_secs(30);
+
+/// Mirrors auth's character-name cap; anything longer cannot be a real name,
+/// and rejecting it early keeps oversized input out of the echoed failure.
+const MAX_TARGET_NAME_CHARS: usize = 32;
+
+/// Outstanding invites one player may have pending at once (spam brake).
+const PARTY_PENDING_INVITE_CAP: usize = 5;
+
+pub(crate) struct Party {
+    pub leader: PlayerId,
+    /// Join order; the leader leaving promotes the earliest remaining member.
+    pub members: Vec<PlayerId>,
+}
+
+/// All party state behind one lock, so the membership index can never drift
+/// from the parties themselves. In-memory only: parties live within one
+/// server run, and a disconnect is a leave.
+#[derive(Default)]
+pub(crate) struct Parties {
+    next_id: u64,
+    parties: HashMap<u64, Party>,
+    member_of: HashMap<PlayerId, u64>,
+    /// (inviter, invitee) → pending invite. Swept lazily on the invite paths
+    /// and purged with the player, so it stays tiny without its own tick.
+    invites: HashMap<(PlayerId, PlayerId), PendingInvite>,
+}
+
+pub(crate) struct PendingInvite {
+    expires_at: Instant,
+    /// A declined invite stays here (answered) until it expires: removing it
+    /// would hand the spam brake back to the inviter on every decline.
+    answered: bool,
+}
+
+impl Parties {
+    fn party_of(&self, player_id: &PlayerId) -> Option<&Party> {
+        self.member_of
+            .get(player_id)
+            .and_then(|id| self.parties.get(id))
+    }
+}
+
+/// What became of a member's removal, computed under the lock and delivered
+/// after it.
+enum Removal {
+    NotInParty,
+    Remaining {
+        leader: PlayerId,
+        members: Vec<PlayerId>,
+    },
+    Disbanded {
+        last: PlayerId,
+    },
+}
+
+impl super::GameState {
+    /// Invite `target_name` to the sender's party. Like whisper the target is
+    /// resolved by name among online players, wherever they are.
+    pub async fn invite_to_party(&self, inviter_id: &PlayerId, target_name: &str) {
+        if target_name.chars().count() > MAX_TARGET_NAME_CHARS {
+            self.party_invite_failed(inviter_id, "", "that name is too long.".to_string())
+                .await;
+            return;
+        }
+        let (inviter, target) = {
+            let players = self.players.read().await;
+            let inviter = players
+                .get(inviter_id)
+                .map(|p| (p.name.clone(), p.is_official_npc));
+            let target = match match_name(players.values(), |p| p.name.as_str(), target_name) {
+                NameMatch::Unique(p) => Ok((p.id, p.name.clone(), p.is_official_npc)),
+                NameMatch::None => Err(format!("no one called {target_name} is online.")),
+                NameMatch::Ambiguous => Err(format!(
+                    "several players match {target_name}; spell the name exactly."
+                )),
+            };
+            (inviter, target)
+        };
+        let Some((inviter_name, inviter_is_npc)) = inviter else {
+            return;
+        };
+        // Both directions: official NPCs neither receive nor send invites.
+        if inviter_is_npc {
+            self.party_invite_failed(
+                inviter_id,
+                target_name,
+                "parties are for player travelers.".to_string(),
+            )
+            .await;
+            return;
+        }
+        let (target_id, target_name, target_is_npc) = match target {
+            Ok(target) => target,
+            Err(reason) => {
+                self.party_invite_failed(inviter_id, target_name, reason)
+                    .await;
+                return;
+            }
+        };
+        if target_id == *inviter_id {
+            self.party_invite_failed(inviter_id, &target_name, "that's you.".to_string())
+                .await;
+            return;
+        }
+        // Official NPCs stay out of parties, like deals and trade windows.
+        if target_is_npc {
+            self.party_invite_failed(
+                inviter_id,
+                &target_name,
+                format!("{target_name} is an NPC — parties are for player travelers."),
+            )
+            .await;
+            return;
+        }
+
+        // Read, not act on, before the verdict: a block must change ONLY the
+        // final delivery, never the computed outcome, or the differences
+        // would let a blocked sender detect the block.
+        let suppressed = {
+            let blocked = self.blocked_names.read().await;
+            blocked
+                .get(&target_id)
+                .is_some_and(|names| names.contains(&inviter_name))
+        };
+
+        enum Outcome {
+            Deliver,
+            /// Same invite already pending: ack again, but don't re-deliver
+            /// (each re-send would re-pop the target's toast) or refresh the
+            /// TTL.
+            AckOnly,
+            Fail(String),
+        }
+        // `players` stays locked through the mutation: a disconnect blocks on
+        // it and its party sweep runs strictly afterwards, so no invite can
+        // be recorded for a player mid-removal.
+        let outcome = {
+            let players = self.players.read().await;
+            let mut parties = self.parties.write().await;
+            let now = Instant::now();
+            let mut pending = 0;
+            parties.invites.retain(|(from, _), invite| {
+                let keep = invite.expires_at > now;
+                if keep && from == inviter_id {
+                    pending += 1;
+                }
+                keep
+            });
+            if !players.contains_key(inviter_id) {
+                return;
+            }
+            if !players.contains_key(&target_id) {
+                Outcome::Fail(format!("no one called {target_name} is online."))
+            } else {
+                let already_pending = parties.invites.contains_key(&(*inviter_id, target_id));
+                let same_party = parties.member_of.contains_key(inviter_id)
+                    && parties.member_of.get(inviter_id) == parties.member_of.get(&target_id);
+                let failure = match parties.party_of(inviter_id) {
+                    Some(party) if party.leader != *inviter_id => {
+                        Some("only the party leader can invite.".to_string())
+                    }
+                    Some(party) if party.members.len() >= PARTY_MAX_MEMBERS => {
+                        Some(format!("the party is full ({PARTY_MAX_MEMBERS} members)."))
+                    }
+                    // Being in SOME party is deliberately not checked here:
+                    // any answer keyed on it would let anyone poll who is
+                    // grouped with whom. The invite is delivered and the
+                    // accept path sorts it out.
+                    _ if same_party => Some(format!("{target_name} is already in your party.")),
+                    _ => None,
+                };
+                let failure = failure.or_else(|| {
+                    (!already_pending && pending >= PARTY_PENDING_INVITE_CAP)
+                        .then(|| "you have too many pending invites.".to_string())
+                });
+                match failure {
+                    Some(reason) => Outcome::Fail(reason),
+                    None if already_pending => Outcome::AckOnly,
+                    None => {
+                        parties.invites.insert(
+                            (*inviter_id, target_id),
+                            PendingInvite {
+                                expires_at: now + PARTY_INVITE_TTL,
+                                answered: false,
+                            },
+                        );
+                        Outcome::Deliver
+                    }
+                }
+            }
+        };
+        match outcome {
+            Outcome::Fail(reason) => {
+                self.party_invite_failed(inviter_id, &target_name, reason)
+                    .await;
+            }
+            Outcome::AckOnly => {
+                self.send_system_message(inviter_id, format!("Party: invited {target_name}."))
+                    .await;
+            }
+            Outcome::Deliver => {
+                if !suppressed {
+                    self.send_direct_message(
+                        &target_id,
+                        ServerMessage::PartyInviteReceived {
+                            inviter_id: *inviter_id,
+                            inviter_name,
+                        },
+                    )
+                    .await;
+                }
+                self.send_system_message(inviter_id, format!("Party: invited {target_name}."))
+                    .await;
+            }
+        }
+    }
+
+    async fn party_invite_failed(&self, inviter_id: &PlayerId, target_name: &str, reason: String) {
+        self.send_direct_message(
+            inviter_id,
+            ServerMessage::PartyInviteResult {
+                target_name: target_name.to_string(),
+                accepted: false,
+                message: format!("Party: {reason}"),
+            },
+        )
+        .await;
+    }
+
+    pub async fn respond_to_party_invite(
+        &self,
+        invitee_id: &PlayerId,
+        inviter_id: &PlayerId,
+        accept: bool,
+    ) {
+        let valid = {
+            let mut parties = self.parties.write().await;
+            let key = (*inviter_id, *invitee_id);
+            let now = Instant::now();
+            let usable = parties
+                .invites
+                .get(&key)
+                .is_some_and(|invite| !invite.answered && invite.expires_at > now);
+            if usable {
+                if accept {
+                    parties.invites.remove(&key);
+                } else if let Some(invite) = parties.invites.get_mut(&key) {
+                    // Keep the declined entry until it expires: the spam
+                    // brake must not reset on the victim's own click.
+                    invite.answered = true;
+                }
+            }
+            usable
+        };
+        if !valid {
+            self.send_system_message(invitee_id, "Party: that invite has expired.")
+                .await;
+            return;
+        }
+        let invitee_name = self.player_name_of(invitee_id).await;
+        if !accept {
+            self.send_direct_message(
+                inviter_id,
+                ServerMessage::PartyInviteResult {
+                    target_name: invitee_name.clone(),
+                    accepted: false,
+                    message: format!("Party: {invitee_name} declined."),
+                },
+            )
+            .await;
+            return;
+        }
+
+        // `players` stays locked through the mutation (see invite_to_party):
+        // if either side disconnects mid-accept, their removal sweep runs
+        // after this insert and cleans it up, instead of leaving a ghost
+        // member no removal will ever find.
+        let players = self.players.read().await;
+        if !players.contains_key(invitee_id) {
+            return;
+        }
+        if !players.contains_key(inviter_id) {
+            drop(players);
+            self.send_system_message(invitee_id, "Party: that invite is no longer valid.")
+                .await;
+            return;
+        }
+        let result = {
+            let mut parties = self.parties.write().await;
+            if parties.member_of.contains_key(invitee_id) {
+                Err((
+                    "you are already in a party.".to_string(),
+                    format!("{invitee_name} can't accept a party invite right now."),
+                ))
+            } else if let Some(party_id) = parties.member_of.get(inviter_id).copied() {
+                let party = parties.parties.get_mut(&party_id).expect("indexed party");
+                if party.leader != *inviter_id {
+                    Err((
+                        "that invite is no longer valid.".to_string(),
+                        format!("the invite to {invitee_name} is no longer valid."),
+                    ))
+                } else if party.members.len() >= PARTY_MAX_MEMBERS {
+                    Err((
+                        "that party is full.".to_string(),
+                        "the party is full.".to_string(),
+                    ))
+                } else {
+                    party.members.push(*invitee_id);
+                    let roster = (party.leader, party.members.clone());
+                    parties.member_of.insert(*invitee_id, party_id);
+                    Ok(roster)
+                }
+            } else {
+                // First accept creates the party.
+                let party_id = parties.next_id;
+                parties.next_id += 1;
+                parties.parties.insert(
+                    party_id,
+                    Party {
+                        leader: *inviter_id,
+                        members: vec![*inviter_id, *invitee_id],
+                    },
+                );
+                parties.member_of.insert(*inviter_id, party_id);
+                parties.member_of.insert(*invitee_id, party_id);
+                Ok((*inviter_id, vec![*inviter_id, *invitee_id]))
+            }
+        };
+        // Before the sends: broadcast_party_state re-reads `players`, and a
+        // second same-task read can deadlock behind a queued writer.
+        drop(players);
+        match result {
+            Err((invitee_msg, inviter_msg)) => {
+                self.send_system_message(invitee_id, format!("Party: {invitee_msg}"))
+                    .await;
+                self.send_direct_message(
+                    inviter_id,
+                    ServerMessage::PartyInviteResult {
+                        target_name: invitee_name,
+                        accepted: false,
+                        message: format!("Party: {inviter_msg}"),
+                    },
+                )
+                .await;
+            }
+            Ok((leader, members)) => {
+                info!(
+                    invitee = %invitee_name,
+                    size = members.len(),
+                    "party join"
+                );
+                self.send_direct_message(
+                    inviter_id,
+                    ServerMessage::PartyInviteResult {
+                        target_name: invitee_name.clone(),
+                        accepted: true,
+                        message: format!("Party: {invitee_name} joined."),
+                    },
+                )
+                .await;
+                self.broadcast_party_state(leader, &members).await;
+            }
+        }
+    }
+
+    pub async fn leave_party(&self, player_id: &PlayerId) {
+        if self.remove_party_member(player_id).await {
+            self.send_system_message(player_id, "Party: you left the party.")
+                .await;
+        } else {
+            self.send_system_message(player_id, "Party: you are not in a party.")
+                .await;
+        }
+    }
+
+    /// Disconnect hook: drop the player's party membership and every invite
+    /// involving them, in either direction.
+    pub(crate) async fn clear_party_for_player(&self, player_id: &PlayerId) {
+        {
+            let mut parties = self.parties.write().await;
+            parties
+                .invites
+                .retain(|(from, to), _| from != player_id && to != player_id);
+        }
+        self.remove_party_member(player_id).await;
+    }
+
+    /// Remove a player from its party — promoting the earliest remaining
+    /// member if it led, disbanding when one member would remain. Pending
+    /// invites are untouched (leaving a party shouldn't void one you
+    /// received); returns false when the player was in no party.
+    async fn remove_party_member(&self, player_id: &PlayerId) -> bool {
+        let removal = {
+            let mut parties = self.parties.write().await;
+            match parties.member_of.remove(player_id) {
+                None => Removal::NotInParty,
+                Some(party_id) => {
+                    let party = parties.parties.get_mut(&party_id).expect("indexed party");
+                    party.members.retain(|m| m != player_id);
+                    if party.members.len() < 2 {
+                        let last = party.members.first().copied();
+                        parties.parties.remove(&party_id);
+                        match last {
+                            Some(last) => {
+                                parties.member_of.remove(&last);
+                                Removal::Disbanded { last }
+                            }
+                            None => Removal::NotInParty,
+                        }
+                    } else {
+                        if party.leader == *player_id {
+                            party.leader = party.members[0];
+                        }
+                        Removal::Remaining {
+                            leader: party.leader,
+                            members: party.members.clone(),
+                        }
+                    }
+                }
+            }
+        };
+        match removal {
+            Removal::NotInParty => false,
+            Removal::Remaining { leader, members } => {
+                self.send_party_cleared(player_id).await;
+                self.broadcast_party_state(leader, &members).await;
+                true
+            }
+            Removal::Disbanded { last } => {
+                self.send_party_cleared(player_id).await;
+                self.send_party_cleared(&last).await;
+                self.send_system_message(&last, "Party: disbanded.").await;
+                true
+            }
+        }
+    }
+
+    pub async fn describe_party(&self, player_id: &PlayerId) -> String {
+        let (leader, ids) = {
+            let parties = self.parties.read().await;
+            match parties.party_of(player_id) {
+                Some(party) => (party.leader, party.members.clone()),
+                None => return "Party: you are not in a party. /party <name> invites.".to_string(),
+            }
+        };
+        let players = self.players.read().await;
+        let names: Vec<String> = ids
+            .iter()
+            .map(|id| {
+                let name = players.get(id).map_or("?", |p| p.name.as_str());
+                if *id == leader {
+                    format!("{name} (leader)")
+                } else {
+                    name.to_string()
+                }
+            })
+            .collect();
+        format!("Party: {}", names.join(", "))
+    }
+
+    async fn broadcast_party_state(&self, leader_id: PlayerId, member_ids: &[PlayerId]) {
+        let members: Vec<PartyMember> = {
+            let players = self.players.read().await;
+            member_ids
+                .iter()
+                .filter_map(|id| {
+                    players.get(id).map(|p| PartyMember {
+                        id: *id,
+                        name: p.name.clone(),
+                    })
+                })
+                .collect()
+        };
+        let msg = ServerMessage::PartyState { leader_id, members };
+        for id in member_ids {
+            self.send_direct_message(id, msg.clone()).await;
+        }
+    }
+
+    async fn send_party_cleared(&self, player_id: &PlayerId) {
+        self.send_direct_message(
+            player_id,
+            ServerMessage::PartyState {
+                leader_id: PlayerId::from(0),
+                members: Vec::new(),
+            },
+        )
+        .await;
+    }
+}

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -546,6 +546,11 @@ impl super::GameState {
             players.remove(player_id)
         };
 
+        // After the roster removal on purpose: party mutations hold the
+        // players lock, so an in-flight accept lands before this sweep and
+        // gets cleaned up instead of leaving a ghost member.
+        self.clear_party_for_player(player_id).await;
+
         if let Some(player) = removed_player {
             self.remove_player_spatial_cell(player_id, &player.position)
                 .await;

--- a/server/src/game_state/tests/mod.rs
+++ b/server/src/game_state/tests/mod.rs
@@ -20,6 +20,7 @@ mod dungeon_tests;
 mod enchant_tests;
 mod fishing_tests;
 mod movement_tests;
+mod party_tests;
 mod persistence_tests;
 mod pickup_tests;
 mod player_tests;

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -1,0 +1,554 @@
+use super::*;
+
+fn drain(rx: &mut UnboundedReceiver<ServerMessage>) {
+    while rx.try_recv().is_ok() {}
+}
+
+async fn add(game_state: &GameState, name: &str, x: f32) -> UnboundedReceiver<ServerMessage> {
+    game_state.add_player(make_player(name, x, 0.0)).await;
+    game_state.register_direct_channel(&pid(name)).await
+}
+
+async fn form_party(game_state: &GameState, leader: &str, member: &str) {
+    game_state.invite_to_party(&pid(leader), member).await;
+    game_state
+        .respond_to_party_invite(&pid(member), &pid(leader), true)
+        .await;
+}
+
+#[tokio::test]
+async fn invite_and_accept_forms_party() {
+    let game_state = make_test_game_state("party_form");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    // Far outside the AOI on purpose: invites are name-based like whisper.
+    let mut bob_rx = add(&game_state, "bob", 500.0).await;
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteReceived {
+            inviter_id,
+            inviter_name,
+        }) => {
+            assert_eq!(inviter_id, pid("alice"));
+            assert_eq!(inviter_name, "alice");
+        }
+        other => panic!("Expected invite for bob, got {:?}", other),
+    }
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("invited bob"), "{message}")
+        }
+        other => panic!("Expected ack for alice, got {:?}", other),
+    }
+
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), true)
+        .await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult { accepted, .. }) => assert!(accepted),
+        other => panic!("Expected accepted result, got {:?}", other),
+    }
+    for rx in [&mut alice_rx, &mut bob_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PartyState { leader_id, members }) => {
+                assert_eq!(leader_id, pid("alice"));
+                let names: Vec<&str> = members.iter().map(|m| m.name.as_str()).collect();
+                assert_eq!(names, ["alice", "bob"]);
+            }
+            other => panic!("Expected party state, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test]
+async fn decline_reports_to_inviter_and_forms_nothing() {
+    let game_state = make_test_game_state("party_decline");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), false)
+        .await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("declined"), "{message}");
+        }
+        other => panic!("Expected declined result, got {:?}", other),
+    }
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    // A declined invite cannot be accepted afterwards.
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), true)
+        .await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("expired"), "{message}")
+        }
+        other => panic!("Expected expired notice, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn respond_without_invite_is_expired() {
+    let game_state = make_test_game_state("party_no_invite");
+    let _alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), true)
+        .await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("expired"), "{message}")
+        }
+        other => panic!("Expected expired notice, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn leader_leave_promotes_earliest_member() {
+    let game_state = make_test_game_state("party_promote");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    let mut carol_rx = add(&game_state, "carol", 10.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    form_party(&game_state, "alice", "carol").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    drain(&mut carol_rx);
+
+    game_state.leave_party(&pid("alice")).await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyState { members, .. }) => assert!(members.is_empty()),
+        other => panic!("Expected cleared state for alice, got {:?}", other),
+    }
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("left"), "{message}")
+        }
+        other => panic!("Expected leave notice, got {:?}", other),
+    }
+    for rx in [&mut bob_rx, &mut carol_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PartyState { leader_id, members }) => {
+                assert_eq!(leader_id, pid("bob"));
+                let names: Vec<&str> = members.iter().map(|m| m.name.as_str()).collect();
+                assert_eq!(names, ["bob", "carol"]);
+            }
+            other => panic!("Expected promoted roster, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test]
+async fn party_of_two_disbands_on_leave() {
+    let game_state = make_test_game_state("party_disband");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.leave_party(&pid("bob")).await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::PartyState { members, .. }) => assert!(members.is_empty()),
+        other => panic!("Expected cleared state for bob, got {:?}", other),
+    }
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyState { members, .. }) => assert!(members.is_empty()),
+        other => panic!("Expected cleared state for alice, got {:?}", other),
+    }
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("disbanded"), "{message}")
+        }
+        other => panic!("Expected disband notice, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn disconnect_leaves_party() {
+    let game_state = make_test_game_state("party_disconnect");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    let mut carol_rx = add(&game_state, "carol", 10.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    form_party(&game_state, "alice", "carol").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    drain(&mut carol_rx);
+
+    game_state.remove_player(&pid("bob")).await;
+    for rx in [&mut alice_rx, &mut carol_rx] {
+        let state = loop {
+            match rx.try_recv() {
+                Ok(ServerMessage::PartyState { leader_id, members }) => break (leader_id, members),
+                Ok(_) => continue,
+                Err(err) => panic!("Expected roster after disconnect, got {:?}", err),
+            }
+        };
+        assert_eq!(state.0, pid("alice"));
+        let names: Vec<&str> = state.1.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, ["alice", "carol"]);
+    }
+}
+
+#[tokio::test]
+async fn only_the_leader_invites() {
+    let game_state = make_test_game_state("party_leader_only");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    let mut carol_rx = add(&game_state, "carol", 10.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("bob"), "carol").await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("leader"), "{message}");
+        }
+        other => panic!("Expected leader-only rejection, got {:?}", other),
+    }
+    assert!(matches!(carol_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn inviting_a_partied_player_gives_no_membership_oracle() {
+    let game_state = make_test_game_state("party_taken");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    let mut dave_rx = add(&game_state, "dave", 10.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    // Delivered like any other invite: an inviter-visible difference keyed
+    // on bob's membership would let anyone poll who is grouped with whom.
+    game_state.invite_to_party(&pid("dave"), "bob").await;
+    match dave_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("invited bob"), "{message}")
+        }
+        other => panic!("Expected plain ack, got {:?}", other),
+    }
+    assert!(matches!(
+        bob_rx.try_recv(),
+        Ok(ServerMessage::PartyInviteReceived { .. })
+    ));
+
+    // The accept path sorts it out instead.
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("dave"), true)
+        .await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("already in a party"), "{message}")
+        }
+        other => panic!("Expected already-in-party notice, got {:?}", other),
+    }
+    match dave_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("can't accept"), "{message}");
+        }
+        other => panic!("Expected neutral failure, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn cannot_invite_your_own_member() {
+    let game_state = make_test_game_state("party_own_member");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("already in your party"), "{message}");
+        }
+        other => panic!("Expected own-member rejection, got {:?}", other),
+    }
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn decline_does_not_reset_the_spam_brake() {
+    let game_state = make_test_game_state("party_decline_brake");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), false)
+        .await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    // Re-inviting right after the decline must not pop a fresh toast.
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("invited bob"), "{message}")
+        }
+        other => panic!("Expected plain ack, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn official_npcs_cannot_be_invited() {
+    let game_state = make_test_game_state("party_npc");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut npc = make_player("rica", 5.0, 0.0);
+    npc.is_official_npc = true;
+    game_state.add_player(npc).await;
+    let mut npc_rx = game_state.register_direct_channel(&pid("rica")).await;
+    drain(&mut alice_rx);
+
+    game_state.invite_to_party(&pid("alice"), "rica").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("NPC"), "{message}");
+        }
+        other => panic!("Expected NPC rejection, got {:?}", other),
+    }
+    assert!(matches!(npc_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn official_npcs_cannot_invite_either() {
+    let game_state = make_test_game_state("party_npc_inviter");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut npc = make_player("karl", 5.0, 0.0);
+    npc.is_official_npc = true;
+    game_state.add_player(npc).await;
+    let mut npc_rx = game_state.register_direct_channel(&pid("karl")).await;
+    drain(&mut alice_rx);
+
+    game_state.invite_to_party(&pid("karl"), "alice").await;
+    match npc_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("player travelers"), "{message}");
+        }
+        other => panic!("Expected NPC-inviter rejection, got {:?}", other),
+    }
+    assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn repeat_invite_is_acked_but_not_redelivered() {
+    let game_state = make_test_game_state("party_repeat");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    assert!(matches!(
+        bob_rx.try_recv(),
+        Ok(ServerMessage::PartyInviteReceived { .. })
+    ));
+    // The re-invite must not pop a second toast on bob's screen.
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    for _ in 0..2 {
+        match alice_rx.try_recv() {
+            Ok(ServerMessage::SystemMessage { message }) => {
+                assert!(message.contains("invited bob"), "{message}")
+            }
+            other => panic!("Expected ack, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test]
+async fn pending_invites_are_capped() {
+    let game_state = make_test_game_state("party_invite_cap");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    for i in 1..=6 {
+        add(&game_state, &format!("target{i}"), i as f32).await;
+    }
+    drain(&mut alice_rx);
+
+    for i in 1..=5 {
+        game_state
+            .invite_to_party(&pid("alice"), &format!("target{i}"))
+            .await;
+    }
+    drain(&mut alice_rx);
+    game_state.invite_to_party(&pid("alice"), "target6").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("too many pending"), "{message}");
+        }
+        other => panic!("Expected pending-cap rejection, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn leaving_no_party_keeps_received_invites() {
+    let game_state = make_test_game_state("party_leave_keeps_invite");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    game_state.leave_party(&pid("bob")).await;
+    drain(&mut bob_rx);
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), true)
+        .await;
+    match bob_rx.try_recv() {
+        Ok(ServerMessage::PartyState { members, .. }) => assert_eq!(members.len(), 2),
+        other => panic!("Expected party formed after stray /leave, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn full_party_rejects_further_invites() {
+    let game_state = make_test_game_state("party_full");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    for i in 2..=8 {
+        let name = format!("member{i}");
+        add(&game_state, &name, i as f32).await;
+        form_party(&game_state, "alice", &name).await;
+    }
+    let mut extra_rx = add(&game_state, "extra", 50.0).await;
+    drain(&mut alice_rx);
+
+    game_state.invite_to_party(&pid("alice"), "extra").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("full"), "{message}");
+        }
+        other => panic!("Expected full-party rejection, got {:?}", other),
+    }
+    assert!(matches!(extra_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn blocked_inviter_gets_a_silent_expiry() {
+    let game_state = make_test_game_state("party_blocked");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    game_state
+        .set_player_blocks(&pid("bob"), vec!["alice".to_string()])
+        .await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.invite_to_party(&pid("alice"), "bob").await;
+    // The block is invisible: alice gets the normal ack, bob hears nothing.
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("invited bob"), "{message}")
+        }
+        other => panic!("Expected normal ack, got {:?}", other),
+    }
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn self_and_unknown_invites_are_rejected() {
+    let game_state = make_test_game_state("party_bad_targets");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+
+    game_state.invite_to_party(&pid("alice"), "alice").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("that's you"), "{message}");
+        }
+        other => panic!("Expected self-invite rejection, got {:?}", other),
+    }
+
+    game_state.invite_to_party(&pid("alice"), "nobody").await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyInviteResult {
+            accepted, message, ..
+        }) => {
+            assert!(!accepted);
+            assert!(message.contains("no one called"), "{message}");
+        }
+        other => panic!("Expected unknown-name rejection, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn party_chat_command_invites_and_reports() {
+    let game_state = make_test_game_state("party_command");
+    let auth = make_test_auth("party_command");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state
+        .send_chat_message(&pid("alice"), "/party".to_string(), &auth)
+        .await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("not in a party"), "{message}")
+        }
+        other => panic!("Expected empty-party status, got {:?}", other),
+    }
+
+    game_state
+        .send_chat_message(&pid("alice"), "/party bob".to_string(), &auth)
+        .await;
+    assert!(matches!(
+        bob_rx.try_recv(),
+        Ok(ServerMessage::PartyInviteReceived { .. })
+    ));
+    drain(&mut alice_rx);
+    game_state
+        .respond_to_party_invite(&pid("bob"), &pid("alice"), true)
+        .await;
+    drain(&mut alice_rx);
+
+    game_state
+        .send_chat_message(&pid("alice"), "/party".to_string(), &auth)
+        .await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("alice (leader)"), "{message}");
+            assert!(message.contains("bob"), "{message}");
+        }
+        other => panic!("Expected roster status, got {:?}", other),
+    }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -34,7 +34,8 @@ pub const NPC_TOKEN_PATH_FROM_ROOT: &str = "data/npc_token";
 ///     (cast/bite/struggle messages) — see `doc/FISHING.md`.
 /// v8: fishing struggle rounds replaced by continuous FishingFight beats.
 /// v9: `Player.main_hand` + PlayerMainHandChanged equipment broadcast.
-pub const PROTOCOL_VERSION: u32 = 9;
+/// v10: party (PartyInvite/PartyRespond/PartyLeave, PartyState snapshots).
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// WebSocket close code sent when the handshake is refused (wrong protocol
 /// version, or traffic before `ClientInfo`). Lives outside the serialized

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -82,6 +82,13 @@ pub struct BuybackEntry {
     pub price: i64,
 }
 
+/// One party member as listed in `PartyState`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartyMember {
+    pub id: PlayerId,
+    pub name: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
     /// Mandatory first message: protocol check plus who is connecting. The
@@ -310,6 +317,19 @@ pub enum ClientMessage {
     OpenTrade {
         target_player_id: PlayerId,
     },
+    /// Invite a named player to the sender's party. Name-based like whisper:
+    /// the target may be outside the sender's AOI.
+    PartyInvite {
+        target_name: String,
+    },
+    /// Accept or decline a pending party invite from `inviter_id`.
+    PartyRespond {
+        inviter_id: PlayerId,
+        accept: bool,
+    },
+    /// Leave the current party. The leader leaving promotes the earliest
+    /// remaining member; a party reduced to one member disbands.
+    PartyLeave,
     /// Cast the equipped fishing rod at a water point. The server validates
     /// rod, range, floor and water (water-field depth at the point) and
     /// answers with a `FishingCasted` broadcast or a direct `FishingError`.
@@ -460,6 +480,25 @@ pub enum ServerMessage {
     /// line, not the player's own speech.
     SystemMessage {
         message: String,
+    },
+    /// Direct to the invitee: a party invite to answer with `PartyRespond`
+    /// before it expires server-side.
+    PartyInviteReceived {
+        inviter_id: PlayerId,
+        inviter_name: String,
+    },
+    /// Direct to the inviter: the invite's outcome. Kept distinct from
+    /// `SystemMessage` like `TradeError` so the agent-client reacts to it.
+    PartyInviteResult {
+        target_name: String,
+        accepted: bool,
+        message: String,
+    },
+    /// Direct to each member after any roster change. Empty `members` means
+    /// the receiver is no longer in a party.
+    PartyState {
+        leader_id: PlayerId,
+        members: Vec<PartyMember>,
     },
     GameState {
         /// A list, not a map keyed by id: `PlayerId` is numeric and


### PR DESCRIPTION
First step of the plan discussed in #58: the party core. Invite, accept/decline, leave — in-memory only, as suggested there.

## Design

- **A party is born on the first accepted invite and disbands when one member would remain.** No create button, no empty or one-man parties to sweep. The leader is the first inviter; if the leader leaves, the earliest remaining member is promoted.
- **Invites are name-based with whisper's reach** (`/party <name>`, or the new `PartyInvite` message): the target may be far outside the AOI — finding each other is what parties are for.
- State is one in-memory map behind one lock, `open_shops`-style. A disconnect is a leave, cleaned up in `remove_player`.
- Protocol bumps to v10 (three client messages, three server messages).

## Abuse

Your note in #58 about harassment shaped this part, so it got the same scrutiny as trade:

- Invites respect `/block` invisibly: the outcome is computed identically for a blocked sender and only the final delivery is skipped, so no message difference reveals the block.
- Re-inviting the same person is acked but not re-delivered for the invite's 30s TTL, each sender is capped at 5 pending invites, and **declining keeps the spent entry until it expires** — the brake doesn't reset on the victim's own click.
- Whether the target is already in some party never changes the inviter's response (the invite is delivered; the accept path sorts it out), so there is no way to poll who is grouped with whom.
- Official NPCs neither send nor receive invites, like deals and trade windows.
- The web toast is a small queue, oldest first, so an invite flood can neither swap the name under a click nor bury a legitimate invite.

## Concurrency

Party mutations hold the `players` read lock while writing the party map, and `remove_player` clears party state only after the roster removal. An in-flight accept therefore lands strictly before the disconnect sweep and gets promoted/disbanded normally — no ghost member a later removal would never find. The lock edge is one-directional (`players` → `parties`, no `.await` inside the write sections).

## Agents are players too

The agent-client receives invites as urgent events, keeps pending inviters in its world state, and answers with `party_accept` / `party_decline` (optionally naming the inviter). Tested live on a local server: invited my agent from across the map with `/party 코코아` while it was off at the Old Crypt — its model read the event and accepted on its own:

> "darkdarkcocoa가 파티 초대를 보냈다. 받아서 같이 사냥하자."

Roster, `/party` status, leave and disband all round-tripped between the web client and the agent.

## Tested

- `cargo test -p onlinerpg-server` — 229 pass (19 new party tests: forming, decline, expiry, promotion, disband, disconnect, leader-only, caps, block invisibility, NPC exclusion, oracle absence).
- `cargo test -p agent-client` — 102 pass; `cargo fmt` / `clippy` clean; `svelte-check` 0 errors.
- Live E2E as above, plus the invite toast, roster panel and session-boundary store resets in the web client.

Next, as discussed: party-member markers on the world map, as a separate PR on top of this one.


## Screenshots

The roster panel during the live test (leader crowned), and the moment 코코아 joined:

<img width="490" alt="party-panel" src="https://github.com/user-attachments/assets/48128a03-8052-4e98-9db9-2ec14ce509ec" />

<img width="1568" alt="party-live" src="https://github.com/user-attachments/assets/7541b27a-a9cb-457c-95aa-018e4dfc5266" />
