### PR TITLE
Verify rejected cross-floor deals preserve state

### DIFF
--- a/server/src/game_state/deals.rs
+++ b/server/src/game_state/deals.rs
@@ -445,6 +445,27 @@ impl super::GameState {
         self.deal_ledgers.write().await.last_accepted_offer.clear();
     }
 
+    #[cfg(test)]
+    pub(crate) async fn deal_ledger_state_for_test(
+        &self,
+        merchant_name: &str,
+        player_name: &str,
+    ) -> (i64, i64, Option<u64>) {
+        let ledgers = self.deal_ledgers.read().await;
+        (
+            ledgers.npc_granted.get(merchant_name).copied().unwrap_or(0),
+            ledgers
+                .player_received
+                .get(player_name)
+                .copied()
+                .unwrap_or(0),
+            ledgers
+                .last_accepted_offer
+                .get(&(merchant_name.to_string(), player_name.to_string()))
+                .copied(),
+        )
+    }
+
     /// The player's live deals with one merchant, for `ShopState`.
     pub(crate) async fn active_deals_for(
         &self,

--- a/server/src/game_state/tests/trading_tests/merchant_tests.rs
+++ b/server/src/game_state/tests/trading_tests/merchant_tests.rs
@@ -61,16 +61,17 @@ async fn offer_deal_clamps_modifier_to_cha_band() {
 }
 
 #[tokio::test]
-async fn cross_floor_offer_deal_is_rejected() {
+async fn cross_floor_offer_deal_is_rejected_without_consuming_ledger() {
     let game_state = make_test_game_state("cross_floor_offer");
-    let (mut buyer_rx, mut npc_rx) = setup_haggle(&game_state, 10, 0).await;
+    let (mut buyer_rx, mut npc_rx) = setup_haggle(&game_state, 18, 0).await;
     set_floor(&game_state, "buyer", 1).await;
+    let ledger_before = game_state.deal_ledger_state_for_test("Rica", "buyer").await;
 
     game_state
         .offer_deal(
             &pid("npc_rica"),
             &pid("buyer"),
-            "iron_sword",
+            "wooden_shield",
             DealKind::Buy,
             -50,
             "loyal customer",
@@ -87,6 +88,51 @@ async fn cross_floor_offer_deal_is_rejected() {
         }
         other => panic!("Expected DealResult rejection for NPC, got {other:?}"),
     }
+    assert_eq!(
+        game_state.deal_ledger_state_for_test("Rica", "buyer").await,
+        ledger_before,
+        "rejection must preserve NPC budget, player cap, and cooldown"
+    );
+    assert!(game_state
+        .active_deals_for(&pid("buyer"), "Rica")
+        .await
+        .is_empty());
+
+    // CHA 18 clamps this to -25%, a 625 discount. The immediate retry proves
+    // the rejection did not consume the cooldown; the ledger snapshot above
+    // directly proves that it did not consume the player's daily budget.
+    set_floor(&game_state, "buyer", 0).await;
+    game_state
+        .offer_deal(
+            &pid("npc_rica"),
+            &pid("buyer"),
+            "wooden_shield",
+            DealKind::Buy,
+            -50,
+            "loyal customer",
+        )
+        .await;
+
+    match buyer_rx.try_recv() {
+        Ok(ServerMessage::DealUpdated { modifier_pct, .. }) => {
+            assert_eq!(modifier_pct, -25);
+        }
+        other => panic!("Expected DealUpdated after same-floor retry, got {other:?}"),
+    }
+    match npc_rx.try_recv() {
+        Ok(ServerMessage::DealResult {
+            accepted,
+            applied_modifier_pct,
+            ..
+        }) => {
+            assert!(accepted);
+            assert_eq!(applied_modifier_pct, -25);
+        }
+        other => panic!("Expected accepted DealResult after retry, got {other:?}"),
+    }
+    let active = game_state.active_deals_for(&pid("buyer"), "Rica").await;
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].modifier_pct, -25);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Overview

The server already rejects cross-floor `OfferDeal` requests before reaching the deal ledger. The existing regression verifies the rejection messages, but it does not prove that the rejection preserves discount budgets, cooldown state, and live deals.

This change strengthens that regression without changing production behavior.

## Steps to reproduce

1. Create a merchant NPC and a CHA 18 buyer on different floors.
2. Submit a discounted `OfferDeal` that would cost 625 units if accepted.
3. Observe that the buyer receives no `DealUpdated` and the NPC receives a rejected `DealResult`.
4. Inspect the existing test and note that it does not compare the ledger or active deals.

## Observed behavior

The rejection path is correct, but the regression would still pass if a future change consumed the NPC budget, player cap, or cooldown before returning. It also did not assert that no live deal was stored.

## Expected behavior

- A cross-floor rejection preserves both discount ledgers and the offer cooldown.
- No live deal is stored for the rejected request.
- The same offer succeeds immediately after the participants return to one floor.

## Root cause

The original regression focused on message delivery and had no test-only view of the private deal ledger.

## Changes

- Add a `cfg(test)` ledger snapshot helper for NPC budget, player cap, and cooldown.
- Extend the cross-floor regression to compare the snapshot before and after rejection.
- Assert that the rejected request creates no live deal.
- Retry the same offer on one floor and verify normal acceptance.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server cross_floor_offer_deal_is_rejected_without_consuming_ledger --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 732 passed
- `git diff --check` — passed

## Scope and limitations

This PR changes test coverage only. It does not change deal validation, pricing, budgets, cooldown duration, deal lifetime, protocol messages, or client behavior.
