### PR TITLE
Cancel scheduled fishing sounds when the local session ends

### DIFF
--- a/client/src/lib/managers/sfxManager.test.ts
+++ b/client/src/lib/managers/sfxManager.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  cancelPendingFishingSounds,
-  playFishingSound,
-} from './sfxManager'
+import { cancelPendingFishingSounds, playFishingSound } from './sfxManager'
 
 // sfxManager caches audio pools at module level, so FakeAudio instances
 // survive across tests — count plays in a per-test map instead.

--- a/client/src/lib/managers/sfxManager.test.ts
+++ b/client/src/lib/managers/sfxManager.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cancelPendingFishingSounds,
+  playFishingSound,
+} from './sfxManager'
+
+// sfxManager caches audio pools at module level, so FakeAudio instances
+// survive across tests — count plays in a per-test map instead.
+let plays = new Map<string, number>()
+
+class FakeAudio {
+  preload = ''
+  volume = 1
+  currentTime = 0
+  constructor(public url: string) {}
+  load() {}
+  play() {
+    plays.set(this.url, (plays.get(this.url) ?? 0) + 1)
+    return Promise.resolve()
+  }
+}
+
+function playedCount(urlPart: string) {
+  let sum = 0
+  for (const [url, count] of plays) {
+    if (url.includes(urlPart)) sum += count
+  }
+  return sum
+}
+
+describe('delayed fishing sounds', () => {
+  beforeEach(() => {
+    plays = new Map()
+    vi.useFakeTimers()
+    vi.stubGlobal('Audio', FakeAudio)
+    vi.stubGlobal('window', {
+      setTimeout: setTimeout.bind(globalThis),
+      clearTimeout: clearTimeout.bind(globalThis),
+    })
+  })
+
+  afterEach(() => {
+    cancelPendingFishingSounds()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('a delayed splash plays once the flight time elapses', () => {
+    playFishingSound('splash', 1400)
+
+    expect(playedCount('splash')).toBe(0)
+    vi.advanceTimersByTime(1400)
+    expect(playedCount('splash')).toBe(1)
+  })
+
+  it('an aborted cast cancels the pending splash — no splash after the line is back in', () => {
+    playFishingSound('splash', 1400)
+
+    cancelPendingFishingSounds()
+
+    vi.advanceTimersByTime(5000)
+    expect(playedCount('splash')).toBe(0)
+  })
+
+  it('cancels every pending timer, whoosh included, when aborted inside the swing delay', () => {
+    playFishingSound('cast', 200)
+    playFishingSound('splash', 1400)
+
+    cancelPendingFishingSounds()
+
+    vi.advanceTimersByTime(5000)
+    expect(playedCount('cast')).toBe(0)
+    expect(playedCount('splash')).toBe(0)
+  })
+
+  it('cancel does not touch sounds that already played', () => {
+    playFishingSound('splash', 1400)
+    vi.advanceTimersByTime(1400)
+
+    cancelPendingFishingSounds()
+
+    expect(playedCount('splash')).toBe(1)
+  })
+
+  it('immediate sounds are unaffected by a pending-timer cancel', () => {
+    cancelPendingFishingSounds()
+    playFishingSound('plop')
+
+    expect(playedCount('plop')).toBe(1)
+  })
+})

--- a/client/src/lib/managers/sfxManager.ts
+++ b/client/src/lib/managers/sfxManager.ts
@@ -176,14 +176,26 @@ export function preloadFishingSounds() {
   }
 }
 
+const pendingFishingTimers = new Set<number>()
+
 /** `delayMs` lets e.g. the splash line up with the bobber landing rather
  *  than the swing that threw it (same pattern as `playSwordMissSound`). */
 export function playFishingSound(kind: FishingSound, delayMs = 0) {
   if (!canUseAudio()) return
   if (delayMs > 0) {
-    window.setTimeout(() => playFishingSound(kind), delayMs)
+    const timer = window.setTimeout(() => {
+      pendingFishingTimers.delete(timer)
+      playFishingSound(kind)
+    }, delayMs)
+    pendingFishingTimers.add(timer)
     return
   }
   const { url, volume, pool } = FISHING_SOUNDS[kind]
   playAudioFromPool(fishingPools, url, volume, pool)
+}
+
+/** A cast aborted mid-flight must not splash after the line is back in. */
+export function cancelPendingFishingSounds() {
+  for (const timer of pendingFishingTimers) window.clearTimeout(timer)
+  pendingFishingTimers.clear()
 }

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -13,7 +13,10 @@ import type { GameState, LocalPlayer, RemotePlayer } from '../stores/gameStore'
 import { Vector3 } from 'three'
 import { remotePlayerManager } from '../managers/remotePlayerManager'
 import { FishingAnimationName } from '../types/animations'
-import { playFishingSound } from '../managers/sfxManager'
+import {
+  cancelPendingFishingSounds,
+  playFishingSound,
+} from '../managers/sfxManager'
 import { FISHING_CAST_SWING_DELAY_MS } from '../data/combatTiming'
 import { monsterManager } from '../managers/monsterManager'
 import { housingManager } from '../managers/housingManager'
@@ -1155,6 +1158,7 @@ export function handleServerMessage(
       }
       if (isSelf) {
         myFishing.set({ phase: 'idle' })
+        cancelPendingFishingSounds()
         const outcome = data.outcome
         if (outcome === 'Escaped') {
           playFishingSound('snap')


### PR DESCRIPTION
## Summary

Fixes the item from `doc/TODO.md` (낚시 후속 / PR #53 review):

> 어보트된 캐스팅의 스플래시 사운드 setTimeout 취소

Aborting a cast mid-flight (e.g. walking away before the bobber lands) still played the splash one flight-time later, because the delayed `cast`/`splash` timers in `sfxManager` fired with no way to cancel them.

- `sfxManager` now tracks pending delayed fishing-sound timers and exposes `cancelPendingFishingSounds()`.
- `FishingEnded` for the local player clears any pending timers before playing the outcome sound. Immediate sounds (`plop`, `snap`, `catch`) and already-played sounds are unaffected; an abort inside the swing delay also cancels the whoosh.

## Test plan

- [x] 5 new tests in `sfxManager.test.ts` (fake timers + stubbed `Audio`): delayed splash plays on schedule, cancel before landing suppresses it, cancel inside the swing delay suppresses both sounds, cancel leaves played/immediate sounds alone
- [x] `npx vitest run` — 355 passed
- [x] `npm run lint` / `npm run check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)