### PR TITLE
Read the merchant sell rate from defs in the catch EV test

### DIFF
--- a/server/src/item_defs.rs
+++ b/server/src/item_defs.rs
@@ -477,6 +477,11 @@ mod tests {
         }
         let defs = ItemDefs::load();
         let table = defs.catch_table();
+        let sell_rate = crate::merchant_defs::merchant_defs()
+            .get_by_npc_name("Rica")
+            .expect("Rica has a merchant definition")
+            .sell_rate_percent as f64
+            / 100.0;
         let ev_at = |level: u32| -> f64 {
             let weights = crate::game_state::fishing::effective_weights(table, level);
             let total: f64 = weights.iter().map(|w| *w as f64).sum();
@@ -489,8 +494,8 @@ mod tests {
                         // Coins arrive at face value.
                         def.dice.as_deref().map_or(0.0, dice_avg)
                     } else {
-                        // Items sell at the merchant rate (Rica: 40%).
-                        def.base_price.unwrap_or(0) as f64 * 0.4
+                        // Items sell at Rica's merchant rate.
+                        def.base_price.unwrap_or(0) as f64 * sell_rate
                     };
                     *weight as f64 * value
                 })


### PR DESCRIPTION
## Summary

Fixes the `doc/TODO.md` fishing follow-up item: *EV 테스트의 상인 환율 0.4 하드코딩 → merchant defs에서 읽기*.

`expected_catch_value_stays_in_the_coin_pile_economy_at_every_level` valued non-coin catches with a literal `* 0.4`. If `sellRatePercent` in `data-src/merchants.csv` were ever rebalanced, the guardrail would keep testing the old economy — silently. The test now reads Rica's rate from `merchant_defs()`, the same source the trading code uses.

The corresponding TODO line is left untouched to avoid conflicting with #82's adjacent edit — it can be dropped whenever TODO is next tidied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)