### PR TITLE
Enforce a server-side player attack interval

### DIFF
--- a/data-src/player_anim_timing.csv
+++ b/data-src/player_anim_timing.csv
@@ -1,5 +1,6 @@
 id,delayMs,comment
 player_attack_impact,540,slash1 blade lands - hit/miss sfx and monster flinch
+player_attack_interval,1380,slash1 cadence with server-arrival jitter allowance
 player_attack_damage_text,750,damage number pops after a slash1 hit
 sword_miss,450,whiff sfx on a missed slash1 swing
 prop_swing_impact,660,barrel/crate shatters as the slash1 blade lands

--- a/server/src/game_state/combat.rs
+++ b/server/src/game_state/combat.rs
@@ -34,6 +34,22 @@ pub(super) static PLAYER_ATTACK_IMPACT_DELAY: LazyLock<Duration> = LazyLock::new
     )
 });
 
+// A completed slash1 clip lasts 1,533ms in the clients. Keep a small
+// server-arrival allowance so ordinary network jitter does not turn a normal
+// animation-complete follow-up into a silent rejected swing. The value is
+// authored beside the other player animation timings, rather than copied from
+// a client fallback.
+pub(super) static PLAYER_ATTACK_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
+    let timing: serde_json::Value =
+        serde_json::from_str(include_str!("../../../data/player_anim_timing.json"))
+            .expect("player_anim_timing.json parses");
+    Duration::from_millis(
+        timing["player_attack_interval"]["delayMs"]
+            .as_u64()
+            .expect("player_attack_interval.delayMs is a number"),
+    )
+});
+
 fn dropped_weapon_position(monster_position: Position) -> Position {
     let angle = rand::thread_rng().gen_range(0.0..TAU);
     offset_position_at_angle(monster_position, angle, WEAPON_DROP_OFFSET_METERS)
@@ -90,6 +106,19 @@ impl super::GameState {
             }
             game_state.spawn_world_drops(origin, floor_level).await;
         });
+    }
+
+    async fn claim_player_attack_window(&self, player_id: &PlayerId, now: u64) -> bool {
+        let mut last_attacks = self.last_player_attacks.write().await;
+        match last_attacks.get(player_id) {
+            Some(last) if now.saturating_sub(*last) < PLAYER_ATTACK_INTERVAL.as_millis() as u64 => {
+                false
+            }
+            _ => {
+                last_attacks.insert(*player_id, now);
+                true
+            }
+        }
     }
 
     /// Sum of the guard bonuses from every equipped item — the single place
@@ -236,6 +265,12 @@ impl super::GameState {
                 return;
             }
         };
+        if !self
+            .claim_player_attack_window(player_id, Self::now_ms())
+            .await
+        {
+            return;
+        }
         // A landed attack (not a rejected one) breaks fishing concentration.
         self.cancel_fishing_if_active(player_id).await;
         debug!("Player {} attacking monster {}", player_name, monster_id);

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -142,6 +142,7 @@ pub struct GameState {
     /// `players`.
     player_ids_by_name: Arc<RwLock<HashMap<String, PlayerId>>>,
     movement_intents: Arc<RwLock<HashMap<PlayerId, player::MoveQueue>>>,
+    last_player_attacks: Arc<RwLock<HashMap<PlayerId, u64>>>,
     player_spatial_cells: Arc<RwLock<HashMap<SpatialCell, HashSet<PlayerId>>>>,
     monsters: Arc<RwLock<HashMap<String, crate::types::Monster>>>,
     ambient_spawn_allowances: Arc<RwLock<HashMap<(PlayerId, String), u64>>>,
@@ -272,6 +273,7 @@ impl GameState {
             players: Arc::new(RwLock::new(HashMap::new())),
             player_ids_by_name: Arc::new(RwLock::new(HashMap::new())),
             movement_intents: Arc::new(RwLock::new(HashMap::new())),
+            last_player_attacks: Arc::new(RwLock::new(HashMap::new())),
             player_spatial_cells: Arc::new(RwLock::new(HashMap::new())),
             monsters: Arc::new(RwLock::new(HashMap::new())),
             ambient_spawn_allowances: Arc::new(RwLock::new(HashMap::new())),

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -526,6 +526,7 @@ impl super::GameState {
             .write()
             .await
             .retain(|(owner_id, _), _| owner_id != player_id);
+        self.last_player_attacks.write().await.remove(player_id);
         // A player disconnecting inside a dungeon leaves its floor first,
         // so its monsters get reassigned (or despawned) instead of being
         // dropped by remove_monsters_by_owner below.

--- a/server/src/game_state/tests/combat_tests.rs
+++ b/server/src/game_state/tests/combat_tests.rs
@@ -878,6 +878,81 @@ async fn player_attack_at_melee_range_is_allowed() {
     );
 }
 
+#[tokio::test]
+async fn player_attack_interval_is_server_enforced() {
+    let game_state = make_test_game_state("player_attack_interval");
+    let player_id = pid("attacker");
+
+    game_state
+        .add_player(make_player("attacker", 0.0, 0.0))
+        .await;
+    let mut attacker_rx = game_state.register_direct_channel(&player_id).await;
+    game_state.monsters.write().await.insert(
+        "nearby_monster".to_string(),
+        make_monster("nearby_monster", pos(1.0), 0),
+    );
+
+    game_state
+        .broadcast_player_attack(&player_id, "nearby_monster".to_string())
+        .await;
+    game_state
+        .broadcast_player_attack(&player_id, "nearby_monster".to_string())
+        .await;
+
+    let attack_count = drain(&mut attacker_rx)
+        .into_iter()
+        .filter(|message| matches!(message, ServerMessage::PlayerAttacked { .. }))
+        .count();
+    assert_eq!(
+        attack_count, 1,
+        "back-to-back requests must produce one authoritative attack roll"
+    );
+
+    game_state.last_player_attacks.write().await.insert(
+        player_id,
+        GameState::now_ms()
+            .saturating_sub(super::combat::PLAYER_ATTACK_INTERVAL.as_millis() as u64),
+    );
+    game_state
+        .broadcast_player_attack(&player_id, "nearby_monster".to_string())
+        .await;
+
+    assert!(drain(&mut attacker_rx)
+        .into_iter()
+        .any(|message| matches!(message, ServerMessage::PlayerAttacked { .. })));
+}
+
+#[tokio::test]
+async fn rejected_player_attack_does_not_consume_interval() {
+    let game_state = make_test_game_state("rejected_player_attack_interval");
+    let player_id = pid("attacker");
+
+    game_state
+        .add_player(make_player("attacker", 0.0, 0.0))
+        .await;
+    let mut attacker_rx = game_state.register_direct_channel(&player_id).await;
+    game_state.monsters.write().await.insert(
+        "nearby_monster".to_string(),
+        make_monster("nearby_monster", pos(1.0), 0),
+    );
+
+    game_state
+        .broadcast_player_attack(&player_id, "missing_monster".to_string())
+        .await;
+    expect_attack_rejected(
+        &mut attacker_rx,
+        "missing_monster",
+        AttackRejectReason::InvalidTarget,
+    );
+    game_state
+        .broadcast_player_attack(&player_id, "nearby_monster".to_string())
+        .await;
+
+    assert!(drain(&mut attacker_rx)
+        .into_iter()
+        .any(|message| matches!(message, ServerMessage::PlayerAttacked { .. })));
+}
+
 /// A player at 0 HP (awaiting respawn) must not be able to keep attacking.
 #[tokio::test]
 async fn dead_player_cannot_attack() {


### PR DESCRIPTION
## Overview

Player attack requests were validated for attacker state, floor, target existence, and reach, but had no server-enforced attack interval. A modified client could submit valid attacks faster than the normal `slash1` animation cadence and receive a damage roll for every request.

This change adds an atomic server-side attack window after target validation and before any combat side effect. Its 1,380ms duration is authored with the other player animation timings and leaves a small server-arrival allowance below the 1,533ms `slash1` clip.

## Steps to reproduce

1. Place a live player and monster within valid melee range on the same floor.
2. Submit two valid player attack messages without advancing server time by the configured attack interval.
3. Observe the monster HP and attack broadcasts.
4. Compare this with a normal client, which waits for the `slash1` animation to finish before its next attack.

## Observed behavior

Both requests reached damage calculation because `broadcast_player_attack` had no per-player cadence state. Client timing was therefore treated as combat authority.

## Expected behavior

- The first valid attack claims the player's server-side attack window.
- Another valid attack inside the configured interval is ignored before fishing cancellation, damage roll, state mutation, or broadcast.
- Invalid target requests do not consume the interval.
- Disconnecting removes the transient interval state.

## Root cause

The browser client implemented presentation timing, while the server implemented target validation only. The existing `last_combat_at` value tracks combat activity for other mechanics and is not an atomic attack-intent gate, so it could not safely enforce cadence.

## Changes

- Add a server-only last-attack map keyed by player.
- Read the 1,380ms interval from the authored player animation timing data and atomically claim it after target validation.
- Clear the transient entry when a player disconnects.
- Add regressions for repeated valid attacks and invalid requests that must not consume the interval.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server player_attack_interval_is_server_enforced --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server rejected_player_attack_does_not_consume_interval --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 702 passed
- `git diff --check` — passed

## Scope and limitations

The interval is a server-owned rule derived from the current player animation timing data. It deliberately allows a small arrival margin below the normal `slash1` clip length; it does not add weapon-specific attack speed, change damage formulas, send a new rejection message, or reset the interval on death, respawn, or target changes.
