### PR TITLE
Require server allowances for ambient monster spawns

### DIFF
--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -144,6 +144,7 @@ pub struct GameState {
     movement_intents: Arc<RwLock<HashMap<PlayerId, player::MoveQueue>>>,
     player_spatial_cells: Arc<RwLock<HashMap<SpatialCell, HashSet<PlayerId>>>>,
     monsters: Arc<RwLock<HashMap<String, crate::types::Monster>>>,
+    ambient_spawn_allowances: Arc<RwLock<HashMap<(PlayerId, String), u64>>>,
     broadcast_tx: GameStateSender,
     server_notice: Arc<RwLock<Option<String>>>,
     game_clock: Arc<std::sync::RwLock<GameClock>>,
@@ -273,6 +274,7 @@ impl GameState {
             movement_intents: Arc::new(RwLock::new(HashMap::new())),
             player_spatial_cells: Arc::new(RwLock::new(HashMap::new())),
             monsters: Arc::new(RwLock::new(HashMap::new())),
+            ambient_spawn_allowances: Arc::new(RwLock::new(HashMap::new())),
             broadcast_tx,
             server_notice: Arc::new(RwLock::new(None)),
             game_clock: Arc::new(std::sync::RwLock::new(GameClock {

--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -18,6 +18,7 @@ const MONSTER_MOVE_BUDGET_CAP_METERS: f32 = 12.0;
 /// misconfigured types). Kept just above the player's own speed so an unknown
 /// type stays tightly bounded rather than inheriting a fast monster's leeway.
 const DEFAULT_MONSTER_RUN_SPEED: f32 = 3.5;
+const AMBIENT_SPAWN_ALLOWANCE_TTL_MS: u64 = 30_000;
 
 impl super::GameState {
     fn find_ambient_rule(
@@ -415,34 +416,43 @@ impl super::GameState {
             (counts, alive)
         };
 
-        let mut requested_this_tick = 0usize;
+        let now = Self::now_ms();
+        let requests = {
+            let mut allowances = self.ambient_spawn_allowances.write().await;
+            allowances.retain(|_, expires_at| *expires_at > now);
+            let mut reserved = allowances.len();
+            let mut requests = Vec::new();
 
-        for rule in ambient_spawns {
-            for player_id in &player_ids {
-                if total_alive + requested_this_tick >= max_total {
-                    return;
+            for rule in ambient_spawns {
+                for player_id in &player_ids {
+                    if total_alive + reserved >= max_total {
+                        break;
+                    }
+
+                    let owned = owner_type_counts
+                        .get(&(*player_id, rule.monster_type.clone()))
+                        .copied()
+                        .unwrap_or(0);
+                    let key = (*player_id, rule.monster_type.clone());
+
+                    if owned >= rule.max_per_player || allowances.contains_key(&key) {
+                        continue;
+                    }
+
+                    allowances.insert(key, now.saturating_add(AMBIENT_SPAWN_ALLOWANCE_TTL_MS));
+                    requests.push((*player_id, rule.monster_type.clone()));
+                    reserved += 1;
                 }
-
-                let owned = owner_type_counts
-                    .get(&(*player_id, rule.monster_type.clone()))
-                    .copied()
-                    .unwrap_or(0);
-
-                if owned >= rule.max_per_player {
-                    continue;
-                }
-
-                // Ask the client to find a valid position near itself and spawn
-                self.send_direct_message(
-                    player_id,
-                    ServerMessage::SpawnMonsterRequest {
-                        monster_type: rule.monster_type.clone(),
-                    },
-                )
-                .await;
-
-                requested_this_tick += 1;
             }
+            requests
+        };
+
+        for (player_id, monster_type) in requests {
+            self.send_direct_message(
+                &player_id,
+                ServerMessage::SpawnMonsterRequest { monster_type },
+            )
+            .await;
         }
     }
 
@@ -485,6 +495,15 @@ impl super::GameState {
         let dx = onlinerpg_shared::shortest_world_delta_x(player_pos.x, position.x);
         let dz = position.z - player_pos.z;
         let max = rule.max_distance + 10.0; // tolerance
-        dx * dx + dz * dz <= max * max
+        if dx * dx + dz * dz > max * max {
+            return false;
+        }
+
+        let now = Self::now_ms();
+        self.ambient_spawn_allowances
+            .write()
+            .await
+            .remove(&(*player_id, monster_type.to_string()))
+            .is_some_and(|expires_at| expires_at > now)
     }
 }

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -522,6 +522,10 @@ impl super::GameState {
 
     pub async fn remove_player(&self, player_id: &PlayerId) {
         self.movement_intents.write().await.remove(player_id);
+        self.ambient_spawn_allowances
+            .write()
+            .await
+            .retain(|(owner_id, _), _| owner_id != player_id);
         // A player disconnecting inside a dungeon leaves its floor first,
         // so its monsters get reassigned (or despawned) instead of being
         // dropped by remove_monsters_by_owner below.

--- a/server/src/game_state/tests/combat_tests.rs
+++ b/server/src/game_state/tests/combat_tests.rs
@@ -264,11 +264,12 @@ async fn non_finite_spawn_request_is_rejected() {
         y: 0.5,
         z: 22.0,
     };
-    assert!(
-        game_state
-            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
-            .await
-    );
+    let mut player_rx = game_state.register_direct_channel(&player_id).await;
+    game_state.tick_monster_spawns().await;
+    assert!(drain(&mut player_rx).into_iter().any(|message| matches!(
+        message,
+        ServerMessage::SpawnMonsterRequest { monster_type } if monster_type == "goblin"
+    )));
 
     for (label, position) in non_finite_positions(valid) {
         assert!(
@@ -286,6 +287,104 @@ async fn non_finite_spawn_request_is_rejected() {
             "rotation {value_name}"
         );
     }
+    assert!(
+        game_state
+            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
+            .await
+    );
+}
+
+#[tokio::test]
+async fn ambient_spawn_requires_unconsumed_server_allowance() {
+    let game_state = make_test_game_state("ambient_spawn_allowance");
+    let player_id = pid("spawner");
+    let valid = Position {
+        x: 12.0,
+        y: 0.5,
+        z: 22.0,
+    };
+
+    game_state
+        .add_player(make_player("spawner", 10.0, 20.0))
+        .await;
+    let mut player_rx = game_state.register_direct_channel(&player_id).await;
+
+    assert!(
+        !game_state
+            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
+            .await,
+        "an unsolicited ambient spawn must be rejected"
+    );
+
+    game_state.tick_monster_spawns().await;
+    assert!(drain(&mut player_rx).into_iter().any(|message| matches!(
+        message,
+        ServerMessage::SpawnMonsterRequest { monster_type } if monster_type == "goblin"
+    )));
+    assert!(
+        game_state
+            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
+            .await
+    );
+    assert!(
+        !game_state
+            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
+            .await,
+        "one allowance must authorize at most one spawn"
+    );
+}
+
+#[tokio::test]
+async fn ambient_spawn_allowance_is_bounded_and_expires() {
+    let game_state = make_test_game_state("ambient_spawn_allowance_expiry");
+    let player_id = pid("spawner");
+    let valid = Position {
+        x: 12.0,
+        y: 0.5,
+        z: 22.0,
+    };
+
+    game_state
+        .add_player(make_player("spawner", 10.0, 20.0))
+        .await;
+    let mut player_rx = game_state.register_direct_channel(&player_id).await;
+
+    game_state.tick_monster_spawns().await;
+    game_state.tick_monster_spawns().await;
+    let goblin_requests = drain(&mut player_rx)
+        .into_iter()
+        .filter(|message| {
+            matches!(
+                message,
+                ServerMessage::SpawnMonsterRequest { monster_type } if monster_type == "goblin"
+            )
+        })
+        .count();
+    assert_eq!(goblin_requests, 1);
+
+    game_state
+        .ambient_spawn_allowances
+        .write()
+        .await
+        .insert((player_id, "goblin".to_string()), GameState::now_ms());
+    assert!(
+        !game_state
+            .validate_spawn_request(&player_id, "goblin", &valid, 1.5)
+            .await
+    );
+
+    game_state.tick_monster_spawns().await;
+    assert!(drain(&mut player_rx).into_iter().any(|message| matches!(
+        message,
+        ServerMessage::SpawnMonsterRequest { monster_type } if monster_type == "goblin"
+    )));
+    game_state.remove_player(&player_id).await;
+    assert!(game_state
+        .ambient_spawn_allowances
+        .read()
+        .await
+        .keys()
+        .all(|(owner_id, _)| owner_id != &player_id));
 }
 
 /// A client-owned monster is still untrusted movement. Staying within the


### PR DESCRIPTION
## Overview

Ambient monster spawn messages were checked against type, position, zone, global, and per-player caps, but the server did not require a corresponding spawn request from its own tick. A modified client could submit eligible spawns whenever capacity became available.

This change gives each server-issued player/type request one bounded, expiring allowance and requires the client response to consume it atomically.

## Steps to reproduce

1. Connect a player in a valid ambient spawn area with capacity below the configured limits.
2. Before the server requests a monster type, send a valid ambient spawn response for that type.
3. Repeat after the first monster is removed or capacity otherwise becomes available.
4. Inspect accepted spawns and the server's request tick.

## Observed behavior

The server accepted any response that passed the general spawn checks. Request messages acted as client hints rather than capabilities, so a client could choose the timing and type of every eligible ambient spawn.

## Expected behavior

- At most one unconsumed allowance exists for each player and monster type.
- Only the matching player/type response may consume it.
- Invalid responses preserve the allowance, while one valid response consumes it.
- Allowances expire after 30 seconds and are removed on disconnect.
- Existing global and per-player caps remain authoritative.

## Root cause

The request tick emitted `RequestMonsterSpawn` but retained no server state linking that request to the later client response. `validate_spawn_request` and `spawn_monster` could validate eligibility, but not whether the server had authorized this specific spawn opportunity.

## Changes

- Track expiring player/type allowances in server-only state.
- Count active allowances when deciding whether another request may be emitted.
- Prune expired allowances and clean them up on disconnect.
- Consume a matching allowance atomically after the existing type, finite-position, zone, and range checks.
- Add regressions for missing, single-use, bounded, expiring, and invalid-response behavior.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server ambient_spawn_requires_unconsumed_server_allowance --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server ambient_spawn_allowance_is_bounded_and_expires --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server non_finite_spawn_request_is_rejected --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 698 passed
- `git diff --check` — passed

## Scope and limitations

This PR does not change the wire protocol or move ambient position selection to the server. A valid client still chooses the position within the existing checks. The allowance expires in memory and is not persisted across disconnects or server restarts.
