### PR TITLE
Price the catch-table guardrail from the merchant defs

### DIFF
--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -98,6 +98,10 @@ mod combat;
 mod deals;
 pub(crate) mod fishing;
 pub(crate) use deals::band_invariant_holds;
+/// Re-exported for the catch-table economy guardrail in `item_defs`, which
+/// prices a sale exactly as `sell_item` does.
+#[cfg(test)]
+pub(crate) use deals::sell_payout;
 mod dungeon;
 pub(crate) mod hunger;
 mod inventory;

--- a/server/src/item_defs.rs
+++ b/server/src/item_defs.rs
@@ -477,6 +477,7 @@ mod tests {
         }
         let defs = ItemDefs::load();
         let table = defs.catch_table();
+        let sell_rate_percent = crate::merchant_defs::merchant_defs().best_sell_rate_percent();
         let ev_at = |level: u32| -> f64 {
             let weights = crate::game_state::fishing::effective_weights(table, level);
             let total: f64 = weights.iter().map(|w| *w as f64).sum();
@@ -489,8 +490,13 @@ mod tests {
                         // Coins arrive at face value.
                         def.dice.as_deref().map_or(0.0, dice_avg)
                     } else {
-                        // Items sell at the merchant rate (Rica: 40%).
-                        def.base_price.unwrap_or(0) as f64 * 0.4
+                        // Priced the way the game pays: the best merchant rate
+                        // read from the defs, through the same payout formula.
+                        crate::game_state::sell_payout(
+                            def.base_price.unwrap_or(0),
+                            sell_rate_percent,
+                            0,
+                        ) as f64
                     };
                     *weight as f64 * value
                 })

--- a/server/src/merchant_defs.rs
+++ b/server/src/merchant_defs.rs
@@ -58,6 +58,18 @@ impl MerchantDefs {
     pub fn get_by_npc_name(&self, npc_name: &str) -> Option<&MerchantDefinition> {
         self.by_npc_name.get(npc_name)
     }
+
+    /// The most generous sell rate on offer. Economy guardrails price a sale
+    /// at the best rate a player could actually walk to, so a rate change in
+    /// `data-src/merchants.csv` moves them instead of silently loosening them.
+    #[cfg(test)]
+    pub fn best_sell_rate_percent(&self) -> u32 {
+        self.by_npc_name
+            .values()
+            .map(|def| def.sell_rate_percent)
+            .max()
+            .unwrap_or(0)
+    }
 }
 
 pub fn merchant_defs() -> &'static MerchantDefs {


### PR DESCRIPTION
## Summary

Fixes the item from `doc/TODO.md` (낚시 후속 / PR #53 review):

> EV 테스트의 상인 환율 0.4 하드코딩 → merchant defs에서 읽기

`expected_catch_value_stays_in_the_coin_pile_economy_at_every_level` multiplied base prices by a literal `0.4`, with Rica's 40% recorded only in a comment. Raising `sellRatePercent` in `data-src/merchants.csv` would have moved what a catch is actually worth while the guardrail kept measuring the old rate — the failure mode a guardrail exists to prevent.

- `merchant_defs`: `best_sell_rate_percent()` — the most generous rate on offer, i.e. the best a player could actually walk to
- `game_state`: re-export `sell_payout` so the test prices a sale through the same formula `sell_item` pays out with, integer rounding included
- Both additions are `#[cfg(test)]`, so nothing new is compiled into the server

## Test plan

- [x] `cargo test --workspace` — all green; `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean
- [x] Coupling verified: temporarily setting `sellRatePercent` to 50 makes the test fail naming the real reason — `expected sell value per catch at level 20 is 28.4c — outside the 5–25c coin-pile band`. (At 70 it trips the money-pump invariant in `merchant_defs` first, which is the other guardrail doing its job.) Reverted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)