### PR TITLE
Refuse game entry when dungeon chest history cannot be loaded

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -955,6 +955,22 @@ async fn handle_client_message(
                 }
             };
 
+            // Dungeon history is required persistent state. Admitting a session
+            // with an empty fallback would let already-opened chests grant rewards
+            // again while the database is unavailable.
+            let dungeon_history = load_required_dungeon_history(auth_service, character_id).await;
+            let (chest_opens, discovered_dungeons) = match dungeon_history {
+                Ok(history) => history,
+                Err(err) => {
+                    warn!(
+                        "Failed to load dungeon history for character {}: {} — refusing session",
+                        character_id, err
+                    );
+                    return Ok(vec![ServerMessage::CharacterError {
+                        message: err.client_message().to_string(),
+                    }]);
+                }
+            };
             let max_hp = selected_character.max_hp;
             let character_xp = selected_character.xp;
 
@@ -1034,24 +1050,10 @@ async fn handle_client_message(
                 ),
             }
 
-            let auth = Arc::clone(auth_service);
-            let discovered_dungeons =
-                match crate::game_state::auth_db(move || auth.load_dungeon_history(character_id))
-                    .await
-                {
-                    Ok((opens, ids)) => {
-                        game_state.set_chest_opens(character_id, opens).await;
-                        game_state.set_dungeon_discoveries(&id, ids.clone()).await;
-                        ids
-                    }
-                    Err(err) => {
-                        warn!(
-                            "Failed to load dungeon history for character {}: {}",
-                            character_id, err
-                        );
-                        Vec::new()
-                    }
-                };
+            game_state.set_chest_opens(character_id, chest_opens).await;
+            game_state
+                .set_dungeon_discoveries(&id, discovered_dungeons.clone())
+                .await;
 
             // Load inventory from DB
             game_state
@@ -1697,9 +1699,18 @@ fn default_character_max_hp(
     }
 }
 
+async fn load_required_dungeon_history(
+    auth_service: &Arc<AuthService>,
+    character_id: i64,
+) -> Result<(Vec<(String, i64)>, Vec<String>), crate::auth::AuthError> {
+    let auth = Arc::clone(auth_service);
+    crate::game_state::auth_db(move || auth.load_dungeon_history(character_id)).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
     use std::net::Ipv4Addr;
 
     #[test]
@@ -1708,6 +1719,26 @@ mod tests {
         assert!(!token_matches("secret-token", "secret-tokeN"));
         assert!(!token_matches("secret", "secret-token"));
         assert!(!token_matches("", "secret-token"));
+    }
+
+    #[tokio::test]
+    async fn required_dungeon_history_load_fails_when_storage_is_unavailable() {
+        for table in ["character_dungeon_chests", "character_dungeon_discoveries"] {
+            let db_path = std::env::temp_dir().join(format!(
+                "onlinerpg_enter_game_dungeon_history_{}.db",
+                uuid::Uuid::new_v4()
+            ));
+            let auth = Arc::new(AuthService::new(db_path.clone()).unwrap());
+
+            let (opens, discoveries) = load_required_dungeon_history(&auth, 1).await.unwrap();
+            assert!(opens.is_empty());
+            assert!(discoveries.is_empty());
+
+            let conn = Connection::open(db_path).unwrap();
+            conn.execute(&format!("DROP TABLE {table}"), []).unwrap();
+
+            assert!(load_required_dungeon_history(&auth, 1).await.is_err());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Game entry treated dungeon chest history as best-effort state. If its database read failed, the server logged a warning, registered the session, and continued with no restored claims.

The reward path interprets a missing in-memory claim as an unopened chest. This change makes chest history required persistent state and refuses game entry when it cannot be loaded.

## Steps to reproduce

1. Open a dungeon chest so its claim is stored for the character.
2. Disconnect and make the next `character_dungeon_chests` read fail.
3. Enter the game again with that character.
4. Before this change, entry continues after a warning and no chest claims are restored.
5. Reach the same chest during the same reward epoch.
6. The missing in-memory claim can make the already-opened chest eligible for another reward.

## Observed behavior

`EnterGame` loaded chest history after session replacement and player registration. A read error only produced a warning, leaving the character admitted with an empty in-memory claim set.

Skill loading already failed closed before session replacement because an empty fallback could overwrite durable progress. Chest claims had the same persistent-state requirement but were handled as optional.

## Expected behavior

- A successful empty history remains valid for a character that has never opened a dungeon chest.
- Successfully loaded claims are installed before reward interaction is possible.
- A chest-history read error refuses game entry.
- The current session is not replaced and a partial new session is not registered after that failure.

## Root cause

Required reward state was loaded at a best-effort boundary after the session had already been admitted.

The missing boundary violated this invariant:

> A session must restore durable reward claims successfully before it can perform reward mutations.

## Changes

- Move the chest-history read before session replacement and player registration.
- Keep the blocking database operation on the existing asynchronous database boundary.
- Return a character error instead of continuing with an empty fallback after a read failure.
- Install only successfully loaded history in the game state.
- Add a regression that distinguishes a valid empty result from an unavailable history table.

## Validation

The regression verifies that:

- a normal database returns a valid empty history;
- removing the chest-history table makes the required read fail;
- the failure is propagated instead of becoming an empty claim set.

Local validation on the current `master`:

- `cargo test -p onlinerpg-server required_chest_history_load_fails_when_storage_is_unavailable --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 701 passed
- `git diff --check` — passed

## Scope and limitations

This does not change chest rewards, refill epochs, persistence writes, or write-failure rollback. It adds no retry or degraded mode; a client can retry entry after database access is restored. Other best-effort profile data is outside this change.
