### PR TITLE
Normalize items.csv rows to the full header width

### DIFF
--- a/data-src/items.csv
+++ b/data-src/items.csv
@@ -1,48 +1,48 @@
 id,name,description,weight,equipSlot,stackable,icon,worldModel,category,dice,material,basePrice,guard,rarityTier,catchWeight,sizeDice,trophyCm,minFishingLevel,chestTier,chestChance,consumable,nutrition,grillsInto
-iron_sword,Iron Sword,A sturdy iron longsword.,3,main_hand,false,iron_sword.png,weapons/sword.glb,weapon,1d8,metal,10000,
-worn_iron_sword,Worn Iron Sword,A well-used iron longsword. Merchants won't pay for it.,3,main_hand,false,iron_sword.png,weapons/sword.glb,weapon,1d6,metal,,
-wooden_shield,Wooden Shield,A round wooden shield.,6,off_hand,false,shield_wooden.png,armor/shield_wooden.glb,armor,,wood,2500,1,
-raven_shield,Raven Shield,A round wooden shield painted with a black raven crest.,6,off_hand,false,shield_raven.png,armor/shield_raven.glb,armor,,wood,7000,2,,,,,,2,0.2
-leather_helmet,Leather Helmet,A simple leather helmet.,1,head,false,leather_helmet.png,armor/leather_helmet.glb,armor,,leather,1500,1,,,,,,1
-iron_helmet,Iron Helmet,A heavy iron great helm that guards the whole head.,4,head,false,iron_helmet.png,armor/iron_helmet.glb,armor,,metal,6000,2,,,,,,2,0.37
-breastplate,Breastplate,A polished steel breastplate that turns aside all but the truest blows.,20,chest,false,plate_armor.png,armor/plate_armor.glb,armor,,metal,40000,7,,,,,,4
-leather_pants,Leather Pants,Durable leather leggings.,4,pants,false,leather_pants.png,armor/leather_pants.glb,armor,,leather,2500,1,,,,,,1,0.3
-iron_boots,Iron Boots,Heavy iron boots.,6,boots,false,iron_boots.png,armor/iron_boots.glb,armor,,metal,6000,2,,,,,,2,0.37
-leather_gloves,Leather Gloves,Supple leather gloves with a sure grip.,0.5,hands,false,leather_gloves.png,armor/leather_gloves.glb,armor,,leather,2000,1,,,,,,2,0.37
-iron_gauntlets,Iron Gauntlets,Heavy iron gauntlets that shield the hands and wrists.,2,hands,false,iron_gauntlets.png,armor/iron_gauntlets.glb,armor,,metal,6000,2,,,,,,3,0.37
-leather_boots,Leather Boots,Sturdy leather boots that tread softly.,3,boots,false,leather_boots.png,armor/leather_boots.glb,armor,,leather,2500,1,,,,,,2,0.37
-plate_greaves,Plate Greaves,Articulated steel greaves that guard the legs.,8,pants,false,iron_leggings.png,armor/iron_leggings.glb,armor,,metal,12000,3,,,,,,3,0.37
-plate_boots,Plate Boots,Overlapping steel plates that guard the feet and shins.,7,boots,false,plate_greaves.png,armor/plate_greaves.glb,armor,,metal,9000,3,,,,,,3,0.37
-plate_helmet,Plate Helmet,A visored steel close helm that encases the whole head.,5,head,false,plate_helmet.png,armor/plate_helmet.glb,armor,,metal,15000,3,,,,,,4,0.3
-plate_gauntlets,Plate Gauntlets,Articulated steel gauntlets that encase the hands and wrists.,3,hands,false,plate_gauntlets.png,armor/plate_gauntlets.glb,armor,,metal,10000,3,,,,,,4,0.3
-ring_of_protection,Ring of Protection,A silver ring bearing a cross-emblazoned shield that wards off blows.,0.1,ring,false,cross_shield_ring.png,accessory/cross_shield_ring.glb,accessory,,metal,20000,1,,,,,,5,0.2
-gold_ring,Gold Ring,A plain gold ring.,0.1,ring,false,sword.png,,accessory,,metal,12000,
-silver_necklace,Silver Necklace,A delicate silver chain.,0.3,neck,false,sword.png,,accessory,,metal,8000,
-leather_belt,Leather Belt,A wide leather belt.,1,belt,false,ornate_cross_belt.png,accessory/ornate_cross_belt.glb,accessory,,leather,800,,,,,,,1,0.3
-dagger,Dagger,A small but sharp dagger.,1,main_hand,false,dagger.png,weapons/dagger.glb,weapon,1d4,metal,2500,
-goblin_sword,Goblin Sword,A crude short blade favored by goblins and orcs.,2,main_hand,false,goblin_sword.png,weapons/goblin_sword.glb,weapon,1d4,metal,2000,
-small_sword,Small Sword,A compact crude blade sized for small fighters.,1.5,main_hand,false,small_sword.png,weapons/small_sword.glb,weapon,1d4,metal,1500,
-chain_mail,Chain Mail,Interlocking metal rings forming armor.,30,chest,false,chain_mail.png,armor/chain_mail.glb,armor,,metal,25000,5,,,,,,3
-torch,Torch,A flickering wooden torch.,1,off_hand,false,torch.png,weapons/torch.glb,weapon,1d4,wood,50,
-worn_torch,Worn Torch,A stubby half-burnt torch. Merchants won't pay for it.,1,off_hand,false,torch.png,weapons/torch.glb,weapon,1d4,wood,,
-spear,Spear,A long wooden-shafted spear tipped with iron.,4,main_hand,false,spear_icon.png,weapons/spear.glb,weapon,1d6,metal,3500,
-coin_pile,Coin Pile,A small heap of loose copper coins.,0,,false,sword.png,objects/coin_pile_spill.glb,currency,,,,
-healing_potion,Healing Potion,A crimson brew that knits wounds and restores vitality.,0.5,,true,healing_potion.png,objects/health_potion.glb,healing_potion,6d4,,600,,,,,,,,,true
-scroll_of_return,Scroll of Return,Reading the arcane runes whisks you back to town in a flash of light.,0.2,,true,scroll_of_return.png,objects/scroll.glb,return_scroll,,,800,,,,,,,,,true
-scroll_of_enchant_weapon,Scroll of Enchant Weapon,Arcane runes that hone your wielded weapon's edge — though greedy re-reading may destroy it.,0.2,,true,scroll_of_enchant_weapon.png,objects/scroll_enchant.glb,enchant_scroll,,,1200,,,,,,,,,true
-scroll_of_party_summon,Scroll of Party Summon,Reading the runes calls your whole party to your side — each may answer or ignore the summons.,0.2,,true,scroll_of_party_summon.png,objects/scroll.glb,party_summon_scroll,,,1000,,,,,,,,,true
-table,Table,A sturdy wooden table.,20,,false,table_icon.png,objects/table.glb,furniture,,wood,3000,
-leather_armor,Leather Armor,Supple leather chest armor crossed with straps and buckles.,8,chest,false,leather_armor.png,armor/leather_armor.glb,armor,,leather,6000,2,,,,,,2
-fishing_rod,Fishing Rod,A supple wooden rod with a horsehair line. Cast at water to fish.,2,main_hand,false,fishing_rod.png,weapons/fishing_rod.glb,fishing_rod,,wood,300,,,,,
+iron_sword,Iron Sword,A sturdy iron longsword.,3,main_hand,false,iron_sword.png,weapons/sword.glb,weapon,1d8,metal,10000,,,,,,,,,,,
+worn_iron_sword,Worn Iron Sword,A well-used iron longsword. Merchants won't pay for it.,3,main_hand,false,iron_sword.png,weapons/sword.glb,weapon,1d6,metal,,,,,,,,,,,,
+wooden_shield,Wooden Shield,A round wooden shield.,6,off_hand,false,shield_wooden.png,armor/shield_wooden.glb,armor,,wood,2500,1,,,,,,,,,,
+raven_shield,Raven Shield,A round wooden shield painted with a black raven crest.,6,off_hand,false,shield_raven.png,armor/shield_raven.glb,armor,,wood,7000,2,,,,,,2,0.2,,,
+leather_helmet,Leather Helmet,A simple leather helmet.,1,head,false,leather_helmet.png,armor/leather_helmet.glb,armor,,leather,1500,1,,,,,,1,,,,
+iron_helmet,Iron Helmet,A heavy iron great helm that guards the whole head.,4,head,false,iron_helmet.png,armor/iron_helmet.glb,armor,,metal,6000,2,,,,,,2,0.37,,,
+breastplate,Breastplate,A polished steel breastplate that turns aside all but the truest blows.,20,chest,false,plate_armor.png,armor/plate_armor.glb,armor,,metal,40000,7,,,,,,4,,,,
+leather_pants,Leather Pants,Durable leather leggings.,4,pants,false,leather_pants.png,armor/leather_pants.glb,armor,,leather,2500,1,,,,,,1,0.3,,,
+iron_boots,Iron Boots,Heavy iron boots.,6,boots,false,iron_boots.png,armor/iron_boots.glb,armor,,metal,6000,2,,,,,,2,0.37,,,
+leather_gloves,Leather Gloves,Supple leather gloves with a sure grip.,0.5,hands,false,leather_gloves.png,armor/leather_gloves.glb,armor,,leather,2000,1,,,,,,2,0.37,,,
+iron_gauntlets,Iron Gauntlets,Heavy iron gauntlets that shield the hands and wrists.,2,hands,false,iron_gauntlets.png,armor/iron_gauntlets.glb,armor,,metal,6000,2,,,,,,3,0.37,,,
+leather_boots,Leather Boots,Sturdy leather boots that tread softly.,3,boots,false,leather_boots.png,armor/leather_boots.glb,armor,,leather,2500,1,,,,,,2,0.37,,,
+plate_greaves,Plate Greaves,Articulated steel greaves that guard the legs.,8,pants,false,iron_leggings.png,armor/iron_leggings.glb,armor,,metal,12000,3,,,,,,3,0.37,,,
+plate_boots,Plate Boots,Overlapping steel plates that guard the feet and shins.,7,boots,false,plate_greaves.png,armor/plate_greaves.glb,armor,,metal,9000,3,,,,,,3,0.37,,,
+plate_helmet,Plate Helmet,A visored steel close helm that encases the whole head.,5,head,false,plate_helmet.png,armor/plate_helmet.glb,armor,,metal,15000,3,,,,,,4,0.3,,,
+plate_gauntlets,Plate Gauntlets,Articulated steel gauntlets that encase the hands and wrists.,3,hands,false,plate_gauntlets.png,armor/plate_gauntlets.glb,armor,,metal,10000,3,,,,,,4,0.3,,,
+ring_of_protection,Ring of Protection,A silver ring bearing a cross-emblazoned shield that wards off blows.,0.1,ring,false,cross_shield_ring.png,accessory/cross_shield_ring.glb,accessory,,metal,20000,1,,,,,,5,0.2,,,
+gold_ring,Gold Ring,A plain gold ring.,0.1,ring,false,sword.png,,accessory,,metal,12000,,,,,,,,,,,
+silver_necklace,Silver Necklace,A delicate silver chain.,0.3,neck,false,sword.png,,accessory,,metal,8000,,,,,,,,,,,
+leather_belt,Leather Belt,A wide leather belt.,1,belt,false,ornate_cross_belt.png,accessory/ornate_cross_belt.glb,accessory,,leather,800,,,,,,,1,0.3,,,
+dagger,Dagger,A small but sharp dagger.,1,main_hand,false,dagger.png,weapons/dagger.glb,weapon,1d4,metal,2500,,,,,,,,,,,
+goblin_sword,Goblin Sword,A crude short blade favored by goblins and orcs.,2,main_hand,false,goblin_sword.png,weapons/goblin_sword.glb,weapon,1d4,metal,2000,,,,,,,,,,,
+small_sword,Small Sword,A compact crude blade sized for small fighters.,1.5,main_hand,false,small_sword.png,weapons/small_sword.glb,weapon,1d4,metal,1500,,,,,,,,,,,
+chain_mail,Chain Mail,Interlocking metal rings forming armor.,30,chest,false,chain_mail.png,armor/chain_mail.glb,armor,,metal,25000,5,,,,,,3,,,,
+torch,Torch,A flickering wooden torch.,1,off_hand,false,torch.png,weapons/torch.glb,weapon,1d4,wood,50,,,,,,,,,,,
+worn_torch,Worn Torch,A stubby half-burnt torch. Merchants won't pay for it.,1,off_hand,false,torch.png,weapons/torch.glb,weapon,1d4,wood,,,,,,,,,,,,
+spear,Spear,A long wooden-shafted spear tipped with iron.,4,main_hand,false,spear_icon.png,weapons/spear.glb,weapon,1d6,metal,3500,,,,,,,,,,,
+coin_pile,Coin Pile,A small heap of loose copper coins.,0,,false,sword.png,objects/coin_pile_spill.glb,currency,,,,,,,,,,,,,,
+healing_potion,Healing Potion,A crimson brew that knits wounds and restores vitality.,0.5,,true,healing_potion.png,objects/health_potion.glb,healing_potion,6d4,,600,,,,,,,,,true,,
+scroll_of_return,Scroll of Return,Reading the arcane runes whisks you back to town in a flash of light.,0.2,,true,scroll_of_return.png,objects/scroll.glb,return_scroll,,,800,,,,,,,,,true,,
+scroll_of_enchant_weapon,Scroll of Enchant Weapon,Arcane runes that hone your wielded weapon's edge — though greedy re-reading may destroy it.,0.2,,true,scroll_of_enchant_weapon.png,objects/scroll_enchant.glb,enchant_scroll,,,1200,,,,,,,,,true,,
+scroll_of_party_summon,Scroll of Party Summon,Reading the runes calls your whole party to your side — each may answer or ignore the summons.,0.2,,true,scroll_of_party_summon.png,objects/scroll.glb,party_summon_scroll,,,1000,,,,,,,,,true,,
+table,Table,A sturdy wooden table.,20,,false,table_icon.png,objects/table.glb,furniture,,wood,3000,,,,,,,,,,,
+leather_armor,Leather Armor,Supple leather chest armor crossed with straps and buckles.,8,chest,false,leather_armor.png,armor/leather_armor.glb,armor,,leather,6000,2,,,,,,2,,,,
+fishing_rod,Fishing Rod,A supple wooden rod with a horsehair line. Cast at water to fish.,2,main_hand,false,fishing_rod.png,weapons/fishing_rod.glb,fishing_rod,,wood,300,,,,,,,,,,,
 raw_minnow,Raw Minnow,A tiny silver fish. Barely a mouthful.,0.2,,false,raw_minnow.png,,fish,1d3,,10,,1,50,3d4,12,,,,true,40,grilled_minnow
 raw_perch,Raw Perch,A striped river perch. Decent eating.,0.5,,false,raw_perch.png,,fish,1d6,,25,,2,30,4d6,22,,,,true,40,grilled_perch
 raw_trout,Raw Trout,A speckled trout. Anglers respect it.,1,,false,raw_trout.png,,fish,2d4,,60,,3,14,6d8,42,,,,true,40,grilled_trout
 river_salmon,River Salmon,A powerful silver salmon. A proud catch.,2,,false,river_salmon.png,,fish,2d6,,200,,4,5,8d10,70,10,,,true,40,grilled_salmon
 golden_sturgeon,Golden Sturgeon,An armoured river giant older than the kingdom. Its bony scutes shine like beaten gold.,4,,false,golden_sturgeon.png,,fish,4d6,,1500,,5,1,20d10,150,20,,,true,40,grilled_sturgeon
-old_boot,Old Boot,A waterlogged leather boot. Someone had a worse day than you.,1,,false,old_boot.png,,junk,,leather,,,0,6,9d3,,
-clump_of_kelp,Clump of Kelp,A slimy tangle of seaweed dredged from the bottom.,0.5,,false,clump_of_kelp.png,,junk,,,,,0,5,6d6,,
-message_in_a_bottle,Message in a Bottle,A sealed bottle with a scrap of paper inside. A collector might pay a little.,0.3,,false,message_in_a_bottle.png,,junk,,,15,,0,2,7d3,,
-sunken_coin_pouch,Sunken Coin Pouch,A drowned purse still holding a few coins.,0.2,,false,sunken_coin_pouch.png,,coin_catch,3d8,,,,0,4,6d3,,,,,true
+old_boot,Old Boot,A waterlogged leather boot. Someone had a worse day than you.,1,,false,old_boot.png,,junk,,leather,,,0,6,9d3,,,,,,,
+clump_of_kelp,Clump of Kelp,A slimy tangle of seaweed dredged from the bottom.,0.5,,false,clump_of_kelp.png,,junk,,,,,0,5,6d6,,,,,,,
+message_in_a_bottle,Message in a Bottle,A sealed bottle with a scrap of paper inside. A collector might pay a little.,0.3,,false,message_in_a_bottle.png,,junk,,,15,,0,2,7d3,,,,,,,
+sunken_coin_pouch,Sunken Coin Pouch,A drowned purse still holding a few coins.,0.2,,false,sunken_coin_pouch.png,,coin_catch,3d8,,,,0,4,6d3,,,,,true,,
 apple,Apple,A crisp red apple.,0.3,,true,apple.png,,food,,,3,,,,,,,,,true,60,
 bread,Bread,A fresh-baked loaf.,0.5,,true,bread.png,,food,,,8,,,,,,,,,true,180,
 cheese,Cheese,A wedge of hard cheese. Keeps well on the road.,0.5,,true,cheese.png,,food,,,20,,,,,,,,,true,300,

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -126,7 +126,6 @@
 - 월드모델 없는 기존 아이템(장신구·천갑옷 등)이 sword.png 아이콘으로 보이는 회귀 → 실제 아이콘 부여
 - agent-client: 부분 좌표(z 누락 등)를 조용히 버림 → 피드백 이벤트 추가
 - agent-client: 리플렉스 지연이 1초 orchestrator tick에 편승 (struggle 윈도 더 줄이면 위험)
-- items.csv ragged 행 정규화 (18칸 헤더 대비 기존 행 13–14칸)
 - EV 테스트의 상인 환율 0.4 하드코딩 → merchant defs에서 읽기
 - 문서 오류: doc/FISHING.md "SFX 전부 CC0" 오기, doc/AGENT_CLIENT.md 낚시 섹션만 영어
 - doc/assets/items.md 아이콘 provenance에 ChatGPT tier 누락


### PR DESCRIPTION
## Summary

Fixes the `doc/TODO.md` fishing follow-up item: *items.csv ragged 행 정규화*.

Data rows in `data-src/items.csv` ranged from 13 to 23 fields against what is now a 23-column header, so adding a new column meant deciding per-row how many commas to add — error-prone, and the source of the ragged drift in the first place. Every row now carries exactly 23 fields.

## Safety

`tools/cargo-build-data.rs` skips a column whether it is **missing** (`values.get(i)` → `None` → `unwrap_or_default()`) or **empty** — both hit the `raw.is_empty()` continue. Padding with trailing commas is therefore invisible to the converter. Verified by running a faithful re-implementation of the converter over the file before and after: the outputs are byte-identical.

## Changes

- `data-src/items.csv`: pad all 54 data rows to 23 fields; no cell content touched
- `doc/TODO.md`: drop the resolved follow-up line

🤖 Generated with [Claude Code](https://claude.com/claude-code)