### PR TITLE
Add an optional HUD minimap below the time widget

### DIFF
--- a/client/src/lib/components/GameHud.svelte
+++ b/client/src/lib/components/GameHud.svelte
@@ -3,6 +3,7 @@
   import FPSCounter from './FPSCounter.svelte'
   import WavePhaseDebug from './WavePhaseDebug.svelte'
   import GameTimeWidget from './GameTimeWidget.svelte'
+  import Minimap from './Minimap.svelte'
   import CelestialDebugDialog from './CelestialDebugDialog.svelte'
   import MapEditorPanel from './map-editor/MapEditorPanel.svelte'
   import HousingEditorPanel from './map-editor/HousingEditorPanel.svelte'
@@ -29,6 +30,7 @@
     teleportLoading,
     housingEditorMode,
   } from '../stores/debugStore'
+  import { minimapEnabled } from '../stores/minimapStore'
   import type { AccountCharacter } from '../network/socket'
 
   interface Props {
@@ -71,6 +73,9 @@
   <FPSCounter />
   <WavePhaseDebug />
   <GameTimeWidget />
+  {#if $minimapEnabled && !$mapEditorMode}
+    <Minimap />
+  {/if}
   <DragGhost />
   <CelestialDebugDialog />
   {#if $mapEditorMode}

--- a/client/src/lib/components/Minimap.svelte
+++ b/client/src/lib/components/Minimap.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  import { gameStore } from '../stores/gameStore'
+  import { worldMapVisible } from '../stores/debugStore'
+  import { minimapVersion } from '../stores/editorStore'
+  import {
+    partyRoster,
+    partyPositions,
+    resetPartyPositions,
+  } from '../stores/partyStore'
+  import { regionMinimapServerUrl } from '../terrain/regionMinimapGenerator'
+  import { REGION_CELLS, TILE_DIM } from '../terrain/terrain-constants'
+  import { unwrapWorldXNear } from '../terrain/world-wrap'
+  import { networkManager } from '../network/socket'
+
+  /** Canvas size in CSS pixels. */
+  const SIZE = 180
+  /** World meters shown across the widget — fixed zoom, sized so the region
+   *  bakes (1 px/m) only ever downscale. */
+  const VIEW_WORLD = 384
+  /** Same map rotation as WorldMapDialog: screen-up matches walking up. */
+  const ROTATE_ANGLE = -Math.PI / 4
+  /** Player movement below this step doesn't trigger a redraw. */
+  const REDRAW_STEP_M = 2
+  /** Heading changes below this step (~10°) don't trigger a redraw. */
+  const REDRAW_STEP_RAD = Math.PI / 18
+  // Same cadence/expiry as WorldMapDialog; the server clamps re-polls.
+  const PARTY_POLL_MS = 3000
+  const PARTY_POSITIONS_MAX_AGE_MS = 10000
+  /** ~4 regions cover the rotated view; keep a little slack for movement. */
+  const IMAGE_CACHE_LIMIT = 12
+
+  let canvasEl = $state<HTMLCanvasElement>()
+
+  // Intentionally non-reactive: image loads must not re-run the render effect.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const imageCache = new Map<string, HTMLImageElement | null>()
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const pendingLoads = new Map<string, Promise<HTMLImageElement | null>>()
+
+  function trimImageCache() {
+    for (const key of imageCache.keys()) {
+      if (imageCache.size <= IMAGE_CACHE_LIMIT) break
+      imageCache.delete(key)
+    }
+  }
+
+  function loadRegionImage(
+    rx: number,
+    rz: number
+  ): Promise<HTMLImageElement | null> {
+    const key = `${rx},${rz}`
+    if (imageCache.has(key)) return Promise.resolve(imageCache.get(key)!)
+    if (pendingLoads.has(key)) return pendingLoads.get(key)!
+
+    const promise = new Promise<HTMLImageElement | null>((resolve) => {
+      const img = new Image()
+      img.onload = () => {
+        imageCache.set(key, img)
+        trimImageCache()
+        pendingLoads.delete(key)
+        resolve(img)
+      }
+      img.onerror = () => {
+        imageCache.set(key, null)
+        pendingLoads.delete(key)
+        resolve(null)
+      }
+      img.src = regionMinimapServerUrl(rx, rz)
+    })
+    pendingLoads.set(key, promise)
+    return promise
+  }
+
+  $effect(() => {
+    const _ver = $minimapVersion // flush when the editor regenerates bakes
+    imageCache.clear()
+    pendingLoads.clear()
+  })
+
+  // Quantized player state: redraw on ~2 m moves or ~10° turns, not per frame.
+  let playerX = $derived($gameStore.currentPlayer?.position.x ?? 0)
+  let playerZ = $derived($gameStore.currentPlayer?.position.z ?? 0)
+  let qx = $derived(Math.round(playerX / REDRAW_STEP_M))
+  let qz = $derived(Math.round(playerZ / REDRAW_STEP_M))
+  let qr = $derived(
+    Math.round(($gameStore.currentPlayer?.rotation ?? 0) / REDRAW_STEP_RAD)
+  )
+
+  // Party positions piggyback on the world map's poll channel; only poll
+  // while the widget is mounted and a party exists.
+  let inParty = $derived($partyRoster !== null)
+  $effect(() => {
+    if (!inParty) return
+    networkManager.sendRequestPartyPositions()
+    const timer = setInterval(
+      () => networkManager.sendRequestPartyPositions(),
+      PARTY_POLL_MS
+    )
+    return () => clearInterval(timer)
+  })
+  $effect(() => {
+    const at = $partyPositions.at
+    if (at === 0) return
+    const timer = setTimeout(
+      resetPartyPositions,
+      Math.max(0, at + PARTY_POSITIONS_MAX_AGE_MS - Date.now())
+    )
+    return () => clearTimeout(timer)
+  })
+
+  let renderGeneration = 0
+
+  $effect(() => {
+    if (!canvasEl) return
+
+    // Reactive triggers: quantized pose, party snapshot, regenerated bakes.
+    const px = qx * REDRAW_STEP_M
+    const pz = qz * REDRAW_STEP_M
+    const heading = qr * REDRAW_STEP_RAD
+    const positions = $partyPositions
+    const roster = $partyRoster
+    const _ver = $minimapVersion
+    const gen = ++renderGeneration
+
+    const dpr = window.devicePixelRatio || 1
+    canvasEl.width = SIZE * dpr
+    canvasEl.height = SIZE * dpr
+    const ctx = canvasEl.getContext('2d')!
+    ctx.scale(dpr, dpr)
+
+    const scale = SIZE / VIEW_WORLD
+    const viewLeft = px - VIEW_WORLD / 2
+    const viewTop = pz - VIEW_WORLD / 2
+
+    ctx.fillStyle = '#000'
+    ctx.fillRect(0, 0, SIZE, SIZE)
+
+    // Rotated square needs sqrt(2) coverage, same as the world map.
+    const expanded = VIEW_WORLD * Math.SQRT2
+    const expLeft = px - expanded / 2
+    const expTop = pz - expanded / 2
+    const minRx = Math.floor((expLeft + TILE_DIM / 2) / REGION_CELLS)
+    const maxRx = Math.floor((expLeft + expanded + TILE_DIM / 2) / REGION_CELLS)
+    const minRz = Math.floor((expTop + TILE_DIM / 2) / REGION_CELLS)
+    const maxRz = Math.floor((expTop + expanded + TILE_DIM / 2) / REGION_CELLS)
+
+    const rotated = (draw: () => void) => {
+      ctx.save()
+      ctx.translate(SIZE / 2, SIZE / 2)
+      ctx.rotate(ROTATE_ANGLE)
+      ctx.translate(-SIZE / 2, -SIZE / 2)
+      draw()
+      ctx.restore()
+    }
+
+    const promises: Promise<void>[] = []
+    for (let rz = minRz; rz <= maxRz; rz++) {
+      for (let rx = minRx; rx <= maxRx; rx++) {
+        const regionWorldX = rx * REGION_CELLS - TILE_DIM / 2
+        const regionWorldZ = rz * REGION_CELLS - TILE_DIM / 2
+        const drawX = Math.floor((regionWorldX - viewLeft) * scale)
+        const drawY = Math.floor((regionWorldZ - viewTop) * scale)
+        const drawSize = Math.ceil(REGION_CELLS * scale)
+        promises.push(
+          loadRegionImage(rx, rz).then((img) => {
+            if (gen !== renderGeneration || !img) return
+            rotated(() => ctx.drawImage(img, drawX, drawY, drawSize, drawSize))
+          })
+        )
+      }
+    }
+
+    Promise.all(promises).then(() => {
+      if (gen !== renderGeneration) return
+
+      // Party members: green dots, edge-clamped so an off-map member still
+      // shows which way to walk.
+      if (roster && Date.now() - positions.at <= PARTY_POSITIONS_MAX_AGE_MS) {
+        const ids = new Set(roster.members.map((m) => m.id))
+        const selfId = $gameStore.currentPlayer?.id
+        rotated(() => {
+          for (const pos of positions.members) {
+            if (!ids.has(pos.id) || pos.id === selfId) continue
+            const wx = unwrapWorldXNear(px, pos.x)
+            let mx = (wx - viewLeft) * scale
+            let my = (pos.z - viewTop) * scale
+            // Clamp into the rotated-visible disc around the center.
+            const dx = mx - SIZE / 2
+            const dy = my - SIZE / 2
+            const dist = Math.hypot(dx, dy)
+            const maxDist = SIZE / 2 - 8
+            if (dist > maxDist) {
+              mx = SIZE / 2 + (dx / dist) * maxDist
+              my = SIZE / 2 + (dy / dist) * maxDist
+            }
+            ctx.beginPath()
+            ctx.arc(mx, my, 4, 0, Math.PI * 2)
+            ctx.fillStyle = '#4caf50'
+            ctx.fill()
+            ctx.lineWidth = 1.5
+            ctx.strokeStyle = '#ffffff'
+            ctx.stroke()
+          }
+        })
+      }
+
+      // Self: centered heading arrow. rotation = atan2(dx, dz), so the facing
+      // vector in (x, z) is (sin r, cos r); the rotated transform handles the
+      // map's -45° for us.
+      rotated(() => {
+        const angle = Math.atan2(Math.cos(heading), Math.sin(heading))
+        ctx.translate(SIZE / 2, SIZE / 2)
+        ctx.rotate(angle)
+        ctx.beginPath()
+        ctx.moveTo(7, 0)
+        ctx.lineTo(-5, 5)
+        ctx.lineTo(-2.5, 0)
+        ctx.lineTo(-5, -5)
+        ctx.closePath()
+        ctx.fillStyle = '#ff3333'
+        ctx.fill()
+        ctx.lineWidth = 1.5
+        ctx.strokeStyle = '#ffffff'
+        ctx.stroke()
+      })
+    })
+  })
+</script>
+
+<button
+  class="minimap"
+  title="Open world map (M)"
+  aria-label="Open world map"
+  onclick={() => worldMapVisible.set(true)}
+>
+  <canvas bind:this={canvasEl} style="width: {SIZE}px; height: {SIZE}px;"
+  ></canvas>
+</button>
+
+<style>
+  .minimap {
+    position: absolute;
+    /* Just below the time widget (top: 9px + 36px tall). */
+    top: 53px;
+    right: 9px;
+    width: 180px;
+    height: 180px;
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    background: #000;
+    opacity: 0.92;
+    pointer-events: auto;
+  }
+  .minimap:hover {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+  canvas {
+    display: block;
+  }
+</style>

--- a/client/src/lib/components/Minimap.svelte
+++ b/client/src/lib/components/Minimap.svelte
@@ -2,15 +2,10 @@
   import { gameStore } from '../stores/gameStore'
   import { worldMapVisible } from '../stores/debugStore'
   import { minimapVersion } from '../stores/editorStore'
-  import {
-    partyRoster,
-    partyPositions,
-    resetPartyPositions,
-  } from '../stores/partyStore'
+  import { currentDungeonDepth } from '../stores/dungeonStore'
+  import { playerVisualFloorLevel } from '../stores/housingStore'
   import { regionMinimapServerUrl } from '../terrain/regionMinimapGenerator'
   import { REGION_CELLS, TILE_DIM } from '../terrain/terrain-constants'
-  import { unwrapWorldXNear } from '../terrain/world-wrap'
-  import { networkManager } from '../network/socket'
 
   /** Canvas size in CSS pixels. */
   const SIZE = 180
@@ -23,13 +18,16 @@
   const REDRAW_STEP_M = 2
   /** Heading changes below this step (~10°) don't trigger a redraw. */
   const REDRAW_STEP_RAD = Math.PI / 18
-  // Same cadence/expiry as WorldMapDialog; the server clamps re-polls.
-  const PARTY_POLL_MS = 3000
-  const PARTY_POSITIONS_MAX_AGE_MS = 10000
   /** ~4 regions cover the rotated view; keep a little slack for movement. */
   const IMAGE_CACHE_LIMIT = 12
 
   let canvasEl = $state<HTMLCanvasElement>()
+
+  /** The bakes are surface terrain: underground or upstairs there is nothing
+   *  truthful to draw, so the widget hides rather than showing the surface. */
+  let onSurface = $derived(
+    $currentDungeonDepth === 0 && $playerVisualFloorLevel === 0
+  )
 
   // Intentionally non-reactive: image loads must not re-run the render effect.
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
@@ -86,28 +84,6 @@
     Math.round(($gameStore.currentPlayer?.rotation ?? 0) / REDRAW_STEP_RAD)
   )
 
-  // Party positions piggyback on the world map's poll channel; only poll
-  // while the widget is mounted and a party exists.
-  let inParty = $derived($partyRoster !== null)
-  $effect(() => {
-    if (!inParty) return
-    networkManager.sendRequestPartyPositions()
-    const timer = setInterval(
-      () => networkManager.sendRequestPartyPositions(),
-      PARTY_POLL_MS
-    )
-    return () => clearInterval(timer)
-  })
-  $effect(() => {
-    const at = $partyPositions.at
-    if (at === 0) return
-    const timer = setTimeout(
-      resetPartyPositions,
-      Math.max(0, at + PARTY_POSITIONS_MAX_AGE_MS - Date.now())
-    )
-    return () => clearTimeout(timer)
-  })
-
   let renderGeneration = 0
 
   $effect(() => {
@@ -117,8 +93,6 @@
     const px = qx * REDRAW_STEP_M
     const pz = qz * REDRAW_STEP_M
     const heading = qr * REDRAW_STEP_RAD
-    const positions = $partyPositions
-    const roster = $partyRoster
     const _ver = $minimapVersion
     const gen = ++renderGeneration
 
@@ -173,37 +147,6 @@
     Promise.all(promises).then(() => {
       if (gen !== renderGeneration) return
 
-      // Party members: green dots, edge-clamped so an off-map member still
-      // shows which way to walk.
-      if (roster && Date.now() - positions.at <= PARTY_POSITIONS_MAX_AGE_MS) {
-        const ids = new Set(roster.members.map((m) => m.id))
-        const selfId = $gameStore.currentPlayer?.id
-        rotated(() => {
-          for (const pos of positions.members) {
-            if (!ids.has(pos.id) || pos.id === selfId) continue
-            const wx = unwrapWorldXNear(px, pos.x)
-            let mx = (wx - viewLeft) * scale
-            let my = (pos.z - viewTop) * scale
-            // Clamp into the rotated-visible disc around the center.
-            const dx = mx - SIZE / 2
-            const dy = my - SIZE / 2
-            const dist = Math.hypot(dx, dy)
-            const maxDist = SIZE / 2 - 8
-            if (dist > maxDist) {
-              mx = SIZE / 2 + (dx / dist) * maxDist
-              my = SIZE / 2 + (dy / dist) * maxDist
-            }
-            ctx.beginPath()
-            ctx.arc(mx, my, 4, 0, Math.PI * 2)
-            ctx.fillStyle = '#4caf50'
-            ctx.fill()
-            ctx.lineWidth = 1.5
-            ctx.strokeStyle = '#ffffff'
-            ctx.stroke()
-          }
-        })
-      }
-
       // Self: centered heading arrow. rotation = atan2(dx, dz), so the facing
       // vector in (x, z) is (sin r, cos r); the rotated transform handles the
       // map's -45° for us.
@@ -227,15 +170,17 @@
   })
 </script>
 
-<button
-  class="minimap"
-  title="Open world map (M)"
-  aria-label="Open world map"
-  onclick={() => worldMapVisible.set(true)}
->
-  <canvas bind:this={canvasEl} style="width: {SIZE}px; height: {SIZE}px;"
-  ></canvas>
-</button>
+{#if onSurface}
+  <button
+    class="minimap"
+    title="Open world map (M)"
+    aria-label="Open world map"
+    onclick={() => worldMapVisible.set(true)}
+  >
+    <canvas bind:this={canvasEl} style="width: {SIZE}px; height: {SIZE}px;"
+    ></canvas>
+  </button>
+{/if}
 
 <style>
   .minimap {

--- a/client/src/lib/components/SettingsPanel.svelte
+++ b/client/src/lib/components/SettingsPanel.svelte
@@ -8,6 +8,7 @@
     type QualityLevel,
   } from '../stores/graphicsSettings'
   import VolumeControl from './VolumeControl.svelte'
+  import { minimapEnabled } from '../stores/minimapStore'
   import { mountOverlay } from '../stores/overlayStack'
 
   interface Props {
@@ -33,6 +34,26 @@
     <div class="header">
       <h2>Settings</h2>
       <button class="close-btn" onclick={onClose}>&times;</button>
+    </div>
+
+    <div class="setting-row">
+      <span class="setting-label">Minimap</span>
+      <div class="quality-row">
+        <button
+          class="quality-btn"
+          class:active={$minimapEnabled}
+          onclick={() => minimapEnabled.set(true)}
+        >
+          On
+        </button>
+        <button
+          class="quality-btn"
+          class:active={!$minimapEnabled}
+          onclick={() => minimapEnabled.set(false)}
+        >
+          Off
+        </button>
+      </div>
     </div>
 
     <div class="setting-row">

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -391,11 +391,16 @@ export function handleServerMessage(
     case 'PlayerTeleported': {
       const state = get(gameStore)
       if (state.currentPlayer && state.currentPlayer.id === data.player_id) {
-        state.currentPlayer.position.set(
-          data.position.x,
-          data.position.y,
-          data.position.z
-        )
+        // Through the store, not a bare mutation: subscribers that live
+        // across a teleport (HUD widgets) otherwise keep the old position.
+        gameStore.update((s) => {
+          s.currentPlayer?.position.set(
+            data.position.x,
+            data.position.y,
+            data.position.z
+          )
+          return s
+        })
         dungeonManager.syncFromFloorLevel(
           data.floor_level ?? 0,
           data.position.x,

--- a/client/src/lib/stores/minimapStore.ts
+++ b/client/src/lib/stores/minimapStore.ts
@@ -1,0 +1,14 @@
+import { writable } from 'svelte/store'
+
+const STORAGE_KEY = 'onlinerpg_minimapEnabled'
+
+/** HUD minimap toggle. Off by default (issue #11); persisted per browser. */
+export const minimapEnabled = writable<boolean>(
+  typeof localStorage !== 'undefined' &&
+    localStorage.getItem(STORAGE_KEY) === 'true'
+)
+
+minimapEnabled.subscribe((v) => {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, String(v))
+})


### PR DESCRIPTION
## Summary

Part of #11 — the v1 shape agreed there, with the three answers applied: **default off**, **top-right just below the time widget**, toggled in Settings.

- `Minimap.svelte`: fixed-zoom 180px canvas reusing the existing region minimap bakes, drawn with the world map's −45° rotation so screen-up matches walking up. Fixed zoom (384m across) only ever downscales the 1px/m bakes — no new bakes needed.
- Markers: a red heading arrow for the player. Nothing else — see the update below.
- Hidden off the surface (dungeon depth or upper house floor), where the surface bakes describe nothing nearby.
- Performance: redraws only on ~2m moves, ~10° turns, or bake updates (not per frame); small image cache with a hard cap. **No network traffic at all** — the widget only reads what the client already has.
- Click opens the world map dialog. `minimapEnabled` persists per browser via localStorage, default off.

### Update after review

@darkdarkcocoa's review ([comment](https://github.com/Julian-adv/OpenMMO/pull/77#issuecomment-5158738376)) caught three interactions with the party system. Party markers are **removed from v1** rather than kept on a tuned interval: the concern was the transport, and that call belongs with the party system rather than in a minimap PR. Markers can follow once the transport question is settled. Also fixed: the local `PlayerTeleported` write now goes through `gameStore` (it mutated `currentPlayer.position` in place, so an always-mounted subscriber kept the pre-teleport position — the world map only escaped it by remounting), and the widget hides off the surface.

## Test plan

- [x] Local playtest: terrain/road/river render correctly, heading arrow follows WASD in all four directions, click opens the world map, toggle defaults to off
- [x] `npx vitest run` (352), `npm run lint`, `npm run check`, `npm run format:check` — all clean
## Screenshots

Enabled — the widget sits under the time band, and the baked region tiles show the road and river running past the player:

![minimap enabled](https://github.com/simulacre7/OpenMMO/releases/download/screenshots/minimap.png)

Default off, toggled from Settings — nothing is drawn unless you ask for it:

![settings toggle](https://github.com/simulacre7/OpenMMO/releases/download/screenshots/config.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

