### PR TITLE
Tell the LLM when a move had no usable goal

### DIFF
--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -775,6 +775,16 @@ pub(super) async fn handle_response(
                         error!("Move error to ({gx:.1}, {gz:.1})");
                     }
                 }
+            } else {
+                // Partial coordinates (x without z, direction without
+                // distance) used to vanish silently — tell the LLM instead.
+                warn!("move: no usable goal (x={x:?} z={z:?} dir={direction:?} dist={distance:?})");
+                let mut s = state.lock().await;
+                s.push_agent_event(
+                    "[MoveFailed] That move had no usable goal — give both x and z, \
+                     or a direction with a distance."
+                        .to_string(),
+                );
             }
             continue;
         }


### PR DESCRIPTION
## Summary

Fixes the `doc/TODO.md` fishing follow-up item: *agent-client: 부분 좌표(z 누락 등)를 조용히 버림 → 피드백 이벤트 추가*.

In `handle_response`, a coordinate move resolves through `resolve_move_goal` — and when the LLM emits partial coordinates (`x` without `z`) or a `direction` without a `distance`, that returns `None` and the action fell through `if let Some((gx, gz))` with no else: the character never moves and the LLM gets nothing. The two failure paths right beside it (unknown target name, blocked path) both push `[MoveFailed]` events, so a malformed goal was the only move failure the LLM could not see or correct.

The new else arm pushes a `[MoveFailed]` event naming the accepted forms (both `x` and `z`, or `direction` + `distance`), plus a `warn!` with the raw fields for the journal.

Kept out of scope: `fish` with partial coordinates deliberately falls back to a default cast spot rather than being dropped, and the dungeon-floor move treats `None` as "use the floor's landing" — both are legitimate `None`s, not silent drops.

The corresponding TODO line is left untouched to avoid conflicting with #82's adjacent edit — it can be dropped whenever TODO is next tidied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)