### PR TITLE
Walk toward out-of-range water instead of sending a doomed cast

### DIFF
--- a/client/src/lib/managers/inputHandler.test.ts
+++ b/client/src/lib/managers/inputHandler.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as THREE from 'three'
 
 const MIN_FISHABLE_DEPTH_M = 0.3
+const MAX_CAST_DISTANCE_M = 8
 
 vi.mock('../wasm/onlinerpg_shared', () => ({
   min_fishable_depth_m: () => MIN_FISHABLE_DEPTH_M,
+  max_cast_distance_m: () => MAX_CAST_DISTANCE_M,
 }))
 
 import { inputHandler, type RaycastContext } from './inputHandler'
@@ -110,6 +112,47 @@ describe('processCanvasClick cast-vs-walk', () => {
     )
 
     expect(intent.type).toBe('move_to_ground')
+  })
+
+  it('walks toward water beyond the cast range instead of sending a doomed cast', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => 1.0,
+        playerPosition: { x: MAX_CAST_DISTANCE_M + 1, y: 0, z: 0 },
+      })
+    )
+
+    expect(intent.type).toBe('move_to_ground')
+  })
+
+  it('still casts just inside the maximum range', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => 1.0,
+        // Not exactly MAX: the raycast hit lands within float epsilon of the
+        // origin, which would flip an exact-boundary check either way.
+        playerPosition: { x: MAX_CAST_DISTANCE_M - 0.01, y: 0, z: 0 },
+      })
+    )
+
+    expect(intent.type).toBe('cast_fishing')
+  })
+
+  it('range is measured in XZ, ignoring height difference', () => {
+    const intent = inputHandler.processCanvasClick(
+      centerClick(),
+      contextWith({
+        canCastFishing: true,
+        waterSurfaceAt: () => 1.0,
+        playerPosition: { x: 3, y: 50, z: 4 },
+      })
+    )
+
+    expect(intent.type).toBe('cast_fishing')
   })
 
   it('walks when no water sampler is wired up (dungeon / upper floors)', () => {

--- a/client/src/lib/managers/inputHandler.ts
+++ b/client/src/lib/managers/inputHandler.ts
@@ -3,7 +3,10 @@ import * as THREE from 'three'
 import { get } from 'svelte/store'
 import { myFishing } from '../stores/fishingStore'
 import { isTypingTarget } from '../utils/dom'
-import { min_fishable_depth_m } from '../wasm/onlinerpg_shared'
+import {
+  max_cast_distance_m,
+  min_fishable_depth_m,
+} from '../wasm/onlinerpg_shared'
 import type { Position } from '../utils/movementUtils'
 import type { WallDirection } from '../utils/house-geometry'
 
@@ -470,10 +473,16 @@ class InputHandler {
         groundHit.point.x,
         groundHit.point.z
       )
+      // Out-of-range water falls through to a walk (mirrors the server's
+      // XZ range check) instead of sending a cast it would reject.
+      const castDx = groundHit.point.x - context.playerPosition.x
+      const castDz = groundHit.point.z - context.playerPosition.z
+      const maxCast = max_cast_distance_m()
       if (
         context.canCastFishing &&
         waterSurface !== undefined &&
-        waterSurface - groundHit.point.y > min_fishable_depth_m()
+        waterSurface - groundHit.point.y > min_fishable_depth_m() &&
+        castDx * castDx + castDz * castDz <= maxCast * maxCast
       ) {
         return {
           type: 'cast_fishing',

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -96,6 +96,13 @@ pub fn min_fishable_depth_m() -> f32 {
     crate::fishing::MIN_FISHABLE_DEPTH_M
 }
 
+/// Cast range (`MAX_CAST_DISTANCE_METERS`), so the client can walk toward
+/// out-of-range water instead of sending a cast the server will reject.
+#[wasm_bindgen]
+pub fn max_cast_distance_m() -> f32 {
+    crate::fishing::MAX_CAST_DISTANCE_METERS
+}
+
 // --- Passability cache (WASM global state) ---
 
 thread_local! {


### PR DESCRIPTION
## Summary

Fixes the item from `doc/TODO.md` (낚시 후속 / PR #53 review):

> 클라이언트 사전 사거리 검사 (MAX_CAST_DISTANCE_METERS wasm 노출)

Clicking fishable water beyond the 8m cast range sent the cast anyway — the server rejected it (`server/src/game_state/fishing.rs` range check) and the player only saw an error line. One wasted round-trip, and a click that visibly did nothing.

- `shared/src/wasm_api.rs`: expose `max_cast_distance_m()` next to `min_fishable_depth_m()`, so the client uses the server's exact constant and can't drift.
- `inputHandler.ts`: the cast-vs-walk gate now also mirrors the server's XZ range check. Out-of-range water falls through to `move_to_ground`, so the click walks the player toward the water — consistent with how every other out-of-range interaction feels.
- Server validation is untouched and still authoritative.

## Test plan

- [x] 3 new cases in `inputHandler.test.ts`: beyond range → walk, just inside range → cast, range measured in XZ ignoring height. (An exact-boundary case turned out flaky — the raycast hit lands within float epsilon of the origin — so the boundary is pinned just inside instead.)
- [x] `npx vitest run` — 353 passed
- [x] `npm run lint` / `npm run check` / `npm run format:check` — clean
- [x] `cargo fmt --check` / `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)