### PR TITLE
Prevent deletion of characters active in another session

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -810,14 +810,25 @@ async fn handle_client_message(
                 Ok(name) => name,
                 Err(responses) => return Ok(responses),
             };
-
-            match auth_service.delete_character(&authed_account_name, character_id) {
-                Ok(()) => {
+            match game_state
+                .delete_character_if_inactive(auth_service, &authed_account_name, character_id)
+                .await
+            {
+                Ok(true) => {
                     info!(
                         "Character id={} deleted for account '{}'",
                         character_id, authed_account_name
                     );
                     return Ok(vec![ServerMessage::CharacterDeleted { character_id }]);
+                }
+                Ok(false) => {
+                    warn!(
+                        "Character delete rejected for account '{}': id={} is active",
+                        authed_account_name, character_id
+                    );
+                    return Ok(vec![ServerMessage::CharacterError {
+                        message: "Cannot delete a character while it is in game".to_string(),
+                    }]);
                 }
                 Err(err) => {
                     warn!(
@@ -864,6 +875,7 @@ async fn handle_client_message(
                 Ok(name) => name,
                 Err(responses) => return Ok(responses),
             };
+            let character_sessions = game_state.lock_character_sessions().await;
 
             let selected_character =
                 match auth_service.get_character_for_account(&authed_account_name, character_id) {
@@ -971,6 +983,7 @@ async fn handle_client_message(
                     selected_character.gold,
                 )
                 .await;
+            drop(character_sessions);
 
             match auth_service.load_blocked_names(character_id) {
                 Ok(blocked) => game_state.set_player_blocks(&id, blocked).await,

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -187,6 +187,10 @@ pub struct GameState {
     dirty_inventories: Arc<RwLock<HashSet<PlayerId>>>,
     /// Serializes periodic and shutdown flushes against per-player logout saves.
     persistence_lock: Arc<Mutex<()>>,
+    /// Serializes character deletion against game-entry admission. Without
+    /// this, a delete could observe no live owner and remove the row while a
+    /// concurrent EnterGame is still loading it.
+    character_session_lock: Arc<Mutex<()>>,
     /// In-memory set of currently open doors.
     open_doors: Arc<RwLock<HashSet<DoorKey>>>,
     /// Shared-crate passability cache mirroring what clients build (houses,
@@ -299,6 +303,7 @@ impl GameState {
             dirty_players: Arc::new(RwLock::new(HashSet::new())),
             dirty_inventories: Arc::new(RwLock::new(HashSet::new())),
             persistence_lock: Arc::new(Mutex::new(())),
+            character_session_lock: Arc::new(Mutex::new(())),
             open_doors: Arc::new(RwLock::new(HashSet::new())),
             last_position_correction: Arc::new(RwLock::new(HashMap::new())),
             passability: Arc::new(std::sync::RwLock::new(

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -265,6 +265,42 @@ impl super::GameState {
         self.forget_player_skills(player_id).await;
     }
 
+    /// Whether any live session currently owns the durable character row.
+    ///
+    /// Character deletion is requested before game entry, so checking only the
+    /// requesting connection cannot protect the same character on another
+    /// connection. Keep the lookup on the authoritative session registry.
+    pub async fn is_character_active(&self, character_id: i64) -> bool {
+        self.player_characters
+            .read()
+            .await
+            .values()
+            .any(|(active_character_id, _, _)| *active_character_id == character_id)
+    }
+
+    /// Hold while admitting a character into the game. Character deletion
+    /// takes the same lock around its live-owner check and database mutation,
+    /// closing the otherwise unavoidable check/delete race.
+    pub(crate) async fn lock_character_sessions(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.character_session_lock.lock().await
+    }
+
+    /// Delete an offline character, returning `false` when another connection
+    /// still owns its authoritative live state.
+    pub(crate) async fn delete_character_if_inactive(
+        &self,
+        auth: &AuthService,
+        account_name: &str,
+        character_id: i64,
+    ) -> Result<bool, AuthError> {
+        let _sessions = self.character_session_lock.lock().await;
+        if self.is_character_active(character_id).await {
+            return Ok(false);
+        }
+        auth.delete_character(account_name, character_id)?;
+        Ok(true)
+    }
+
     pub async fn get_player_gold(&self, player_id: &PlayerId) -> i64 {
         let gold_map = self.player_gold.read().await;
         gold_map.get(player_id).copied().unwrap_or(0)

--- a/server/src/game_state/tests/player_tests.rs
+++ b/server/src/game_state/tests/player_tests.rs
@@ -210,3 +210,47 @@ async fn respawn_player_ignores_alive_player() {
         Err(err) => panic!("Expected empty channel, got {:?}", err),
     }
 }
+
+#[tokio::test]
+async fn active_character_cannot_be_deleted_from_another_session() {
+    let auth = make_test_auth("active_character_delete_guard");
+    let account = auth.login_npc("npc_active_delete").unwrap();
+    let record = create_test_character(&auth, &account, "StillPlaying");
+    let game_state = Arc::new(make_test_game_state("active_character_delete_guard"));
+    let player_id = pid("active_character");
+
+    // EnterGame takes the admission lock before reading the durable row. A
+    // concurrent delete must wait until that session appears in the live map,
+    // then reject instead of winning the check/delete race.
+    let admission = game_state.lock_character_sessions().await;
+    let deleting_state = Arc::clone(&game_state);
+    let deleting_auth = auth.clone();
+    let deleting_account = account.clone();
+    let character_id = record.id;
+    let delete = tokio::spawn(async move {
+        deleting_state
+            .delete_character_if_inactive(&deleting_auth, &deleting_account, character_id)
+            .await
+            .unwrap()
+    });
+    tokio::task::yield_now().await;
+    assert!(!delete.is_finished());
+
+    game_state
+        .register_player_character(&player_id, record.id, 0, attrs_with_cha(12), 0)
+        .await;
+    drop(admission);
+
+    assert!(!delete.await.unwrap());
+    assert!(auth.get_character_for_account(&account, record.id).is_ok());
+
+    game_state.unregister_player_character(&player_id).await;
+    assert!(game_state
+        .delete_character_if_inactive(&auth, &account, record.id)
+        .await
+        .unwrap());
+    assert!(matches!(
+        auth.get_character_for_account(&account, record.id),
+        Err(crate::auth::AuthError::CharacterNotFound)
+    ));
+}


### PR DESCRIPTION
## Overview

Character deletion only checked whether the requesting connection had entered the game. A second authenticated connection could therefore delete a character that was still active in another session, removing its durable row and dependent data while the live session continued to use it.

This change rejects deletion while any live session owns the character and serializes that decision with game-entry admission.

## Steps to reproduce

1. Authenticate two connections with the same account.
2. Enter the game with a character on the first connection.
3. Leave the second connection on character selection.
4. Send `DeleteCharacter` for the active character from the second connection.
5. Before this change, the second connection passes its local not-in-game check and deletes the account-owned row.
6. The first connection remains live with a character identity whose durable row and dependent records have been removed.

A live-registry check by itself is not sufficient: deletion could otherwise run after `EnterGame` reads the row but before it registers the live owner.

## Observed behavior

The handler applied `require_not_in_game` only to the requesting connection and then called the account-scoped database deletion directly. It did not consult the authoritative player-to-character registry.

Database cascades could remove character-owned inventory, skills, block entries, and dungeon chest history while another session still held mutable in-memory state for that character.

## Expected behavior

- A character owned by any live session cannot be deleted.
- Deletion cannot race the interval between reading a character for game entry and registering its live owner.
- Deleting an inactive character keeps the existing account ownership checks and success response.
- Once the live session has fully detached, normal deletion is allowed again.

## Root cause

Deletion treated “the requesting connection is not in game” as equivalent to “the target character is not active.” Those are different properties when the same account has multiple authenticated connections.

The missing boundary violated this invariant:

> A durable character row must not be deleted while a live session owns its authoritative state.

## Changes

- Add a live-character lookup backed by the authoritative player-to-character registry.
- Use one session lock for character deletion and game-entry admission.
- Hold the admission lock from before the durable row read until the live registry entry exists.
- Reject active-character deletion with a character error.
- Add a deterministic regression covering the concurrent admission/deletion race and the later inactive deletion path.

## Validation

The regression verifies that:

- deletion waits while game-entry admission is in progress;
- deletion is rejected after the character becomes active;
- the durable character row remains present after the rejection;
- deletion succeeds after the character is unregistered.

Local validation on the current `master`:

- `cargo test -p onlinerpg-server active_character_cannot_be_deleted_from_another_session --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 701 passed
- `git diff --check` — passed

## Scope and limitations

This does not change the wire protocol, account ownership checks, or deletion behavior for inactive characters. The lock only coordinates character admission and deletion within one server process; it does not introduce a distributed lock for multiple servers sharing one database.
