### PR TITLE
Show party member positions on the world map (#58 step 2)

### DIFF
--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -439,6 +439,7 @@ pub fn msg_name(msg: &onlinerpg_shared::ServerMessage) -> &'static str {
         ServerMessage::PartyInviteReceived { .. } => "PartyInviteReceived",
         ServerMessage::PartyInviteResult { .. } => "PartyInviteResult",
         ServerMessage::PartyState { .. } => "PartyState",
+        ServerMessage::PartyPositions { .. } => "PartyPositions",
     }
 }
 

--- a/client/src/lib/components/WorldMapDialog.svelte
+++ b/client/src/lib/components/WorldMapDialog.svelte
@@ -357,6 +357,29 @@
     return out
   })
 
+  // --- Self marker pulse (HTML layer over the canvas dot) ---
+  let selfPulse = $derived.by<{ left: number; top: number } | null>(() => {
+    const cw = containerW
+    const ch = containerH
+    if (cw <= 0 || ch <= 0) return null
+
+    const viewSize = zoomSpan * REGION_PX
+    const canvasSize = Math.min(cw, ch)
+    const scale = canvasSize / viewSize
+    const viewLeft = camX - cw / scale / 2
+    const viewTop = camZ - ch / scale / 2
+
+    const lx = (playerX - viewLeft) * scale
+    const ly = (playerZ - viewTop) * scale
+    const ox = lx - cw / 2
+    const oy = ly - ch / 2
+    const left = ox * COS_R - oy * SIN_R + cw / 2
+    const top = ox * SIN_R + oy * COS_R + ch / 2
+
+    if (left < 0 || left > cw || top < 0 || top > ch) return null
+    return { left, top }
+  })
+
   // --- Party member markers (HTML layer, same transform as the labels) ---
   interface PartyMarker {
     id: number
@@ -665,6 +688,14 @@
             <span class="text">{label.name}</span>
           </div>
         {/each}
+        {#if selfPulse}
+          <div
+            class="self-pulse"
+            style="left: {selfPulse.left}px; top: {selfPulse.top}px;"
+          >
+            <span class="ring"></span>
+          </div>
+        {/if}
         {#each partyMarkers as marker (marker.id)}
           <div
             class="party-marker"
@@ -901,6 +932,38 @@
     height: 11px;
     background: #f5d250;
     border: 2px solid #287832;
+  }
+
+  /* Breathing ring over the canvas-drawn player dot: the one marker that
+     never moves shouldn't look dead. */
+  .self-pulse {
+    position: absolute;
+  }
+
+  .self-pulse .ring {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 80, 80, 0.9);
+    animation: self-ping 2s ease-out infinite;
+  }
+
+  @keyframes self-ping {
+    0% {
+      transform: translate(-50%, -50%) scale(0.6);
+      opacity: 0.9;
+    }
+    70% {
+      transform: translate(-50%, -50%) scale(2.4);
+      opacity: 0;
+    }
+    100% {
+      transform: translate(-50%, -50%) scale(2.4);
+      opacity: 0;
+    }
   }
 
   .party-marker {

--- a/client/src/lib/components/WorldMapDialog.svelte
+++ b/client/src/lib/components/WorldMapDialog.svelte
@@ -8,8 +8,7 @@
   const MIN_ZOOM = 1
   const DEFAULT_ZOOM = 8
 
-  // Party member markers refresh while the dialog is open; stays well above
-  // the server's 1s poll clamp.
+  // Party member marker poll cadence; well above the server's 1s clamp.
   const PARTY_POLL_MS = 3000
 
   // A poll answer can outlive the dialog that requested it (nothing polls
@@ -70,7 +69,11 @@
 
 <script lang="ts">
   import { gameStore, isAdminUser } from '../stores/gameStore'
-  import { partyRoster, partyPositions } from '../stores/partyStore'
+  import {
+    partyRoster,
+    partyPositions,
+    resetPartyPositions,
+  } from '../stores/partyStore'
   import { worldMapVisible, teleportLoading } from '../stores/debugStore'
   import { minimapVersion } from '../stores/editorStore'
   import { regionMinimapServerUrl } from '../terrain/regionMinimapGenerator'
@@ -172,7 +175,7 @@
     const at = $partyPositions.at
     if (at === 0) return
     const timer = setTimeout(
-      () => partyPositions.set({ at: 0, members: [] }),
+      resetPartyPositions,
       Math.max(0, at + PARTY_POSITIONS_MAX_AGE_MS - Date.now())
     )
     return () => clearTimeout(timer)
@@ -318,41 +321,47 @@
     top: number
   }
 
+  // World → overlay coords: scale around the view center, then the same
+  // -45° rotation the canvas applies (ctx.rotate(ROTATE_ANGLE)).
+  function worldToScreen(x: number, z: number, cw: number, ch: number) {
+    const scale = Math.min(cw, ch) / (zoomSpan * REGION_PX)
+    const lx = (x - (camX - cw / scale / 2)) * scale
+    const ly = (z - (camZ - ch / scale / 2)) * scale
+    const ox = lx - cw / 2
+    const oy = ly - ch / 2
+    return {
+      left: ox * COS_R - oy * SIN_R + cw / 2,
+      top: ox * SIN_R + oy * COS_R + ch / 2,
+    }
+  }
+
+  function onScreen(
+    p: { left: number; top: number },
+    cw: number,
+    ch: number,
+    margin: number
+  ) {
+    return (
+      p.left >= -margin &&
+      p.left <= cw + margin &&
+      p.top >= -margin &&
+      p.top <= ch + margin
+    )
+  }
+
   let visibleLabels = $derived.by<PlacedLabel[]>(() => {
     const cw = containerW
     const ch = containerH
     if (cw <= 0 || ch <= 0) return []
-
-    // Same view transform the canvas render effect uses.
-    const viewSize = zoomSpan * REGION_PX
-    const canvasSize = Math.min(cw, ch)
-    const scale = canvasSize / viewSize
-    const viewLeft = camX - cw / scale / 2
-    const viewTop = camZ - ch / scale / 2
 
     const margin = 80 // keep labels whose anchor is just off-edge
     const out: PlacedLabel[] = []
     for (const label of MAP_LABELS) {
       const tier = LABEL_ZOOM[label.kind]
       if (zoomSpan < tier.min || zoomSpan > tier.max) continue
-
-      // World -> pre-rotation canvas coords (matches the player marker).
-      const lx = (label.x - viewLeft) * scale
-      const ly = (label.z - viewTop) * scale
-      // Rotate around canvas center to match ctx.rotate(ROTATE_ANGLE).
-      const ox = lx - cw / 2
-      const oy = ly - ch / 2
-      const left = ox * COS_R - oy * SIN_R + cw / 2
-      const top = ox * SIN_R + oy * COS_R + ch / 2
-
-      if (
-        left < -margin ||
-        left > cw + margin ||
-        top < -margin ||
-        top > ch + margin
-      )
-        continue
-      out.push({ name: label.name, kind: label.kind, left, top })
+      const p = worldToScreen(label.x, label.z, cw, ch)
+      if (!onScreen(p, cw, ch, margin)) continue
+      out.push({ name: label.name, kind: label.kind, left: p.left, top: p.top })
     }
     return out
   })
@@ -362,22 +371,8 @@
     const cw = containerW
     const ch = containerH
     if (cw <= 0 || ch <= 0) return null
-
-    const viewSize = zoomSpan * REGION_PX
-    const canvasSize = Math.min(cw, ch)
-    const scale = canvasSize / viewSize
-    const viewLeft = camX - cw / scale / 2
-    const viewTop = camZ - ch / scale / 2
-
-    const lx = (playerX - viewLeft) * scale
-    const ly = (playerZ - viewTop) * scale
-    const ox = lx - cw / 2
-    const oy = ly - ch / 2
-    const left = ox * COS_R - oy * SIN_R + cw / 2
-    const top = ox * SIN_R + oy * COS_R + ch / 2
-
-    if (left < 0 || left > cw || top < 0 || top > ch) return null
-    return { left, top }
+    const p = worldToScreen(playerX, playerZ, cw, ch)
+    return onScreen(p, cw, ch, 20) ? p : null
   })
 
   // --- Party member markers (HTML layer, same transform as the labels) ---
@@ -397,36 +392,22 @@
     if (!roster || cw <= 0 || ch <= 0) return []
     if (Date.now() - positions.at > PARTY_POSITIONS_MAX_AGE_MS) return []
 
-    const viewSize = zoomSpan * REGION_PX
-    const canvasSize = Math.min(cw, ch)
-    const scale = canvasSize / viewSize
-    const viewLeft = camX - cw / scale / 2
-    const viewTop = camZ - ch / scale / 2
-
     // Join against the roster: a member who left since the last poll (or an
     // id the roster never knew) must not draw a ghost.
     const names = new Map(roster.members.map((m) => [m.id, m.name]))
-    const margin = 40
     const out: PartyMarker[] = []
     for (const pos of positions.members) {
       const name = names.get(pos.id)
       if (!name) continue
-
-      const lx = (wrapWorldX(pos.x) - viewLeft) * scale
-      const ly = (pos.z - viewTop) * scale
-      const ox = lx - cw / 2
-      const oy = ly - ch / 2
-      const left = ox * COS_R - oy * SIN_R + cw / 2
-      const top = ox * SIN_R + oy * COS_R + ch / 2
-
-      if (
-        left < -margin ||
-        left > cw + margin ||
-        top < -margin ||
-        top > ch + margin
-      )
-        continue
-      out.push({ id: pos.id, name, left, top, floor: pos.floor_level })
+      const p = worldToScreen(wrapWorldX(pos.x), pos.z, cw, ch)
+      if (!onScreen(p, cw, ch, 40)) continue
+      out.push({
+        id: pos.id,
+        name,
+        left: p.left,
+        top: p.top,
+        floor: pos.floor_level,
+      })
     }
     return out
   })
@@ -832,6 +813,10 @@
     inset: 0;
     overflow: hidden;
     pointer-events: none;
+    /* dark halo for readability over varied terrain */
+    --label-halo:
+      0 0 2px #000, 1px 1px 1px #000, -1px 1px 1px #000, 1px -1px 1px #000,
+      -1px -1px 1px #000;
   }
 
   .map-label {
@@ -854,13 +839,7 @@
     top: 0;
     white-space: nowrap;
     font-family: Georgia, 'Times New Roman', serif;
-    /* dark halo for readability over varied terrain */
-    text-shadow:
-      0 0 2px #000,
-      1px 1px 1px #000,
-      -1px 1px 1px #000,
-      1px -1px 1px #000,
-      -1px -1px 1px #000;
+    text-shadow: var(--label-halo);
   }
 
   /* point kinds (capital/city/town): marker centered on anchor, text to the right */
@@ -946,22 +925,24 @@
     top: 0;
     width: 14px;
     height: 14px;
+    margin: -7px 0 0 -7px;
     border-radius: 50%;
     border: 2px solid rgba(255, 80, 80, 0.9);
-    animation: self-ping 2s ease-out infinite;
+    animation: self-pulse 2s ease-out infinite;
   }
 
-  @keyframes self-ping {
+  /* The identical 70%/100% stops hold the ring invisible between pulses. */
+  @keyframes self-pulse {
     0% {
-      transform: translate(-50%, -50%) scale(0.6);
+      transform: scale(0.6);
       opacity: 0.9;
     }
     70% {
-      transform: translate(-50%, -50%) scale(2.4);
+      transform: scale(2.4);
       opacity: 0;
     }
     100% {
-      transform: translate(-50%, -50%) scale(2.4);
+      transform: scale(2.4);
       opacity: 0;
     }
   }
@@ -994,11 +975,6 @@
     font-size: 12px;
     font-weight: 700;
     color: #bfe0ff;
-    text-shadow:
-      0 0 2px #000,
-      1px 1px 1px #000,
-      -1px 1px 1px #000,
-      1px -1px 1px #000,
-      -1px -1px 1px #000;
+    text-shadow: var(--label-halo);
   }
 </style>

--- a/client/src/lib/components/WorldMapDialog.svelte
+++ b/client/src/lib/components/WorldMapDialog.svelte
@@ -8,6 +8,14 @@
   const MIN_ZOOM = 1
   const DEFAULT_ZOOM = 8
 
+  // Party member markers refresh while the dialog is open; stays well above
+  // the server's 1s poll clamp.
+  const PARTY_POLL_MS = 3000
+
+  // A poll answer can outlive the dialog that requested it (nothing polls
+  // while the map is closed); older data than this never renders.
+  const PARTY_POSITIONS_MAX_AGE_MS = 10000
+
   // --- Shared place-name labels (generated from data-src/map_labels.csv) ---
   type LabelKind = 'continent' | 'capital' | 'city' | 'town' | 'sea' | 'island'
   interface MapLabel {
@@ -62,6 +70,7 @@
 
 <script lang="ts">
   import { gameStore, isAdminUser } from '../stores/gameStore'
+  import { partyRoster, partyPositions } from '../stores/partyStore'
   import { worldMapVisible, teleportLoading } from '../stores/debugStore'
   import { minimapVersion } from '../stores/editorStore'
   import { regionMinimapServerUrl } from '../terrain/regionMinimapGenerator'
@@ -139,6 +148,34 @@
         zoomSpan = defaultZoomSpan
       }
     }
+  })
+
+  // Party existence only: roster churn must not reset the poll cadence (the
+  // immediate re-poll would just be eaten by the server's 1s clamp).
+  let inParty = $derived($partyRoster !== null)
+
+  // Poll party positions only while the dialog lives (it mounts with
+  // worldMapVisible) and a party exists — closed map means a silent channel.
+  $effect(() => {
+    if (!inParty) return
+    networkManager.sendRequestPartyPositions()
+    const timer = setInterval(
+      () => networkManager.sendRequestPartyPositions(),
+      PARTY_POLL_MS
+    )
+    return () => clearInterval(timer)
+  })
+
+  // The render-time age gate only runs when something recomputes; this makes
+  // expiry certain on an untouched map (same pattern as PartyInviteToast).
+  $effect(() => {
+    const at = $partyPositions.at
+    if (at === 0) return
+    const timer = setTimeout(
+      () => partyPositions.set({ at: 0, members: [] }),
+      Math.max(0, at + PARTY_POSITIONS_MAX_AGE_MS - Date.now())
+    )
+    return () => clearTimeout(timer)
   })
 
   // --- Drag state ---
@@ -316,6 +353,57 @@
       )
         continue
       out.push({ name: label.name, kind: label.kind, left, top })
+    }
+    return out
+  })
+
+  // --- Party member markers (HTML layer, same transform as the labels) ---
+  interface PartyMarker {
+    id: number
+    name: string
+    left: number
+    top: number
+    floor: number
+  }
+
+  let partyMarkers = $derived.by<PartyMarker[]>(() => {
+    const roster = $partyRoster
+    const positions = $partyPositions
+    const cw = containerW
+    const ch = containerH
+    if (!roster || cw <= 0 || ch <= 0) return []
+    if (Date.now() - positions.at > PARTY_POSITIONS_MAX_AGE_MS) return []
+
+    const viewSize = zoomSpan * REGION_PX
+    const canvasSize = Math.min(cw, ch)
+    const scale = canvasSize / viewSize
+    const viewLeft = camX - cw / scale / 2
+    const viewTop = camZ - ch / scale / 2
+
+    // Join against the roster: a member who left since the last poll (or an
+    // id the roster never knew) must not draw a ghost.
+    const names = new Map(roster.members.map((m) => [m.id, m.name]))
+    const margin = 40
+    const out: PartyMarker[] = []
+    for (const pos of positions.members) {
+      const name = names.get(pos.id)
+      if (!name) continue
+
+      const lx = (wrapWorldX(pos.x) - viewLeft) * scale
+      const ly = (pos.z - viewTop) * scale
+      const ox = lx - cw / 2
+      const oy = ly - ch / 2
+      const left = ox * COS_R - oy * SIN_R + cw / 2
+      const top = ox * SIN_R + oy * COS_R + ch / 2
+
+      if (
+        left < -margin ||
+        left > cw + margin ||
+        top < -margin ||
+        top > ch + margin
+      )
+        continue
+      out.push({ id: pos.id, name, left, top, floor: pos.floor_level })
     }
     return out
   })
@@ -577,6 +665,17 @@
             <span class="text">{label.name}</span>
           </div>
         {/each}
+        {#each partyMarkers as marker (marker.id)}
+          <div
+            class="party-marker"
+            style="left: {marker.left}px; top: {marker.top}px;"
+          >
+            <span class="dot"></span>
+            <span class="text"
+              >{marker.name}{marker.floor < 0 ? ` B${-marker.floor}` : ''}</span
+            >
+          </div>
+        {/each}
       </div>
     </div>
   </div>
@@ -802,5 +901,41 @@
     height: 11px;
     background: #f5d250;
     border: 2px solid #287832;
+  }
+
+  .party-marker {
+    position: absolute;
+    user-select: none;
+  }
+
+  .party-marker .dot {
+    position: absolute;
+    left: 0;
+    top: 0;
+    transform: translate(-50%, -50%);
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: #3fa7ff;
+    border: 2px solid #fff;
+    box-sizing: border-box;
+    box-shadow: 0 0 6px rgba(63, 167, 255, 0.8);
+  }
+
+  .party-marker .text {
+    position: absolute;
+    left: 0;
+    top: 0;
+    transform: translate(10px, -50%);
+    white-space: nowrap;
+    font-size: 12px;
+    font-weight: 700;
+    color: #bfe0ff;
+    text-shadow:
+      0 0 2px #000,
+      1px 1px 1px #000,
+      -1px 1px 1px #000,
+      1px -1px 1px #000,
+      -1px -1px 1px #000;
   }
 </style>

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -49,8 +49,10 @@ import {
 } from '../stores/tradeStore'
 import {
   partyRoster,
+  partyPositions,
   pendingPartyInvites,
   MAX_PENDING_PARTY_INVITES,
+  type PartyMemberPositionEntry,
 } from '../stores/partyStore'
 import { editorTreeDataManager } from '../stores/editorStore'
 import type { MonsterData } from '../types/Monster'
@@ -465,6 +467,19 @@ export function handleServerMessage(
       )
       if (data.members.length > 0) {
         pendingPartyInvites.set([])
+      } else {
+        partyPositions.set({ at: 0, members: [] })
+      }
+      break
+
+    case 'PartyPositions':
+      // A poll answer can cross a disband on the wire; without a roster it
+      // could only repopulate the store that disband just cleared.
+      if (get(partyRoster)) {
+        partyPositions.set({
+          at: Date.now(),
+          members: data.members as PartyMemberPositionEntry[],
+        })
       }
       break
 
@@ -473,6 +488,7 @@ export function handleServerMessage(
       // with the old one (in-memory, disconnect = leave), and the server
       // cannot re-send what no longer exists.
       partyRoster.set(null)
+      partyPositions.set({ at: 0, members: [] })
       pendingPartyInvites.set([])
       gameStore.update((state) => {
         state.otherPlayers.clear()

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -50,6 +50,7 @@ import {
 import {
   partyRoster,
   partyPositions,
+  resetPartyPositions,
   pendingPartyInvites,
   MAX_PENDING_PARTY_INVITES,
   type PartyMemberPositionEntry,
@@ -456,21 +457,23 @@ export function handleServerMessage(
       addChatMessage({ text: data.message, sender: 'system' })
       break
 
-    case 'PartyState':
+    case 'PartyState': {
+      const joined = data.members.length > 0
       partyRoster.set(
-        data.members.length > 0
+        joined
           ? {
               leaderId: data.leader_id,
               members: data.members as { id: number; name: string }[],
             }
           : null
       )
-      if (data.members.length > 0) {
+      if (joined) {
         pendingPartyInvites.set([])
       } else {
-        partyPositions.set({ at: 0, members: [] })
+        resetPartyPositions()
       }
       break
+    }
 
     case 'PartyPositions':
       // A poll answer can cross a disband on the wire; without a roster it
@@ -488,7 +491,7 @@ export function handleServerMessage(
       // with the old one (in-memory, disconnect = leave), and the server
       // cannot re-send what no longer exists.
       partyRoster.set(null)
-      partyPositions.set({ at: 0, members: [] })
+      resetPartyPositions()
       pendingPartyInvites.set([])
       gameStore.update((state) => {
         state.otherPlayers.clear()

--- a/client/src/lib/network/networkTypes.ts
+++ b/client/src/lib/network/networkTypes.ts
@@ -150,6 +150,7 @@ export type ClientMessage =
   | 'FishingStop'
   | { PartyRespond: { inviter_id: number; accept: boolean } }
   | 'PartyLeave'
+  | 'RequestPartyPositions'
   | { OpenDungeonChest: { entrance_id: string } }
   | {
       BreakDungeonProp: { entrance_id: string; depth: number; prop_id: number }

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -9,7 +9,7 @@ import type { WallDirection } from '../utils/house-geometry'
 import { gameStore, resetGameStore, serverNotice } from '../stores/gameStore'
 import {
   partyRoster,
-  partyPositions,
+  resetPartyPositions,
   pendingPartyInvites,
 } from '../stores/partyStore'
 import { remotePlayerManager } from '../managers/remotePlayerManager'
@@ -265,7 +265,7 @@ class NetworkManager {
       // leave), and a rejoin into an empty area sends no GameState snapshot
       // to reset these — a phantom roster would survive.
       partyRoster.set(null)
-      partyPositions.set({ at: 0, members: [] })
+      resetPartyPositions()
       pendingPartyInvites.set([])
       this.connect()
       const googleIdToken = getApiAuthToken()

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -7,6 +7,11 @@ import { hmrSingleton } from '../utils/hmr'
 import type { MonsterData } from '../types/Monster'
 import type { WallDirection } from '../utils/house-geometry'
 import { gameStore, resetGameStore, serverNotice } from '../stores/gameStore'
+import {
+  partyRoster,
+  partyPositions,
+  pendingPartyInvites,
+} from '../stores/partyStore'
 import { remotePlayerManager } from '../managers/remotePlayerManager'
 import { monsterManager } from '../managers/monsterManager'
 import {
@@ -256,6 +261,12 @@ class NetworkManager {
       this.reconnectTimer = null
       monsterManager.reset()
       remotePlayerManager.reset()
+      // The old connection's party died with it server-side (disconnect =
+      // leave), and a rejoin into an empty area sends no GameState snapshot
+      // to reset these — a phantom roster would survive.
+      partyRoster.set(null)
+      partyPositions.set({ at: 0, members: [] })
+      pendingPartyInvites.set([])
       this.connect()
       const googleIdToken = getApiAuthToken()
       if (googleIdToken && this.lastCharacterId) {
@@ -612,6 +623,11 @@ class NetworkManager {
 
   sendPartyLeave() {
     this.sendMessage('PartyLeave')
+  }
+
+  /** Poll party member positions for the world map. */
+  sendRequestPartyPositions() {
+    this.sendMessage('RequestPartyPositions')
   }
 
   sendBuyItem(merchantPlayerId: number, itemDefId: string) {

--- a/client/src/lib/stores/gameStore.ts
+++ b/client/src/lib/stores/gameStore.ts
@@ -4,7 +4,7 @@ import type { Vector3 } from 'three'
 import type { CharacterClass, Gender } from '../network/networkTypes'
 import { resetInventoryStore } from './inventoryStore'
 import { resetSkillsStore } from './skillsStore'
-import { partyRoster, pendingPartyInvites } from './partyStore'
+import { partyRoster, partyPositions, pendingPartyInvites } from './partyStore'
 import { resetFishingStore } from './fishingStore'
 import { groundItemManager } from '../managers/groundItemManager'
 
@@ -116,6 +116,7 @@ export const resetGameStore = () => {
   resetSkillsStore()
   resetFishingStore()
   partyRoster.set(null)
+  partyPositions.set({ at: 0, members: [] })
   pendingPartyInvites.set([])
   groundItemManager.reset()
 }

--- a/client/src/lib/stores/gameStore.ts
+++ b/client/src/lib/stores/gameStore.ts
@@ -4,7 +4,11 @@ import type { Vector3 } from 'three'
 import type { CharacterClass, Gender } from '../network/networkTypes'
 import { resetInventoryStore } from './inventoryStore'
 import { resetSkillsStore } from './skillsStore'
-import { partyRoster, partyPositions, pendingPartyInvites } from './partyStore'
+import {
+  partyRoster,
+  resetPartyPositions,
+  pendingPartyInvites,
+} from './partyStore'
 import { resetFishingStore } from './fishingStore'
 import { groundItemManager } from '../managers/groundItemManager'
 
@@ -116,7 +120,7 @@ export const resetGameStore = () => {
   resetSkillsStore()
   resetFishingStore()
   partyRoster.set(null)
-  partyPositions.set({ at: 0, members: [] })
+  resetPartyPositions()
   pendingPartyInvites.set([])
   groundItemManager.reset()
 }

--- a/client/src/lib/stores/partyStore.ts
+++ b/client/src/lib/stores/partyStore.ts
@@ -23,9 +23,10 @@ export interface PartyMemberPositionEntry {
   floor_level: number
 }
 
-/** Latest positions poll answer, stamped on receipt. Rendering joins it
- *  against the roster (a leaver never draws) and age-gates it (an answer
- *  that landed after the map closed never outlives its freshness). */
+/** Latest positions poll answer, stamped on receipt (`at: 0` = never
+ *  received or cleared). Rendering joins it against the roster (a leaver
+ *  never draws) and age-gates it (an answer that landed after the map
+ *  closed never outlives its freshness). */
 export interface PartyPositionsSnapshot {
   at: number
   members: PartyMemberPositionEntry[]
@@ -35,6 +36,10 @@ export const partyPositions = writable<PartyPositionsSnapshot>({
   at: 0,
   members: [],
 })
+
+export function resetPartyPositions() {
+  partyPositions.set({ at: 0, members: [] })
+}
 
 /** A party invite the player hasn't answered yet. */
 export interface PendingPartyInvite {

--- a/client/src/lib/stores/partyStore.ts
+++ b/client/src/lib/stores/partyStore.ts
@@ -15,6 +15,27 @@ export interface PartyRoster {
 
 export const partyRoster = writable<PartyRoster | null>(null)
 
+/** One member's location from ServerMessage::PartyPositions. */
+export interface PartyMemberPositionEntry {
+  id: number
+  x: number
+  z: number
+  floor_level: number
+}
+
+/** Latest positions poll answer, stamped on receipt. Rendering joins it
+ *  against the roster (a leaver never draws) and age-gates it (an answer
+ *  that landed after the map closed never outlives its freshness). */
+export interface PartyPositionsSnapshot {
+  at: number
+  members: PartyMemberPositionEntry[]
+}
+
+export const partyPositions = writable<PartyPositionsSnapshot>({
+  at: 0,
+  members: [],
+})
+
 /** A party invite the player hasn't answered yet. */
 export interface PendingPartyInvite {
   inviterId: number

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1448,6 +1448,12 @@ async fn handle_client_message(
             }
         }
 
+        ClientMessage::RequestPartyPositions => {
+            if let Some(id) = &state.player_id {
+                game_state.send_party_positions(id).await;
+            }
+        }
+
         ClientMessage::BuyItem {
             merchant_player_id,
             item_def_id,

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -1,10 +1,15 @@
 use crate::types::{PlayerId, ServerMessage};
-use onlinerpg_shared::messages::{PartyMember, PARTY_INVITE_TTL};
+use onlinerpg_shared::messages::{PartyMember, PartyMemberPosition, PARTY_INVITE_TTL};
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 pub(crate) const PARTY_MAX_MEMBERS: usize = 8;
+
+/// Positions polls inside this window are dropped; the web map polls every
+/// 3s, well above it.
+const PARTY_POSITIONS_MIN_INTERVAL: Duration = Duration::from_secs(1);
+
 
 /// Mirrors auth's character-name cap; anything longer cannot be a real name,
 /// and rejecting it early keeps oversized input out of the echoed failure.
@@ -30,6 +35,9 @@ pub(crate) struct Parties {
     /// (inviter, invitee) → pending invite. Swept lazily on the invite paths
     /// and purged with the player, so it stays tiny without its own tick.
     invites: HashMap<(PlayerId, PlayerId), PendingInvite>,
+    /// Last answered positions poll per player (spam clamp); purged with the
+    /// player.
+    position_polls: HashMap<PlayerId, Instant>,
 }
 
 pub(crate) struct PendingInvite {
@@ -386,8 +394,47 @@ impl super::GameState {
             parties
                 .invites
                 .retain(|(from, to), _| from != player_id && to != player_id);
+            parties.position_polls.remove(player_id);
         }
         self.remove_party_member(player_id).await;
+    }
+
+    /// Answer a positions poll: where the sender's other members are. No AOI
+    /// or distance cut — the point is members beyond it.
+    pub async fn send_party_positions(&self, player_id: &PlayerId) {
+        let member_ids = {
+            let mut parties = self.parties.write().await;
+            let now = Instant::now();
+            let clamped = parties
+                .position_polls
+                .get(player_id)
+                .is_some_and(|last| now.duration_since(*last) < PARTY_POSITIONS_MIN_INTERVAL);
+            if clamped {
+                return;
+            }
+            parties.position_polls.insert(*player_id, now);
+            match parties.party_of(player_id) {
+                Some(party) => party.members.clone(),
+                None => Vec::new(),
+            }
+        };
+        let members: Vec<PartyMemberPosition> = {
+            let players = self.players.read().await;
+            member_ids
+                .iter()
+                .filter(|id| *id != player_id)
+                .filter_map(|id| {
+                    players.get(id).map(|p| PartyMemberPosition {
+                        id: *id,
+                        x: p.position.x,
+                        z: p.position.z,
+                        floor_level: p.floor_level,
+                    })
+                })
+                .collect()
+        };
+        self.send_direct_message(player_id, ServerMessage::PartyPositions { members })
+            .await;
     }
 
     /// Remove a player from its party — promoting the earliest remaining

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -6,10 +6,9 @@ use tracing::info;
 
 pub(crate) const PARTY_MAX_MEMBERS: usize = 8;
 
-/// Positions polls inside this window are dropped; the web map polls every
-/// 3s, well above it.
+/// Polls inside this window are dropped; the web map polls every 3s, well
+/// above it.
 const PARTY_POSITIONS_MIN_INTERVAL: Duration = Duration::from_secs(1);
-
 
 /// Mirrors auth's character-name cap; anything longer cannot be a real name,
 /// and rejecting it early keeps oversized input out of the echoed failure.
@@ -399,44 +398,6 @@ impl super::GameState {
         self.remove_party_member(player_id).await;
     }
 
-    /// Answer a positions poll: where the sender's other members are. No AOI
-    /// or distance cut — the point is members beyond it.
-    pub async fn send_party_positions(&self, player_id: &PlayerId) {
-        let member_ids = {
-            let mut parties = self.parties.write().await;
-            let now = Instant::now();
-            let clamped = parties
-                .position_polls
-                .get(player_id)
-                .is_some_and(|last| now.duration_since(*last) < PARTY_POSITIONS_MIN_INTERVAL);
-            if clamped {
-                return;
-            }
-            parties.position_polls.insert(*player_id, now);
-            match parties.party_of(player_id) {
-                Some(party) => party.members.clone(),
-                None => Vec::new(),
-            }
-        };
-        let members: Vec<PartyMemberPosition> = {
-            let players = self.players.read().await;
-            member_ids
-                .iter()
-                .filter(|id| *id != player_id)
-                .filter_map(|id| {
-                    players.get(id).map(|p| PartyMemberPosition {
-                        id: *id,
-                        x: p.position.x,
-                        z: p.position.z,
-                        floor_level: p.floor_level,
-                    })
-                })
-                .collect()
-        };
-        self.send_direct_message(player_id, ServerMessage::PartyPositions { members })
-            .await;
-    }
-
     /// Remove a player from its party — promoting the earliest remaining
     /// member if it led, disbanding when one member would remain. Pending
     /// invites are untouched (leaving a party shouldn't void one you
@@ -508,6 +469,43 @@ impl super::GameState {
             })
             .collect();
         format!("Party: {}", names.join(", "))
+    }
+
+    /// Answer a positions poll: where the sender's other members are.
+    pub async fn send_party_positions(&self, player_id: &PlayerId) {
+        let member_ids = {
+            let mut parties = self.parties.write().await;
+            let now = Instant::now();
+            let clamped = parties
+                .position_polls
+                .get(player_id)
+                .is_some_and(|last| now.duration_since(*last) < PARTY_POSITIONS_MIN_INTERVAL);
+            if clamped {
+                return;
+            }
+            parties.position_polls.insert(*player_id, now);
+            match parties.party_of(player_id) {
+                Some(party) => party.members.clone(),
+                None => Vec::new(),
+            }
+        };
+        let members: Vec<PartyMemberPosition> = {
+            let players = self.players.read().await;
+            member_ids
+                .iter()
+                .filter(|id| *id != player_id)
+                .filter_map(|id| {
+                    players.get(id).map(|p| PartyMemberPosition {
+                        id: *id,
+                        x: p.position.x,
+                        z: p.position.z,
+                        floor_level: p.floor_level,
+                    })
+                })
+                .collect()
+        };
+        self.send_direct_message(player_id, ServerMessage::PartyPositions { members })
+            .await;
     }
 
     async fn broadcast_party_state(&self, leader_id: PlayerId, member_ids: &[PlayerId]) {

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -590,6 +590,8 @@ async fn positions_report_dungeon_floor() {
     game_state.send_party_positions(&pid("alice")).await;
     match alice_rx.try_recv() {
         Ok(ServerMessage::PartyPositions { members }) => {
+            let ids: Vec<_> = members.iter().map(|m| m.id).collect();
+            assert_eq!(ids, [pid("bob")]);
             assert_eq!(members[0].floor_level, -2);
         }
         other => panic!("Expected positions, got {:?}", other),

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -533,6 +533,87 @@ async fn self_and_unknown_invites_are_rejected() {
 }
 
 #[tokio::test]
+async fn positions_cover_members_beyond_aoi_and_skip_self() {
+    let game_state = make_test_game_state("party_positions");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    // Far outside the AOI on purpose: distance must not filter positions.
+    let mut bob_rx = add(&game_state, "bob", 500.0).await;
+    // In a party of their own: never visible to alice.
+    add(&game_state, "carol", 10.0).await;
+    add(&game_state, "dave", 15.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    form_party(&game_state, "carol", "dave").await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.send_party_positions(&pid("alice")).await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => {
+            let ids: Vec<_> = members.iter().map(|m| m.id).collect();
+            assert_eq!(ids, [pid("bob")]);
+            assert_eq!(members[0].x, 500.0);
+            assert_eq!(members[0].floor_level, 0);
+        }
+        other => panic!("Expected positions, got {:?}", other),
+    }
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn positions_without_party_are_empty() {
+    let game_state = make_test_game_state("party_positions_none");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    drain(&mut alice_rx);
+
+    game_state.send_party_positions(&pid("alice")).await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => assert!(members.is_empty()),
+        other => panic!("Expected empty positions, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn positions_report_dungeon_floor() {
+    let game_state = make_test_game_state("party_positions_floor");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state
+        .players
+        .write()
+        .await
+        .get_mut(&pid("bob"))
+        .unwrap()
+        .floor_level = -2;
+    drain(&mut alice_rx);
+
+    game_state.send_party_positions(&pid("alice")).await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => {
+            assert_eq!(members[0].floor_level, -2);
+        }
+        other => panic!("Expected positions, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn positions_poll_inside_clamp_window_is_dropped() {
+    let game_state = make_test_game_state("party_positions_clamp");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+
+    game_state.send_party_positions(&pid("alice")).await;
+    assert!(matches!(
+        alice_rx.try_recv(),
+        Ok(ServerMessage::PartyPositions { .. })
+    ));
+    game_state.send_party_positions(&pid("alice")).await;
+    assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
 async fn party_chat_command_invites_and_reports() {
     let game_state = make_test_game_state("party_command");
     let auth = make_test_auth("party_command");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -35,7 +35,9 @@ pub const NPC_TOKEN_PATH_FROM_ROOT: &str = "data/npc_token";
 /// v8: fishing struggle rounds replaced by continuous FishingFight beats.
 /// v9: `Player.main_hand` + PlayerMainHandChanged equipment broadcast.
 /// v10: party (PartyInvite/PartyRespond/PartyLeave, PartyState snapshots).
-pub const PROTOCOL_VERSION: u32 = 10;
+/// v11: party positions poll (RequestPartyPositions → PartyPositions) for
+///      world-map member markers.
+pub const PROTOCOL_VERSION: u32 = 11;
 
 /// WebSocket close code sent when the handshake is refused (wrong protocol
 /// version, or traffic before `ClientInfo`). Lives outside the serialized

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -94,6 +94,16 @@ pub struct PartyMember {
 /// client mirrors it (`INVITE_TTL_MS` in `PartyInviteToast.svelte`).
 pub const PARTY_INVITE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// One member's location as listed in `PartyPositions`. No name: the roster
+/// from `PartyState` already carries it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartyMemberPosition {
+    pub id: PlayerId,
+    pub x: f32,
+    pub z: f32,
+    pub floor_level: i8,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
     /// Mandatory first message: protocol check plus who is connecting. The
@@ -335,6 +345,9 @@ pub enum ClientMessage {
     /// Leave the current party. The leader leaving promotes the earliest
     /// remaining member; a party reduced to one member disbands.
     PartyLeave,
+    /// Ask where the sender's party members are (world-map markers). Poll,
+    /// not push: positions flow only while someone is looking at a map.
+    RequestPartyPositions,
     /// Cast the equipped fishing rod at a water point. The server validates
     /// rod, range, floor and water (water-field depth at the point) and
     /// answers with a `FishingCasted` broadcast or a direct `FishingError`.
@@ -504,6 +517,12 @@ pub enum ServerMessage {
     PartyState {
         leader_id: PlayerId,
         members: Vec<PartyMember>,
+    },
+    /// Direct answer to `RequestPartyPositions`: the other members' locations
+    /// with no AOI cut — the point is members beyond it. Empty when the
+    /// sender is not in a party.
+    PartyPositions {
+        members: Vec<PartyMemberPosition>,
     },
     GameState {
         /// A list, not a map keyed by id: `PlayerId` is numeric and


### PR DESCRIPTION
Step 2 of #58: party members now appear on the world map, wherever they are.

## Design

- **Poll, not push.** New `RequestPartyPositions` → `PartyPositions` (protocol v11). The client asks every 3s while the map dialog is open, so the channel is silent for everyone not looking at a map — nothing new ticks server-side at 5,000 CCU.
- **No AOI cut** — members beyond it are the point. The answer covers only the requester's own party, excludes the requester, and carries no names (the `PartyState` roster already has them).
- **Dungeons**: floors anchor to their entrance, so a member inside keeps a meaningful marker at the dungeon site, with a `B2`-style depth badge.
- The self marker gets a breathing pulse ring, so the map that now tracks live members also shows a live "you are here".

## Abuse & cost

- 1s per-player clamp on polls (`position_polls`, purged with the player). A clamped poll is dropped without refreshing the window, so spam cannot starve refreshes.
- One request → one answer to the requester only, ≤7 entries — amplification ~1:1.
- The parties write lock is held for a hash lookup; building the answer is O(party size) reads.

## Ghost markers

A marker must never outlive membership: rendering joins positions against the current roster, the store clears on disband / session reset / reconnect, and every answer is stamped on receipt — data older than 10s never renders, with a timer making expiry certain (same pattern as the invite toast). This also closes a latent gap from #63: reconnecting into an empty area sends no `GameState` snapshot, so a phantom roster could survive the old session; the reconnect path now clears party stores explicitly.

## Tested

- 4 new server tests: positions cover members beyond the AOI and skip self, empty answer outside a party, dungeon floor reporting, poll clamp.
- Full workspace green: cargo fmt / clippy -D warnings / tests, vitest, svelte-check, eslint, prettier.
- Live E2E on a local server with a 3-member party (two web characters plus an agent-client NPC): markers tracked at the 3s cadence, the agent's marker showed the `B2` badge from inside a dungeon it wandered into, and markers vanished immediately on leave.

## Screenshots

(attached below)
<img width="1347" height="727" alt="pr_map_3party" src="https://github.com/user-attachments/assets/ba036a17-0218-4fbb-ad98-d79fa2868536" />
<img width="783" height="583" alt="pr_map_closeup" src="https://github.com/user-attachments/assets/9b552c17-8112-4b18-924f-0f727088a021" />
