### PR TITLE
Add operator commands: /kick, /mute, /summon, /goto

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ The server handles systemd's `SIGTERM` gracefully: it shows connected players a 
 
 Admin characters can use `/notice <message>` to raise the same banner by hand (this is the live in-game banner, not the login-screen announcements served from `data/announcements/`). `/notice` with no message clears it; players who enter while one is active receive it on join.
 
+Admins also have moderation and movement commands: `/kick <name>` disconnects a player, `/mute <name> [minutes]` silences their chat and whispers (default 10 minutes, survives a relog, cleared by `/unmute <name>` or a server restart), `/summon <name>` teleports them to your side, and `/goto <name>` teleports you to theirs.
+
 Over SSH, detach it from the session so a dropped connection cannot kill the build midway:
 
 ```bash

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -94,10 +94,10 @@
 - [x] 차단 (`/block <이름>`, `/unblock <이름>`, `/block`으로 목록)
 - 운영자 커맨드
   - ban
-  - kick
-  - summon
-  - goto
-  - mute
+  - [x] kick
+  - [x] summon
+  - [x] goto
+  - [x] mute
 - party, guild 기능
 - [x] 키보드로 움직이면 다른 플레이어에게는 움찔거리며 움직이는 것으로 보인다
 - [x] 디버그창 일반인에게는 안 보이게

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -3,7 +3,8 @@ use crate::conn_limit::{resolve_client_ip, ConnectLimiter};
 use crate::game::character_attributes::roll_character_attributes;
 use crate::game::character_hp::{level_one_max_hp, DEFAULT_CHARACTER_RACE};
 use crate::game_state::{
-    encode_server_msg, parse_notice_command, restored_floor_level, DirectMessage, GameState,
+    encode_server_msg, parse_admin_command, parse_notice_command, restored_floor_level,
+    DirectMessage, GameState,
 };
 use crate::google_auth::GoogleAuthVerifier;
 use crate::types::{
@@ -572,7 +573,9 @@ fn requires_admin(msg: &ClientMessage) -> bool {
         | ClientMessage::DebugSetTime { .. }
         | ClientMessage::DebugResetDungeonProps { .. } => true,
         ClientMessage::ChatMessage { message } => {
-            message.starts_with("/give ") || parse_notice_command(message).is_some()
+            message.starts_with("/give ")
+                || parse_notice_command(message).is_some()
+                || parse_admin_command(message).is_some()
         }
         _ => false,
     }
@@ -908,7 +911,11 @@ async fn handle_client_message(
 
             // Enforced unique character names allow name-based session replacement.
             game_state
-                .kick_player_by_name(&selected_character.name, auth_service)
+                .kick_player_by_name(
+                    &selected_character.name,
+                    "Another session logged in with the same account",
+                    auth_service,
+                )
                 .await;
 
             let max_hp = selected_character.max_hp;
@@ -1784,8 +1791,25 @@ mod tests {
         assert!(requires_admin(&ClientMessage::ChatMessage {
             message: "/notice".into()
         }));
+        for admin_command in [
+            "/kick Abuser",
+            "/mute Abuser 5",
+            "/unmute Abuser",
+            "/summon Abuser",
+            "/goto Abuser",
+        ] {
+            assert!(
+                requires_admin(&ClientMessage::ChatMessage {
+                    message: admin_command.into()
+                }),
+                "{admin_command} must be admin-gated"
+            );
+        }
         assert!(!requires_admin(&ClientMessage::ChatMessage {
             message: "hello".into()
+        }));
+        assert!(!requires_admin(&ClientMessage::ChatMessage {
+            message: "/who".into()
         }));
         assert!(!requires_admin(&ClientMessage::Heartbeat));
     }

--- a/server/src/game_state/chat.rs
+++ b/server/src/game_state/chat.rs
@@ -2,11 +2,16 @@ use super::auth_db;
 use crate::auth::AuthService;
 use crate::types::{ClientKind, Player, PlayerId, ServerMessage};
 use crate::world_config::world_config;
+use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
 /// Upper bound on one character's `/block` list, so the per-recipient chat
 /// filter and the DB rows stay bounded at 5,000 concurrent users.
 const MAX_BLOCKS: usize = 100;
+
+/// `/mute` duration (minutes): default when unstated, and the cap (one day).
+const MUTE_DEFAULT_MINUTES: u64 = 10;
+const MUTE_MAX_MINUTES: u64 = 1440;
 
 /// `/who` breakdown. Splits by client program rather than by "human vs bot":
 /// the server cannot tell whether a person or an LLM is driving a web client,
@@ -102,6 +107,42 @@ pub(crate) fn parse_party_command(message: &str) -> Option<Option<&str>> {
     Some((!rest.is_empty()).then_some(rest))
 }
 
+/// Operator commands (doc/TODO.md 운영자 커맨드). `requires_admin` gates them
+/// through this same parser, so the syntax is defined once. Parts return
+/// unvalidated, like the whisper parser: a malformed command draws a usage
+/// reply instead of leaking into local chat.
+#[derive(Debug, PartialEq)]
+pub(crate) enum AdminCommand<'a> {
+    Kick(&'a str),
+    Mute {
+        name: &'a str,
+        minutes: Option<&'a str>,
+    },
+    Unmute(&'a str),
+    Summon(&'a str),
+    Goto(&'a str),
+}
+
+pub(crate) fn parse_admin_command(message: &str) -> Option<AdminCommand<'_>> {
+    if let Some(rest) = strip_command(message, "/kick") {
+        return Some(AdminCommand::Kick(rest));
+    }
+    if let Some(rest) = strip_command(message, "/unmute") {
+        return Some(AdminCommand::Unmute(rest));
+    }
+    if let Some(rest) = strip_command(message, "/mute") {
+        let (name, minutes) = match rest.split_once(' ') {
+            Some((name, minutes)) => (name, Some(minutes.trim())),
+            None => (rest, None),
+        };
+        return Some(AdminCommand::Mute { name, minutes });
+    }
+    if let Some(rest) = strip_command(message, "/summon") {
+        return Some(AdminCommand::Summon(rest));
+    }
+    strip_command(message, "/goto").map(AdminCommand::Goto)
+}
+
 /// Case-insensitive lookup of a player-typed name. Names are unique ignoring
 /// ASCII case (the characters table enforces it), so the first match is the
 /// match. Used by `/unblock` against the stored block list; online-player
@@ -129,6 +170,11 @@ impl super::GameState {
                 "server notice updated"
             );
             self.set_server_notice(notice.map(str::to_string)).await;
+            return;
+        }
+
+        if let Some(command) = parse_admin_command(&message) {
+            self.handle_admin_command(player_id, command, auth).await;
             return;
         }
 
@@ -187,6 +233,14 @@ impl super::GameState {
         };
 
         if let Some(player_name) = player_name {
+            if let Some(minutes) = self.muted_minutes_left(&player_name).await {
+                self.send_system_message(
+                    player_id,
+                    format!("Muted: you cannot chat for another {minutes}m."),
+                )
+                .await;
+                return;
+            }
             // Chat content stays out of logs on purpose (privacy, F-012).
             info!(from = %player_name, len = message.len(), "chat message");
             let mut recipients = self
@@ -240,6 +294,14 @@ impl super::GameState {
             warn!("Whisper from non-existent player: {}", player_id);
             return;
         };
+        if let Some(minutes) = self.muted_minutes_left(&from).await {
+            self.send_system_message(
+                player_id,
+                format!("Muted: you cannot whisper for another {minutes}m."),
+            )
+            .await;
+            return;
+        }
         let (target_id, to) = match target {
             Ok(target) => target,
             Err(message) => {
@@ -413,6 +475,170 @@ impl super::GameState {
             }
         }
         format!("Unblock: {stored} is no longer blocked.")
+    }
+
+    /// Remaining mute minutes for a character name (rounded up, so a mute
+    /// never reads "0m" while still active), pruning the entry on expiry.
+    async fn muted_minutes_left(&self, name: &str) -> Option<u64> {
+        let key = name.to_ascii_lowercase();
+        {
+            let muted = self.muted_until.read().await;
+            let (_, until) = muted.get(&key)?;
+            if let Some(left) = until.checked_duration_since(Instant::now()) {
+                return Some(left.as_secs().div_ceil(60).max(1));
+            }
+        }
+        self.muted_until.write().await.remove(&key);
+        None
+    }
+
+    async fn handle_admin_command(
+        &self,
+        admin_id: &PlayerId,
+        command: AdminCommand<'_>,
+        auth: &AuthService,
+    ) {
+        let reply = match command {
+            AdminCommand::Kick(name) => self.kick_command(admin_id, name, auth).await,
+            AdminCommand::Mute { name, minutes } => {
+                self.mute_command(admin_id, name, minutes).await
+            }
+            AdminCommand::Unmute(name) => self.unmute_command(name).await,
+            AdminCommand::Summon(name) => self.summon_command(admin_id, name).await,
+            AdminCommand::Goto(name) => self.goto_command(admin_id, name).await,
+        };
+        self.send_system_message(admin_id, reply).await;
+    }
+
+    async fn kick_command(&self, admin_id: &PlayerId, name: &str, auth: &AuthService) -> String {
+        if name.is_empty() {
+            return "Kick: /kick <name>".to_string();
+        }
+        let Some(target_id) = self.player_id_by_name(name).await else {
+            return format!("Kick: no one called {name} is here.");
+        };
+        if target_id == *admin_id {
+            return "Kick: that's you.".to_string();
+        }
+        let canonical = self.player_name_of(&target_id).await;
+        info!(admin = ?admin_id, target = %canonical, "admin kick");
+        self.kick_player_by_name(&canonical, "Removed by an operator", auth)
+            .await;
+        format!("Kick: {canonical} was disconnected.")
+    }
+
+    async fn mute_command(
+        &self,
+        admin_id: &PlayerId,
+        name: &str,
+        raw_minutes: Option<&str>,
+    ) -> String {
+        if name.is_empty() {
+            return "Mute: /mute <name> [minutes]".to_string();
+        }
+        let minutes = match raw_minutes {
+            None => MUTE_DEFAULT_MINUTES,
+            Some(raw) => match raw.parse() {
+                Ok(m) if (1..=MUTE_MAX_MINUTES).contains(&m) => m,
+                _ => return format!("Mute: minutes must be 1–{MUTE_MAX_MINUTES}."),
+            },
+        };
+        // Online-only: the roster carries the canonical spelling, and a mute
+        // on someone absent has nothing to bite on anyway.
+        let Some(target_id) = self.player_id_by_name(name).await else {
+            return format!("Mute: no one called {name} is here.");
+        };
+        if target_id == *admin_id {
+            return "Mute: that's you.".to_string();
+        }
+        let canonical = self.player_name_of(&target_id).await;
+        let until = Instant::now() + Duration::from_secs(minutes * 60);
+        {
+            let mut muted = self.muted_until.write().await;
+            let now = Instant::now();
+            muted.retain(|_, (_, expiry)| *expiry > now);
+            muted.insert(canonical.to_ascii_lowercase(), (canonical.clone(), until));
+        }
+        info!(admin = ?admin_id, target = %canonical, minutes, "admin mute");
+        self.send_system_message(&target_id, format!("You are muted for {minutes}m."))
+            .await;
+        format!("Mute: {canonical} cannot chat for {minutes}m. /unmute {canonical} undoes this.")
+    }
+
+    async fn unmute_command(&self, name: &str) -> String {
+        if name.is_empty() {
+            return "Unmute: /unmute <name>".to_string();
+        }
+        let mut muted = self.muted_until.write().await;
+        let now = Instant::now();
+        muted.retain(|_, (_, expiry)| *expiry > now);
+        match muted.remove(&name.to_ascii_lowercase()) {
+            Some((canonical, _)) => format!("Unmute: {canonical} can chat again."),
+            None => format!("Unmute: {name} is not muted."),
+        }
+    }
+
+    async fn summon_command(&self, admin_id: &PlayerId, name: &str) -> String {
+        if name.is_empty() {
+            return "Summon: /summon <name>".to_string();
+        }
+        let Some(target_id) = self.player_id_by_name(name).await else {
+            return format!("Summon: no one called {name} is here.");
+        };
+        if target_id == *admin_id {
+            return "Summon: that's you.".to_string();
+        }
+        let admin = {
+            let players = self.players.read().await;
+            players
+                .get(admin_id)
+                .map(|p| (p.position, p.rotation, p.floor_level, p.name.clone()))
+        };
+        let Some((center, rotation, floor, admin_name)) = admin else {
+            warn!("/summon from non-existent player: {admin_id}");
+            return "Summon: server error, try again.".to_string();
+        };
+        let canonical = self.player_name_of(&target_id).await;
+        // Queued waypoints target the place the player was summoned from;
+        // snapping to one after the teleport would drag them straight back.
+        self.movement_intents.write().await.remove(&target_id);
+        let arrival = self.arrival_beside(&target_id, &center);
+        self.teleport_player(&target_id, arrival, rotation, floor)
+            .await;
+        info!(admin = ?admin_id, target = %canonical, "admin summon");
+        self.send_system_message(
+            &target_id,
+            format!("An operator summoned you to {admin_name}'s side."),
+        )
+        .await;
+        format!("Summon: {canonical} is at your side.")
+    }
+
+    async fn goto_command(&self, admin_id: &PlayerId, name: &str) -> String {
+        if name.is_empty() {
+            return "Goto: /goto <name>".to_string();
+        }
+        let Some(target_id) = self.player_id_by_name(name).await else {
+            return format!("Goto: no one called {name} is here.");
+        };
+        if target_id == *admin_id {
+            return "Goto: that's you.".to_string();
+        }
+        let target = {
+            let players = self.players.read().await;
+            players
+                .get(&target_id)
+                .map(|p| (p.position, p.rotation, p.floor_level, p.name.clone()))
+        };
+        let Some((center, rotation, floor, canonical)) = target else {
+            return format!("Goto: no one called {name} is here.");
+        };
+        self.movement_intents.write().await.remove(admin_id);
+        let arrival = self.arrival_beside(admin_id, &center);
+        self.teleport_player(admin_id, arrival, rotation, floor)
+            .await;
+        info!(admin = ?admin_id, target = %canonical, "admin goto");
+        format!("Goto: you are at {canonical}'s side.")
     }
 
     /// Last resort for a player wedged somewhere movement can't undo: return

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -93,7 +93,7 @@ pub(crate) fn encode_server_msg(msg: &ServerMessage) -> Option<Bytes> {
 }
 
 mod chat;
-pub(crate) use chat::parse_notice_command;
+pub(crate) use chat::{parse_admin_command, parse_notice_command};
 mod combat;
 mod deals;
 pub(crate) mod fishing;
@@ -254,6 +254,10 @@ pub struct GameState {
     /// player_id → character names whose chat/whispers this player never
     /// receives (`/block`). Loaded from the DB at login, dropped on logout.
     blocked_names: Arc<RwLock<HashMap<PlayerId, HashSet<String>>>>,
+    /// Lowercased character name → (canonical name, mute expiry). Keyed by
+    /// name, not session, so a relog does not clear it; in-memory only, so a
+    /// restart does. Expired entries are pruned on each admin command.
+    muted_until: Arc<RwLock<HashMap<String, (String, Instant)>>>,
     /// (character_id, dungeon entrance id) → world clock seconds at that
     /// character's last chest open. Keyed by character (not the per-session
     /// player id) and DB-backed, so the refill gate survives a reconnect and
@@ -364,6 +368,7 @@ impl GameState {
             parties: Arc::new(RwLock::new(party::Parties::default())),
             buybacks: Arc::new(RwLock::new(HashMap::new())),
             blocked_names: Arc::new(RwLock::new(HashMap::new())),
+            muted_until: Arc::new(RwLock::new(HashMap::new())),
             chest_opens: Arc::new(RwLock::new(HashMap::new())),
             dungeon_discoveries: Arc::new(RwLock::new(HashMap::new())),
             pending_discovery_saves: Arc::new(RwLock::new(Vec::new())),

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -2,7 +2,6 @@ use crate::types::{PlayerId, ServerMessage};
 use onlinerpg_shared::messages::{
     PartyMember, PartyMemberPosition, PARTY_INVITE_TTL, PARTY_SUMMON_TTL,
 };
-use onlinerpg_shared::world::Position;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 use tracing::info;
@@ -15,13 +14,6 @@ const MAX_TARGET_NAME_CHARS: usize = 32;
 
 /// Outstanding invites one player may have pending at once (spam brake).
 const PARTY_PENDING_INVITE_CAP: usize = 5;
-
-/// Arrival ring radius (m) around a summon's caster; golden-angle spacing
-/// keeps simultaneous arrivals apart.
-const SUMMON_RING_RADIUS: f32 = 1.6;
-
-/// Golden angle in radians, spreading arrival spots around the ring.
-const GOLDEN_ANGLE_RAD: f32 = 2.399_963;
 
 pub(crate) struct Party {
     pub leader: PlayerId,
@@ -564,38 +556,7 @@ impl super::GameState {
         }
         // No explicit remove: the teleport's void_summons_aimed_at hook
         // clears every summons aimed at the mover, this entry included.
-        // Golden-angle ring: a per-member arrival spot without a placement
-        // scan, so simultaneous accepts don't stack. A blocked spot (dungeon
-        // walls run 1m from a corridor's center) retries at half radius and
-        // finally lands on the caster's own — walkable — cell.
-        let angle = (member_id.get() % 360) as f32 * GOLDEN_ANGLE_RAD;
-        let arrival = {
-            let cache = self.passability_read();
-            let cell_floor = super::passability::authoritative_floor(&cache, &center);
-            let mut arrival = center;
-            for radius in [SUMMON_RING_RADIUS, SUMMON_RING_RADIUS * 0.5] {
-                let candidate = Position {
-                    x: center.x + angle.cos() * radius,
-                    y: center.y,
-                    z: center.z + angle.sin() * radius,
-                };
-                if super::passability::wrapped_block_info(
-                    &cache,
-                    center.x,
-                    center.z,
-                    candidate.x,
-                    candidate.z,
-                    cell_floor,
-                    center.y,
-                )
-                .is_none()
-                {
-                    arrival = candidate;
-                    break;
-                }
-            }
-            arrival
-        };
+        let arrival = self.arrival_beside(member_id, &center);
         info!(member = %member_name, caster = %caster_name, "party summon accepted");
         self.teleport_player(member_id, arrival, rotation, floor)
             .await;

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -15,6 +15,13 @@ const MAX_MOVE_TARGET_DISTANCE: f32 = 60.0;
 /// Most queued waypoints per player; legit smoothed paths stay well under.
 const MAX_QUEUED_WAYPOINTS: usize = 32;
 
+/// Arrival ring radius (m) around a teleport's center (`arrival_beside`);
+/// golden-angle spacing keeps simultaneous arrivals apart.
+const ARRIVAL_RING_RADIUS: f32 = 1.6;
+
+/// Golden angle in radians, spreading arrival spots around the ring.
+const GOLDEN_ANGLE_RAD: f32 = 2.399_963;
+
 /// Keep the shared housing limit representable on the signed wire.
 const _: () = assert!(MAX_FLOOR_LEVEL <= i8::MAX as u8);
 
@@ -329,7 +336,12 @@ impl super::GameState {
             .unwrap_or_else(|| player_id.to_string())
     }
 
-    pub async fn kick_player_by_name(&self, name: &str, auth: &AuthService) -> Option<PlayerId> {
+    pub async fn kick_player_by_name(
+        &self,
+        name: &str,
+        reason: &str,
+        auth: &AuthService,
+    ) -> Option<PlayerId> {
         let old_player_id = self.player_id_by_name(name).await;
 
         if let Some(ref player_id) = old_player_id {
@@ -345,7 +357,7 @@ impl super::GameState {
                 player_id,
                 ServerMessage::Kicked {
                     player_id: *player_id,
-                    reason: "Another session logged in with the same account".to_string(),
+                    reason: reason.to_string(),
                 },
             )
             .await;
@@ -1159,6 +1171,38 @@ impl super::GameState {
         };
         self.finish_position_update(player_id, position, current_floor, moved_player, update_msg)
             .await;
+    }
+
+    /// A walkable spot on a small ring beside `center` for a teleport
+    /// arrival, golden-angle-seeded by the mover's id so simultaneous
+    /// arrivals don't stack. A blocked spot (dungeon walls run 1m from a
+    /// corridor's center) retries at half radius and finally lands on
+    /// `center` itself — a walkable cell by construction.
+    pub(crate) fn arrival_beside(&self, mover: &PlayerId, center: &Position) -> Position {
+        let angle = (mover.get() % 360) as f32 * GOLDEN_ANGLE_RAD;
+        let cache = self.passability_read();
+        let cell_floor = super::passability::authoritative_floor(&cache, center);
+        for radius in [ARRIVAL_RING_RADIUS, ARRIVAL_RING_RADIUS * 0.5] {
+            let candidate = Position {
+                x: center.x + angle.cos() * radius,
+                y: center.y,
+                z: center.z + angle.sin() * radius,
+            };
+            if super::passability::wrapped_block_info(
+                &cache,
+                center.x,
+                center.z,
+                candidate.x,
+                candidate.z,
+                cell_floor,
+                center.y,
+            )
+            .is_none()
+            {
+                return candidate;
+            }
+        }
+        *center
     }
 
     pub async fn teleport_player(

--- a/server/src/game_state/tests/chat_tests.rs
+++ b/server/src/game_state/tests/chat_tests.rs
@@ -514,6 +514,263 @@ async fn escape_command_returns_a_stuck_player_to_spawn() {
     }
 }
 
+#[test]
+fn admin_command_parses_actions() {
+    use super::chat::{parse_admin_command, AdminCommand};
+
+    assert_eq!(
+        parse_admin_command("/kick Abuser"),
+        Some(AdminCommand::Kick("Abuser"))
+    );
+    assert_eq!(
+        parse_admin_command("/mute Abuser"),
+        Some(AdminCommand::Mute {
+            name: "Abuser",
+            minutes: None
+        })
+    );
+    assert_eq!(
+        parse_admin_command("/mute Abuser 30"),
+        Some(AdminCommand::Mute {
+            name: "Abuser",
+            minutes: Some("30")
+        })
+    );
+    assert_eq!(
+        parse_admin_command("/unmute Abuser"),
+        Some(AdminCommand::Unmute("Abuser"))
+    );
+    assert_eq!(
+        parse_admin_command("/summon Abuser"),
+        Some(AdminCommand::Summon("Abuser"))
+    );
+    assert_eq!(
+        parse_admin_command("/goto Abuser"),
+        Some(AdminCommand::Goto("Abuser"))
+    );
+    // Whole-word rule: /kickstart is not /kick.
+    assert_eq!(parse_admin_command("/kickstart party"), None);
+    assert_eq!(parse_admin_command("hello /kick Abuser"), None);
+    // Unvalidated on purpose: a bare command parses (and is admin-gated),
+    // then draws a usage reply instead of leaking into local chat.
+    assert_eq!(parse_admin_command("/kick"), Some(AdminCommand::Kick("")));
+}
+
+#[tokio::test]
+async fn kick_command_disconnects_the_named_player() {
+    let game_state = make_test_game_state("admin_kick");
+    let auth = make_test_auth("admin_kick");
+    let admin_id = pid("admin");
+    let target_id = pid("target");
+    game_state.add_player(make_player("admin", 0.0, 0.0)).await;
+    game_state.add_player(make_player("target", 5.0, 0.0)).await;
+    let mut admin_rx = game_state.register_direct_channel(&admin_id).await;
+    let mut target_rx = game_state.register_direct_channel(&target_id).await;
+
+    // Mixed case on purpose: resolution is case-insensitive.
+    game_state
+        .send_chat_message(&admin_id, "/kick TARGET".to_string(), &auth)
+        .await;
+
+    assert!(
+        drain(&mut target_rx).iter().any(|m| matches!(
+            m,
+            ServerMessage::Kicked { reason, .. } if reason == "Removed by an operator"
+        )),
+        "the target must be told it was kicked"
+    );
+    assert!(
+        drain(&mut admin_rx).iter().any(|m| matches!(
+            m,
+            ServerMessage::SystemMessage { message } if message == "Kick: target was disconnected."
+        )),
+        "the admin must get a confirmation"
+    );
+    assert!(
+        game_state.get_player_position(&target_id).await.is_none(),
+        "the kicked player must leave the roster"
+    );
+
+    game_state
+        .send_chat_message(&admin_id, "/kick Nobody".to_string(), &auth)
+        .await;
+    match admin_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "Kick: no one called Nobody is here.")
+        }
+        other => panic!("Expected a kick error, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn mute_command_silences_chat_and_whispers_until_unmute() {
+    let game_state = make_test_game_state("admin_mute");
+    let auth = make_test_auth("admin_mute");
+    let admin_id = pid("admin");
+    let spammer_id = pid("spammer");
+    let listener_id = pid("listener");
+    game_state.add_player(make_player("admin", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("spammer", 5.0, 0.0))
+        .await;
+    game_state
+        .add_player(make_player("listener", 10.0, 0.0))
+        .await;
+    let mut admin_rx = game_state.register_direct_channel(&admin_id).await;
+    let mut spammer_rx = game_state.register_direct_channel(&spammer_id).await;
+    let mut listener_rx = game_state.register_direct_channel(&listener_id).await;
+
+    game_state
+        .send_chat_message(&admin_id, "/mute SPAMMER 5".to_string(), &auth)
+        .await;
+    match admin_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => assert_eq!(
+            message,
+            "Mute: spammer cannot chat for 5m. /unmute spammer undoes this."
+        ),
+        other => panic!("Expected a mute reply, got {:?}", other),
+    }
+    match spammer_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "You are muted for 5m.")
+        }
+        other => panic!("Expected a mute notice, got {:?}", other),
+    }
+
+    game_state
+        .send_chat_message(&spammer_id, "buy gold".to_string(), &auth)
+        .await;
+    match spammer_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "Muted: you cannot chat for another 5m.")
+        }
+        other => panic!("Expected a muted reply, got {:?}", other),
+    }
+    match listener_rx.try_recv() {
+        Err(MpscTryRecvError::Empty) => {}
+        other => panic!("Muted chat must not be delivered, got {:?}", other),
+    }
+
+    game_state
+        .send_chat_message(&spammer_id, "/w listener psst".to_string(), &auth)
+        .await;
+    match spammer_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "Muted: you cannot whisper for another 5m.")
+        }
+        other => panic!("Expected a muted whisper reply, got {:?}", other),
+    }
+    match listener_rx.try_recv() {
+        Err(MpscTryRecvError::Empty) => {}
+        other => panic!("Muted whisper must not be delivered, got {:?}", other),
+    }
+
+    // Keyed by name, not session: a relog must not clear it.
+    game_state.remove_player(&spammer_id).await;
+    game_state
+        .add_player(make_player("spammer", 5.0, 0.0))
+        .await;
+    let mut spammer_rx = game_state.register_direct_channel(&spammer_id).await;
+    while listener_rx.try_recv().is_ok() {}
+    while admin_rx.try_recv().is_ok() {}
+    game_state
+        .send_chat_message(&spammer_id, "still here".to_string(), &auth)
+        .await;
+    match spammer_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "Muted: you cannot chat for another 5m.")
+        }
+        other => panic!("Expected the mute to survive a relog, got {:?}", other),
+    }
+
+    game_state
+        .send_chat_message(&admin_id, "/unmute spammer".to_string(), &auth)
+        .await;
+    match admin_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert_eq!(message, "Unmute: spammer can chat again.")
+        }
+        other => panic!("Expected an unmute reply, got {:?}", other),
+    }
+    game_state
+        .send_chat_message(&spammer_id, "hello".to_string(), &auth)
+        .await;
+    match listener_rx.try_recv() {
+        Ok(ServerMessage::ChatMessage { player_id, .. }) => assert_eq!(player_id, spammer_id),
+        other => panic!("Chat must flow again after unmute, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn summon_and_goto_teleport_beside_the_target() {
+    let game_state = make_test_game_state("admin_summon_goto");
+    let auth = make_test_auth("admin_summon_goto");
+    let admin_id = pid("admin");
+    let wanderer_id = pid("wanderer");
+    game_state.add_player(make_player("admin", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("wanderer", 500.0, 0.0))
+        .await;
+    let mut admin_rx = game_state.register_direct_channel(&admin_id).await;
+    let mut wanderer_rx = game_state.register_direct_channel(&wanderer_id).await;
+
+    game_state
+        .send_chat_message(&admin_id, "/summon WANDERER".to_string(), &auth)
+        .await;
+    let (position, _, floor) = game_state
+        .get_player_position(&wanderer_id)
+        .await
+        .expect("wanderer should still be online");
+    let distance = (position.x.powi(2) + position.z.powi(2)).sqrt();
+    assert!(
+        distance <= 2.0,
+        "summon must land beside the admin, got {position:?}"
+    );
+    assert_eq!(floor, 0);
+    assert!(
+        drain(&mut wanderer_rx).iter().any(|m| matches!(
+            m,
+            ServerMessage::SystemMessage { message }
+                if message == "An operator summoned you to admin's side."
+        )),
+        "the summoned player must be told what happened"
+    );
+    assert!(drain(&mut admin_rx).iter().any(|m| matches!(
+        m,
+        ServerMessage::SystemMessage { message } if message == "Summon: wanderer is at your side."
+    )));
+
+    // Send the wanderer far away again, then walk the admin over instead.
+    game_state
+        .teleport_player(
+            &wanderer_id,
+            Position {
+                x: -300.0,
+                y: 0.0,
+                z: 40.0,
+            },
+            0.0,
+            0,
+        )
+        .await;
+    game_state
+        .send_chat_message(&admin_id, "/goto wanderer".to_string(), &auth)
+        .await;
+    let (position, _, _) = game_state
+        .get_player_position(&admin_id)
+        .await
+        .expect("admin should still be online");
+    let distance = ((position.x + 300.0).powi(2) + (position.z - 40.0).powi(2)).sqrt();
+    assert!(
+        distance <= 2.0,
+        "goto must land beside the wanderer, got {position:?}"
+    );
+    assert!(drain(&mut admin_rx).iter().any(|m| matches!(
+        m,
+        ServerMessage::SystemMessage { message } if message == "Goto: you are at wanderer's side."
+    )));
+}
+
 #[tokio::test]
 async fn escape_command_refused_while_in_combat() {
     let game_state = make_test_game_state("escape_in_combat");

--- a/server/src/game_state/tests/persistence_tests.rs
+++ b/server/src/game_state/tests/persistence_tests.rs
@@ -143,7 +143,9 @@ async fn kick_flushes_dropped_inventory_before_replacement_load() {
     assert_eq!(auth.load_inventory(char_id).unwrap().len(), 1);
 
     // A replacement login kicks A by (unique) character name.
-    game_state.kick_player_by_name(&record.name, &auth).await;
+    game_state
+        .kick_player_by_name(&record.name, "test", &auth)
+        .await;
 
     // The kick flushed A's post-drop inventory and detached it, so a
     // replacement load reads zero swords (no dupe) instead of a stale one.


### PR DESCRIPTION
## Summary

Implements the `doc/TODO.md` *운영자 커맨드* set, minus `/ban` (reasoning below). All four are chat commands routed through the existing `parse_*` / `requires_admin` architecture, so only connections whose account email is allowlisted **and** whose character has `admin_role > 0` can issue them — same gate as `/notice` and `/give`.

| Command | Effect |
|---|---|
| `/kick <name>` | Disconnects the player, with "Removed by an operator" shown client-side |
| `/mute <name> [minutes]` | Silences chat **and** whispers (default 10m, max 1440m); the target is told, and gets a countdown reply if they try to talk |
| `/unmute <name>` | Lifts the mute |
| `/summon <name>` | Teleports the player to the admin's side |
| `/goto <name>` | Teleports the admin to the player's side |

## Design notes

- **Kick** reuses the exact persist-then-kick flow session replacement already runs (`kick_player_by_name`, now taking the reason as a parameter) — no second disconnect path to keep correct.
- **Mute** is keyed by lowercased character name, not session id, so a relog does not clear it; it is deliberately in-memory only (a restart clears it). Expired entries prune lazily and on each admin command, so the map stays bounded. The enforcement check is one uncontended read-lock on an almost-always-empty map, in keeping with the 5,000-CCU budget.
- **Summon/goto** land on the party summon's golden-angle arrival ring — that logic is extracted from `party.rs` into `GameState::arrival_beside()` and shared, so blocked-spot retries behave identically everywhere. Both clear the mover's queued waypoints first (the `/escape` lesson: a stale waypoint drags the teleported player straight back).
- **`/ban` is left in TODO**: a real ban needs a persistent identity decision (character? account email? Google sub?) and an enforcement point in the login path — both feel like maintainer calls rather than something to guess at in a drive-by PR. Happy to follow up with it if you pick the shape.

## Tests

- Parser cases incl. the whole-word rule (`/kickstart` is not `/kick`) and unvalidated-parts convention
- `requires_admin` classification for all five commands (and `/who` staying public)
- Kick: target receives `Kicked`, leaves the roster; case-insensitive resolution; unknown-name reply
- Mute: chat and whispers suppressed with countdown replies, invisible to bystanders, survives a relog, lifted by `/unmute`
- Summon/goto: mover lands within the arrival ring of the target, on the right floor

README's production section documents the new commands next to `/notice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)