### PR TITLE
Stop waking the LLM for other players' fishing endings

### DIFF
--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -989,14 +989,15 @@ impl SharedState {
                 }
             }
 
-            // Fishing: the outcome (and any refusal) is worth an LLM look —
-            // recast, eat the catch, or give up. The in-flight events are
-            // noise: the reflex layer already answered them.
+            // Fishing: only our own outcome is worth an LLM look — recast, eat
+            // the catch, or give up. In-flight events are reflex-handled, and
+            // another player's ending renders no prompt line (driver/prompt.rs),
+            // so both are noise.
             ServerMessage::FishingEnded { player_id, .. } => {
                 if self_id == Some(player_id) {
                     EventUrgency::Urgent
                 } else {
-                    EventUrgency::Routine
+                    EventUrgency::Noise
                 }
             }
             ServerMessage::FishingError { .. } => EventUrgency::Urgent,
@@ -2732,5 +2733,19 @@ pub(crate) mod tests {
             "monster ended at y={y}, floor 2 sits at {}",
             dungeon.floor_y(2)
         );
+    }
+
+    /// Another player's FishingEnded renders no prompt line, so scheduling an
+    /// LLM cycle for it would buy a blank prompt; our own stays urgent.
+    #[test]
+    fn fishing_ended_wakes_llm_only_for_own_outcome() {
+        let (mut s, _rx) = test_state();
+        s.self_player_id = Some(PlayerId::from(1));
+        let ended = |id: u64| ServerMessage::FishingEnded {
+            player_id: PlayerId::from(id),
+            outcome: onlinerpg_shared::fishing::FishingOutcome::Escaped,
+        };
+        assert_eq!(s.classify_event(&ended(1)), EventUrgency::Urgent);
+        assert_eq!(s.classify_event(&ended(2)), EventUrgency::Noise);
     }
 }

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -118,7 +118,6 @@
 - 타 플레이어 낚시 자세 표시 (FishingCasted의 player_id → remotePlayerManager 연결)
 - 어보트된 캐스팅의 스플래시 사운드 setTimeout 취소
 - 클라이언트 사전 사거리 검사 (MAX_CAST_DISTANCE_METERS wasm 노출)
-- agent-client: 타인의 FishingEnded가 Routine 분류로 LLM 사이클 유발 → Noise로 내리거나 관전 라인 추가
 - agent-client: 부분 좌표(z 누락 등)를 조용히 버림 → 피드백 이벤트 추가
 - agent-client: 리플렉스 지연이 1초 orchestrator tick에 편승 (struggle 윈도 더 줄이면 위험)
 - items.csv ragged 행 정규화 (18칸 헤더 대비 기존 행 13–14칸)


### PR DESCRIPTION
## Summary

Fixes the `doc/TODO.md` fishing follow-up (PR #53 review): *agent-client: 타인의 FishingEnded가 Routine 분류로 LLM 사이클 유발 → Noise로 내리거나 관전 라인 추가*.

Another player's `FishingEnded` is classified `EventUrgency::Routine` (`agent-client/src/state.rs`), which schedules a batched LLM cycle — but the prompt builder returns `None` for endings that aren't ours (`agent-client/src/driver/prompt.rs`). So every catch landed near an NPC woke its LLM with nothing to show for it: a blank API call.

This takes the TODO's first option and demotes it to `Noise`, matching the other spectator fishing beats. Our own `FishingEnded` stays `Urgent`.

## Changes

- `agent-client/src/state.rs`: classify another player's `FishingEnded` as `Noise`; comment updated
- Unit test: own ending is `Urgent`, someone else's is `Noise`
- `doc/TODO.md`: drop the resolved follow-up line

🤖 Generated with [Claude Code](https://claude.com/claude-code)