### PR TITLE
Show the party invite's deadline as a draining gauge

### DIFF
--- a/client/src/lib/components/PartyInviteToast.svelte
+++ b/client/src/lib/components/PartyInviteToast.svelte
@@ -43,6 +43,8 @@
     onaccept={() => respond(invite, true)}
     ondecline={() => respond(invite, false)}
     {queued}
+    gaugeDurationMs={INVITE_TTL_MS}
+    gaugeStartAt={invite.offeredAt}
   >
     <strong>{invite.inviterName}</strong> invites you to a party
   </ConsentToast>


### PR DESCRIPTION
#71 shipped the summon toast with a TTL gauge; the invite toast from #63 never had one, though its 30s server deadline (`PARTY_INVITE_TTL`) is just as hard. Your `ConsentToast` already exposes the gauge, so the retrofit is exactly two props — an invite now shows how much time is left instead of vanishing without warning.

**Not the trade offer, though.** `OFFER_TTL_MS` only clears the client's own toast; there is no server deadline behind it, since an NPC-pushed `open_trade` deliberately stays unregistered until the player opens the window. A gauge there would count down confidently on an offer that already died when the NPC walked away.

**Verified.** prettier / eslint / svelte-check / vitest clean. Live on a local server with two characters and a real `/party` invite: the gauge drains in step with the 30s deadline (screenshot below). The gauge is display-only — TTL dismissal stays with the toast's existing `setTimeout`.

**Screenshot** — the invite toast mid-drain during the live test:

![Party invite toast with the draining TTL gauge](https://raw.githubusercontent.com/darkdarkcocoa/OpenMMO/pr-shots-party-summon/party-invite/invite-toast-gauge.png)
