### PR TITLE
Reject out-of-range agent schedule times

### DIFF
--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -91,6 +91,9 @@ impl ScheduleEntry {
                     .trim()
                     .parse::<u32>()
                     .map_err(|_| format!("invalid minute in: {time_str}"))?;
+                if minute >= 60 {
+                    return Err(format!("minute out of range in: {time_str}"));
+                }
                 if h.trim() == "*" {
                     ScheduleCondition::Recurring { minute }
                 } else {
@@ -98,6 +101,9 @@ impl ScheduleEntry {
                         .trim()
                         .parse::<u32>()
                         .map_err(|_| format!("invalid hour in: {time_str}"))?;
+                    if hour >= 24 {
+                        return Err(format!("hour out of range in: {time_str}"));
+                    }
                     ScheduleCondition::Time { hour, minute }
                 }
             }
@@ -955,6 +961,38 @@ fn spawn_llm_task(
 mod tests {
     use super::*;
     use onlinerpg_shared::CharacterAttributes;
+
+    fn schedule(at: &str) -> ScheduleEntry {
+        ScheduleEntry {
+            at: at.to_string(),
+            pos: [0.0; 3],
+            rotation: 0.0,
+            floor_level: 0,
+            label: None,
+            action: None,
+            object_id: None,
+            waypoints: Vec::new(),
+            condition: None,
+        }
+    }
+
+    #[test]
+    fn schedule_times_stay_within_clock_bounds() {
+        for value in ["0:00", "23:59", "*:00", "*:59", "day", "night"] {
+            let mut entry = schedule(value);
+            assert!(entry.parse_condition().is_ok(), "{value} should be valid");
+            assert!(entry.condition.is_some());
+        }
+
+        for value in ["24:00", "25:30", "12:60", "*:60", "*:99"] {
+            let mut entry = schedule(value);
+            assert!(
+                entry.parse_condition().is_err(),
+                "{value} should be rejected"
+            );
+            assert!(entry.condition.is_none());
+        }
+    }
 
     fn character(name: &str, class: CharacterClass, gender: Gender) -> Character {
         Character {


### PR DESCRIPTION
## Overview

Agent schedules accepted numeric times outside a 24-hour clock. Values such as `24:00`, `12:60`, and `*:60` parsed successfully but could never match the runtime clock.

This change rejects out-of-range hours and minutes while loading a schedule.

## Steps to reproduce

1. Add a schedule entry with `at = "24:00"`, `at = "12:60"`, or `at = "*:60"`.
2. Start the agent client and let the existing schedule loader call `parse_condition`.
3. Observe that each numeric value parses successfully and receives a `ScheduleCondition`.
4. Run the game clock through every valid hour and minute.
5. Observe that the configured entry never matches and no load-time error explains why.

## Observed behavior

`ScheduleEntry::parse_condition` checked only whether the hour and minute were numeric. It did not enforce `hour < 24` or `minute < 60`.

An invalid fixed time was stored as `ScheduleCondition::Time`, while an invalid wildcard minute was stored as `ScheduleCondition::Recurring`. The agent started normally, but the entry silently became unreachable. Operators received no indication that the configured action would never run.

## Expected behavior

- Fixed schedule hours are limited to `0..=23`.
- Fixed and recurring minutes are limited to `0..=59`.
- `day`, `night`, and wildcard schedules with valid minutes remain supported.
- Invalid schedules fail during the existing load-time validation path.

## Root cause

The parser treated successful `u32` conversion as complete validation. Runtime matching assumes a 24-hour clock, so syntactically numeric but unreachable values crossed the configuration boundary.

## Changes

- Reject minutes at or above `60` before constructing either time condition.
- Reject fixed hours at or above `24`.
- Add a table-driven regression covering valid boundaries and invalid fixed and recurring values.

## Validation

The regression covers:

- valid: `0:00`, `23:59`, `*:00`, `*:59`, `day`, and `night`;
- rejected: `24:00`, `25:30`, `12:60`, `*:60`, and `*:99`;
- rejected entries do not retain a parsed condition.

Local validation:

- `cargo test -p agent-client schedule_times_stay_within_clock_bounds -- --nocapture` — 1 passed
- `cargo test -p agent-client --locked` — 104 passed
- `cargo check --workspace --locked` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked` — 681 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Scope and limitations

This PR validates clock bounds only. It does not change schedule matching, introduce timezone handling, or alter `day` and `night` semantics.
