### PR TITLE
Add direct MiniMax agent backend

### DIFF
--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -26,12 +26,13 @@ account = "npc_example"
 # the agent's map, event feed and full LLM prompts, so keep it off loopback.
 # watch_port = 8808
 
-# LLM backend to use: "none", "claude", "openrouter", "codex", "openai"
+# LLM backend to use: "none", "claude", "openrouter", "codex", "openai", "minimax"
 # - none: no LLM driver; schedule and monster AI drive the NPC on their own
 # - claude: Claude CLI (stdio subprocess)
 # - openrouter: OpenRouter API (HTTP, any model)
 # - codex: Codex CLI (stdio subprocess)
 # - openai: any OpenAI-compatible chat completions endpoint (HTTP)
+# - minimax: direct MiniMax API using the Anthropic-compatible or OpenAI-compatible protocol
 llm = "none"
 
 # LLM timing (seconds)
@@ -77,6 +78,21 @@ system_prompt_file = "data/system_prompt.txt"
 max_tokens = 1024                              # Max response tokens
 temperature = 0.7
 
+# MiniMax API settings (used when llm = "minimax")
+[minimax]
+# api_key = "..."                              # Or set MINIMAX_API_KEY
+model = "MiniMax-M3"                           # Also supports MiniMax-M2.7
+region = "global_en"                           # "global_en" or "cn_zh"
+protocol = "anthropic"                         # "anthropic" or "openai"
+global_openai_base_url = "https://api.minimax.io/v1"
+global_anthropic_base_url = "https://api.minimax.io/anthropic"
+cn_openai_base_url = "https://api.minimaxi.com/v1"
+cn_anthropic_base_url = "https://api.minimaxi.com/anthropic"
+system_prompt_file = "data/system_prompt.txt"
+max_tokens = 1024
+temperature = 0.7
+# thinking = "adaptive"                        # "adaptive" or "disabled"; omit for the protocol default
+
 # Codex CLI settings (used when llm = "codex")
 # Requires `codex` CLI installed (npm i -g @openai/codex) and OPENAI_API_KEY set.
 [codex]
@@ -89,7 +105,7 @@ system_prompt_file = "data/system_prompt.txt"
 [openai]
 base_url = "https://ollama.com/v1"             # Origin + path prefix; code appends /chat/completions
 # api_key = "..."                              # Or set OPENAI_COMPAT_API_KEY env var; omit if no auth needed
-model = "minimax-m3"                           # Any model ID the endpoint accepts
+model = "some-model"                           # Any model ID the endpoint accepts
 system_prompt_file = "data/system_prompt.txt"
 max_tokens = 1024                              # Max response tokens
 temperature = 0.7

--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -6,6 +6,7 @@ mod geom;
 mod google_auth;
 mod item_defs;
 mod llm_scheduler;
+mod minimax;
 mod monster_ai;
 mod openai;
 mod openrouter;
@@ -40,6 +41,8 @@ pub enum LlmType {
     Codex,
     /// Any OpenAI-compatible chat completions endpoint (HTTP)
     Openai,
+    /// MiniMax API (HTTP)
+    Minimax,
 }
 
 /// Config parsed from TOML. Uses `[[npcs]]` array for multi-NPC orchestrator.
@@ -92,6 +95,9 @@ struct Config {
     /// Generic OpenAI-compatible endpoint config
     #[serde(default)]
     openai: openai::OpenAiConfig,
+    /// MiniMax API integration config
+    #[serde(default)]
+    minimax: minimax::MiniMaxConfig,
 }
 
 /// How the client proves who it is to the game server.
@@ -215,6 +221,9 @@ async fn main() -> anyhow::Result<()> {
         }
         if npc.openai == openai::OpenAiConfig::default() {
             npc.openai = config.openai.clone();
+        }
+        if npc.minimax == minimax::MiniMaxConfig::default() {
+            npc.minimax = config.minimax.clone();
         }
     }
 
@@ -500,6 +509,19 @@ always_active = true
         assert_eq!(config.auth.mode, AuthMode::NpcToken);
         assert_eq!(config.auth.google.client_id, google_auth::DEFAULT_CLIENT_ID);
         assert_eq!(config.terrain, default_terrain());
+    }
+
+    #[test]
+    fn minimax_backend_parses() {
+        let config = parse(
+            r#"
+server = "ws://127.0.0.1:10006"
+
+[[npcs]]
+llm = "minimax"
+"#,
+        );
+        assert_eq!(config.npcs[0].llm, LlmType::Minimax);
     }
 
     #[test]

--- a/agent-client/src/minimax.rs
+++ b/agent-client/src/minimax.rs
@@ -1,0 +1,391 @@
+use std::sync::LazyLock;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::driver::LlmBackend;
+use crate::openai::{resolve_api_key, Endpoint as OpenAiEndpoint, OpenAiInvoker};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MiniMaxRegion {
+    #[default]
+    GlobalEn,
+    CnZh,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MiniMaxProtocol {
+    #[default]
+    Anthropic,
+    Openai,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MiniMaxThinking {
+    Adaptive,
+    Disabled,
+}
+
+impl MiniMaxThinking {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Adaptive => "adaptive",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(default)]
+pub struct MiniMaxConfig {
+    pub api_key: String,
+    pub model: String,
+    pub region: MiniMaxRegion,
+    pub protocol: MiniMaxProtocol,
+    pub global_openai_base_url: String,
+    pub global_anthropic_base_url: String,
+    pub cn_openai_base_url: String,
+    pub cn_anthropic_base_url: String,
+    pub system_prompt_file: String,
+    pub max_tokens: u32,
+    pub temperature: f32,
+    pub thinking: Option<MiniMaxThinking>,
+}
+
+impl Default for MiniMaxConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+            model: "MiniMax-M3".to_string(),
+            region: MiniMaxRegion::GlobalEn,
+            protocol: MiniMaxProtocol::Anthropic,
+            global_openai_base_url: "https://api.minimax.io/v1".to_string(),
+            global_anthropic_base_url: "https://api.minimax.io/anthropic".to_string(),
+            cn_openai_base_url: "https://api.minimaxi.com/v1".to_string(),
+            cn_anthropic_base_url: "https://api.minimaxi.com/anthropic".to_string(),
+            system_prompt_file: "data/system_prompt.txt".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            thinking: None,
+        }
+    }
+}
+
+struct ResolvedEndpoint {
+    protocol: MiniMaxProtocol,
+    url: String,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    temperature: f32,
+    thinking: Option<MiniMaxThinking>,
+}
+
+impl MiniMaxConfig {
+    fn endpoint(&self) -> anyhow::Result<ResolvedEndpoint> {
+        if self.model.is_empty() {
+            anyhow::bail!("minimax.model is not set");
+        }
+
+        let api_key = resolve_api_key(&self.api_key, "MINIMAX_API_KEY");
+        if api_key.is_empty() {
+            anyhow::bail!(
+                "MiniMax API key not set. Set minimax.api_key in config or MINIMAX_API_KEY env var"
+            );
+        }
+
+        let (base_url, path) = match (self.region, self.protocol) {
+            (MiniMaxRegion::GlobalEn, MiniMaxProtocol::Openai) => {
+                (&self.global_openai_base_url, "chat/completions")
+            }
+            (MiniMaxRegion::GlobalEn, MiniMaxProtocol::Anthropic) => {
+                (&self.global_anthropic_base_url, "v1/messages")
+            }
+            (MiniMaxRegion::CnZh, MiniMaxProtocol::Openai) => {
+                (&self.cn_openai_base_url, "chat/completions")
+            }
+            (MiniMaxRegion::CnZh, MiniMaxProtocol::Anthropic) => {
+                (&self.cn_anthropic_base_url, "v1/messages")
+            }
+        };
+        if base_url.is_empty() {
+            anyhow::bail!("MiniMax base URL is not set for the selected region and protocol");
+        }
+
+        Ok(ResolvedEndpoint {
+            protocol: self.protocol,
+            url: format!("{}/{}", base_url.trim_end_matches('/'), path),
+            api_key,
+            model: self.model.clone(),
+            max_tokens: self.max_tokens,
+            temperature: self.temperature,
+            thinking: self.thinking,
+        })
+    }
+}
+
+pub enum MiniMaxInvoker {
+    Openai(OpenAiInvoker),
+    Anthropic(AnthropicInvoker),
+}
+
+impl MiniMaxInvoker {
+    pub fn new(config: &MiniMaxConfig, system_prompt: String) -> anyhow::Result<Self> {
+        let endpoint = config.endpoint()?;
+        Ok(match endpoint.protocol {
+            MiniMaxProtocol::Openai => Self::Openai(OpenAiInvoker::new(
+                OpenAiEndpoint {
+                    name: "MiniMax",
+                    url: endpoint.url,
+                    api_key: endpoint.api_key,
+                    model: endpoint.model,
+                    max_tokens: None,
+                    max_completion_tokens: Some(endpoint.max_tokens),
+                    temperature: endpoint.temperature,
+                    reasoning_effort: None,
+                    thinking: endpoint.thinking.map(|value| value.as_str().to_string()),
+                    reasoning_split: Some(true),
+                },
+                system_prompt,
+            )),
+            MiniMaxProtocol::Anthropic => {
+                Self::Anthropic(AnthropicInvoker::new(endpoint, system_prompt))
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl LlmBackend for MiniMaxInvoker {
+    async fn send_message(&self, content: &str) -> anyhow::Result<String> {
+        match self {
+            Self::Openai(invoker) => invoker.send_message(content).await,
+            Self::Anthropic(invoker) => invoker.send_message(content).await,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum AnthropicContent {
+    Text(String),
+    Blocks(Vec<Value>),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct AnthropicMessage {
+    role: String,
+    content: AnthropicContent,
+}
+
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    system: String,
+    messages: Vec<AnthropicMessage>,
+    max_tokens: u32,
+    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingRequest>,
+}
+
+#[derive(Clone, Serialize)]
+struct ThinkingRequest {
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<Value>,
+}
+
+pub struct AnthropicInvoker {
+    endpoint: ResolvedEndpoint,
+    system_prompt: String,
+    messages: Mutex<Vec<AnthropicMessage>>,
+}
+
+static HTTP: LazyLock<Client> = LazyLock::new(Client::new);
+
+impl AnthropicInvoker {
+    fn new(endpoint: ResolvedEndpoint, system_prompt: String) -> Self {
+        info!(
+            "MiniMax invoker ready (url={}, model={})",
+            endpoint.url, endpoint.model
+        );
+        Self {
+            endpoint,
+            system_prompt,
+            messages: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn complete(&self, request: &AnthropicRequest) -> anyhow::Result<AnthropicResponse> {
+        let response = HTTP
+            .post(&self.endpoint.url)
+            .bearer_auth(&self.endpoint.api_key)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("MiniMax API request failed: {e}"))?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read MiniMax response body: {e}"))?;
+
+        if !status.is_success() {
+            anyhow::bail!("MiniMax API error (HTTP {status}): {body}");
+        }
+
+        serde_json::from_str(&body)
+            .map_err(|e| anyhow::anyhow!("Failed to parse MiniMax response: {e}\nRaw: {body}"))
+    }
+}
+
+fn response_text(blocks: &[Value]) -> String {
+    blocks
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect()
+}
+
+#[async_trait]
+impl LlmBackend for AnthropicInvoker {
+    async fn send_message(&self, content: &str) -> anyhow::Result<String> {
+        debug!(">>> TO MINIMAX ({} bytes):\n{content}", content.len());
+
+        let mut messages = self.messages.lock().await;
+        let mut turn = messages.clone();
+        turn.push(AnthropicMessage {
+            role: "user".to_string(),
+            content: AnthropicContent::Text(content.to_string()),
+        });
+
+        const MAX_PENDING_MESSAGES: usize = 39;
+        if turn.len() > MAX_PENDING_MESSAGES {
+            let keep_from = turn.len() - MAX_PENDING_MESSAGES;
+            turn = turn[keep_from..].to_vec();
+            warn!(
+                "MiniMax: trimmed conversation history to {} messages",
+                turn.len()
+            );
+        }
+
+        let request = AnthropicRequest {
+            model: self.endpoint.model.clone(),
+            system: self.system_prompt.clone(),
+            messages: turn,
+            max_tokens: self.endpoint.max_tokens,
+            temperature: self.endpoint.temperature,
+            thinking: self.endpoint.thinking.map(|value| ThinkingRequest {
+                kind: value.as_str().to_string(),
+            }),
+        };
+
+        let response = self.complete(&request).await?;
+        let result = response_text(&response.content);
+
+        let mut turn = request.messages;
+        turn.push(AnthropicMessage {
+            role: "assistant".to_string(),
+            content: AnthropicContent::Blocks(response.content),
+        });
+        *messages = turn;
+
+        debug!("<<< FROM MINIMAX ({} bytes):\n{result}", result.len());
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn config() -> MiniMaxConfig {
+        MiniMaxConfig {
+            api_key: "test-key".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn selects_region_and_protocol_endpoints() {
+        let cases = [
+            (
+                MiniMaxRegion::GlobalEn,
+                MiniMaxProtocol::Openai,
+                "https://api.minimax.io/v1/chat/completions",
+            ),
+            (
+                MiniMaxRegion::GlobalEn,
+                MiniMaxProtocol::Anthropic,
+                "https://api.minimax.io/anthropic/v1/messages",
+            ),
+            (
+                MiniMaxRegion::CnZh,
+                MiniMaxProtocol::Openai,
+                "https://api.minimaxi.com/v1/chat/completions",
+            ),
+            (
+                MiniMaxRegion::CnZh,
+                MiniMaxProtocol::Anthropic,
+                "https://api.minimaxi.com/anthropic/v1/messages",
+            ),
+        ];
+
+        for (region, protocol, expected) in cases {
+            let mut config = config();
+            config.region = region;
+            config.protocol = protocol;
+            assert_eq!(config.endpoint().unwrap().url, expected);
+        }
+    }
+
+    #[test]
+    fn current_model_ids_are_passed_through() {
+        for model in ["MiniMax-M3", "MiniMax-M2.7"] {
+            let mut config = config();
+            config.model = model.to_string();
+            assert_eq!(config.endpoint().unwrap().model, model);
+        }
+    }
+
+    #[test]
+    fn parses_china_openai_configuration() {
+        let config: MiniMaxConfig = toml::from_str(
+            r#"
+api_key = "test-key"
+model = "MiniMax-M2.7"
+region = "cn_zh"
+protocol = "openai"
+thinking = "disabled"
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.region, MiniMaxRegion::CnZh);
+        assert_eq!(config.protocol, MiniMaxProtocol::Openai);
+        assert_eq!(config.thinking, Some(MiniMaxThinking::Disabled));
+    }
+
+    #[test]
+    fn extracts_text_and_keeps_thinking_out_of_the_reply() {
+        let blocks = vec![
+            json!({"type": "thinking", "thinking": "private", "signature": "sig"}),
+            json!({"type": "text", "text": "first"}),
+            json!({"type": "text", "text": " second"}),
+        ];
+        assert_eq!(response_text(&blocks), "first second");
+    }
+}

--- a/agent-client/src/openai.rs
+++ b/agent-client/src/openai.rs
@@ -70,10 +70,13 @@ impl OpenAiConfig {
             url: format!("{}/chat/completions", self.base_url.trim_end_matches('/')),
             api_key: resolve_api_key(&self.api_key, "OPENAI_COMPAT_API_KEY"),
             model: self.model.clone(),
-            max_tokens: self.max_tokens,
+            max_tokens: Some(self.max_tokens),
+            max_completion_tokens: None,
             temperature: self.temperature,
             reasoning_effort: (!self.reasoning_effort.is_empty())
                 .then(|| self.reasoning_effort.clone()),
+            thinking: None,
+            reasoning_split: None,
         })
     }
 }
@@ -85,19 +88,35 @@ pub struct Endpoint {
     pub url: String,
     pub api_key: String,
     pub model: String,
-    pub max_tokens: u32,
+    pub max_tokens: Option<u32>,
+    pub max_completion_tokens: Option<u32>,
     pub temperature: f32,
     pub reasoning_effort: Option<String>,
+    pub thinking: Option<String>,
+    pub reasoning_split: Option<bool>,
 }
 
 #[derive(Serialize)]
 struct ChatRequest {
     model: String,
     messages: Vec<ChatMessage>,
-    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_completion_tokens: Option<u32>,
     temperature: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_split: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct ThinkingRequest {
+    #[serde(rename = "type")]
+    kind: String,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -226,8 +245,15 @@ impl LlmBackend for OpenAiInvoker {
             model: self.endpoint.model.clone(),
             messages: turn,
             max_tokens: self.endpoint.max_tokens,
+            max_completion_tokens: self.endpoint.max_completion_tokens,
             temperature: self.endpoint.temperature,
             reasoning_effort: self.endpoint.reasoning_effort.clone(),
+            thinking: self
+                .endpoint
+                .thinking
+                .clone()
+                .map(|kind| ThinkingRequest { kind }),
+            reasoning_split: self.endpoint.reasoning_split,
         };
 
         let result = self.complete(&request).await?;
@@ -284,5 +310,26 @@ mod tests {
         );
         cfg.reasoning_effort = String::new();
         assert!(cfg.endpoint().unwrap().reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn provider_specific_completion_options_are_serialized() {
+        let request = ChatRequest {
+            model: "some-model".to_string(),
+            messages: Vec::new(),
+            max_tokens: None,
+            max_completion_tokens: Some(2048),
+            temperature: 0.7,
+            reasoning_effort: None,
+            thinking: Some(ThinkingRequest {
+                kind: "adaptive".to_string(),
+            }),
+            reasoning_split: Some(true),
+        };
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["max_completion_tokens"], 2048);
+        assert_eq!(value["thinking"]["type"], "adaptive");
+        assert_eq!(value["reasoning_split"], true);
+        assert!(value.get("max_tokens").is_none());
     }
 }

--- a/agent-client/src/openrouter.rs
+++ b/agent-client/src/openrouter.rs
@@ -49,9 +49,12 @@ pub fn invoker(config: &OpenRouterConfig, system_prompt: String) -> anyhow::Resu
             url: OPENROUTER_API_URL.to_string(),
             api_key,
             model: config.model.clone(),
-            max_tokens: config.max_tokens,
+            max_tokens: Some(config.max_tokens),
+            max_completion_tokens: None,
             temperature: config.temperature,
             reasoning_effort: None,
+            thinking: None,
+            reasoning_split: None,
         },
         system_prompt,
     ))

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -20,6 +20,7 @@ use crate::codex::{self, CodexConfig};
 use crate::driver;
 use crate::google_auth::GoogleAuth;
 use crate::llm_scheduler::{LlmPriority, LlmScheduler, TimeoutBackend};
+use crate::minimax::{self, MiniMaxConfig};
 use crate::openai::{self, OpenAiConfig};
 use crate::openrouter::{self, OpenRouterConfig};
 use crate::state::{SharedState, WorldCache};
@@ -155,6 +156,8 @@ pub struct NpcConfig {
     pub codex: CodexConfig,
     #[serde(default)]
     pub openai: OpenAiConfig,
+    #[serde(default)]
+    pub minimax: MiniMaxConfig,
 
     // --- Auto-provisioning ---
     /// Character name to create if no characters exist on this account.
@@ -657,6 +660,7 @@ impl NpcConfig {
             LlmType::Openrouter => Some(&self.openrouter.system_prompt_file),
             LlmType::Codex => Some(&self.codex.system_prompt_file),
             LlmType::Openai => Some(&self.openai.system_prompt_file),
+            LlmType::Minimax => Some(&self.minimax.system_prompt_file),
             LlmType::None => None,
         }
     }
@@ -842,6 +846,12 @@ fn build_llm_backend(
                 Arc::new(openai::OpenAiInvoker::new(ep, system_prompt))
                     as Arc<dyn driver::LlmBackend>
             }),
+        ),
+        LlmType::Minimax => (
+            "MiniMax API",
+            &npc.minimax.model,
+            minimax::MiniMaxInvoker::new(&npc.minimax, system_prompt)
+                .map(|i| Arc::new(i) as Arc<dyn driver::LlmBackend>),
         ),
         LlmType::None => return None,
     };


### PR DESCRIPTION
Reason: Add direct MiniMax support for MiniMax-M3 and MiniMax-M2.7 with configurable global and China API endpoints.

- Add a named minimax backend with global_en and cn_zh region selection.
- Support Anthropic-compatible and OpenAI-compatible request formats with direct MINIMAX_API_KEY authentication.
- Preserve Anthropic thinking blocks across turns and separate OpenAI-compatible reasoning from reply content.
- Document both current model IDs and all four configurable regional base URLs.

Checks:
- cargo fmt --all -- --check
- cargo check -p agent-client
- cargo test -p agent-client
- cargo clippy --workspace --all-targets --locked -- -D warnings
