### PR TITLE
Push party positions to the party instead of per-client polling

### DIFF
--- a/client/src/lib/components/WorldMapDialog.svelte
+++ b/client/src/lib/components/WorldMapDialog.svelte
@@ -9,13 +9,6 @@
   const MIN_ZOOM = 1
   const DEFAULT_ZOOM = 8
 
-  // Party member marker poll cadence; above the server's 2s clamp.
-  const PARTY_POLL_MS = 3000
-
-  // A poll answer can outlive the dialog that requested it (nothing polls
-  // while the map is closed); older data than this never renders.
-  const PARTY_POSITIONS_MAX_AGE_MS = 10000
-
   // --- Shared place-name labels (generated from data-src/map_labels.csv,
   // plus the player's discovered dungeon entrances) ---
   type LabelKind =
@@ -69,11 +62,7 @@
 
 <script lang="ts">
   import { gameStore, isAdminUser } from '../stores/gameStore'
-  import {
-    partyRoster,
-    partyPositions,
-    resetPartyPositions,
-  } from '../stores/partyStore'
+  import { partyRoster, partyPositions } from '../stores/partyStore'
   import { worldMapVisible, teleportLoading } from '../stores/debugStore'
   import { discoveredDungeonIds } from '../stores/dungeonStore'
   import { houseMapFootprints } from '../stores/housingMapStore'
@@ -134,32 +123,15 @@
     }
   })
 
-  // Party existence only: roster churn must not reset the poll cadence (the
-  // immediate re-poll would just be eaten by the server's clamp).
+  // Party existence only: roster churn must not re-request (a membership
+  // change already triggers a server push).
   let inParty = $derived($partyRoster !== null)
 
-  // Poll party positions only while the dialog lives (it mounts with
-  // worldMapVisible) and a party exists — closed map means a silent channel.
+  // One snapshot when the dialog opens with a party, or a party forms while
+  // it is open; steady-state updates are pushed by the server.
   $effect(() => {
     if (!inParty) return
     networkManager.sendRequestPartyPositions()
-    const timer = setInterval(
-      () => networkManager.sendRequestPartyPositions(),
-      PARTY_POLL_MS
-    )
-    return () => clearInterval(timer)
-  })
-
-  // The render-time age gate only runs when something recomputes; this makes
-  // expiry certain on an untouched map (same pattern as PartyInviteToast).
-  $effect(() => {
-    const at = $partyPositions.at
-    if (at === 0) return
-    const timer = setTimeout(
-      resetPartyPositions,
-      Math.max(0, at + PARTY_POSITIONS_MAX_AGE_MS - Date.now())
-    )
-    return () => clearTimeout(timer)
   })
 
   // --- Drag state ---
@@ -388,13 +360,12 @@
     const cw = containerW
     const ch = containerH
     if (!roster || cw <= 0 || ch <= 0) return []
-    if (Date.now() - positions.at > PARTY_POSITIONS_MAX_AGE_MS) return []
 
-    // Join against the roster: a member who left since the last poll (or an
+    // Join against the roster: a member who left since the last push (or an
     // id the roster never knew) must not draw a ghost.
     const names = new Map(roster.members.map((m) => [m.id, m.name]))
     const out: PartyMarker[] = []
-    for (const pos of positions.members) {
+    for (const pos of positions) {
       const name = names.get(pos.id)
       if (!name) continue
       const p = worldToScreen(pos.x, pos.z, cw, ch)

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -53,7 +53,7 @@ import {
 } from '../stores/tradeStore'
 import {
   partyRoster,
-  partyPositions,
+  applyPartyPositions,
   resetPartyPositions,
   resetPartyStores,
   pendingPartyInvites,
@@ -512,14 +512,11 @@ export function handleServerMessage(
     }
 
     case 'PartyPositions':
-      // A poll answer can cross a disband on the wire; without a roster it
-      // could only repopulate the store that disband just cleared.
-      if (get(partyRoster)) {
-        partyPositions.set({
-          at: Date.now(),
-          members: data.members as PartyMemberPositionEntry[],
-        })
-      }
+      applyPartyPositions(
+        data.members as PartyMemberPositionEntry[],
+        get(gameStore).currentPlayer?.id,
+        get(partyRoster) !== null
+      )
       break
 
     case 'GameState':

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -630,7 +630,7 @@ class NetworkManager {
     this.sendMessage('PartyLeave')
   }
 
-  /** Poll party member positions for the world map. */
+  /** One-shot party-position snapshot for a just-opened map. */
   sendRequestPartyPositions() {
     this.sendMessage('RequestPartyPositions')
   }

--- a/client/src/lib/stores/partyStore.test.ts
+++ b/client/src/lib/stores/partyStore.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+import {
+  partyPositions,
+  applyPartyPositions,
+  resetPartyPositions,
+} from './partyStore'
+
+// The push payload is party-wide (serialized once server-side, recipient
+// included); the client-side filter here is the only self-exclusion.
+const push = [
+  { id: 1, x: 10, z: 20, floor_level: 0 },
+  { id: 2, x: 30, z: 40, floor_level: -1 },
+]
+
+describe('applyPartyPositions', () => {
+  beforeEach(() => resetPartyPositions())
+
+  it('stores the payload minus self', () => {
+    applyPartyPositions(push, 1, true)
+    expect(get(partyPositions)).toEqual([push[1]])
+  })
+
+  it('keeps everyone when self is not in the payload', () => {
+    applyPartyPositions(push, 99, true)
+    expect(get(partyPositions)).toEqual(push)
+  })
+
+  it('drops a push that crosses a disband (no roster)', () => {
+    applyPartyPositions(push, 1, false)
+    expect(get(partyPositions)).toEqual([])
+  })
+
+  it('filters nothing when self is unknown', () => {
+    applyPartyPositions(push, undefined, true)
+    expect(get(partyPositions)).toEqual(push)
+  })
+})

--- a/client/src/lib/stores/partyStore.ts
+++ b/client/src/lib/stores/partyStore.ts
@@ -23,21 +23,26 @@ export interface PartyMemberPositionEntry {
   floor_level: number
 }
 
-/** Latest positions poll answer, stamped on receipt (`at: 0` = never
- *  received or cleared); rendering joins it against the roster and age-gates
- *  it. */
-export interface PartyPositionsSnapshot {
-  at: number
-  members: PartyMemberPositionEntry[]
+/** Latest pushed locations of the *other* party members (self is filtered
+ *  on receipt). Validity is event-driven — server pushes on relocation and
+ *  membership change, and the roster join drops leavers — so there is no
+ *  freshness gate. */
+export const partyPositions = writable<PartyMemberPositionEntry[]>([])
+
+/** Apply a pushed party-wide payload. A push can cross a disband on the
+ *  wire, so without a roster it is dropped; the server serializes one
+ *  payload for the whole party, so self is filtered here. */
+export function applyPartyPositions(
+  members: PartyMemberPositionEntry[],
+  selfId: number | undefined,
+  inParty: boolean
+) {
+  if (!inParty) return
+  partyPositions.set(members.filter((m) => m.id !== selfId))
 }
 
-export const partyPositions = writable<PartyPositionsSnapshot>({
-  at: 0,
-  members: [],
-})
-
 export function resetPartyPositions() {
-  partyPositions.set({ at: 0, members: [] })
+  partyPositions.set([])
 }
 
 /** Full party reset for session-death paths (logout, reconnect, GameState

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -167,8 +167,9 @@ struct ConnectionState {
     env_reported: bool,
 }
 
-/// Positions polls inside this window are dropped; the web map polls every
-/// 3s, leaving a 1s margin so its own cadence never races the clamp.
+/// Positions snapshot requests inside this window are dropped. Steady-state
+/// data rides the push tick; a client only asks on map open, so this is
+/// purely a spam brake.
 const PARTY_POSITIONS_MIN_INTERVAL: Duration = Duration::from_secs(2);
 
 impl ConnectionState {

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -210,6 +210,10 @@ pub struct GameState {
     dirty_players: Arc<RwLock<HashSet<PlayerId>>>,
     /// Players whose inventory has changed since the last periodic save.
     dirty_inventories: Arc<RwLock<HashSet<PlayerId>>>,
+    /// Players who relocated (or whose party reshaped) since the last
+    /// party-position push; the tick maps them to parties, so entries from
+    /// partyless players just drop out there.
+    party_position_dirty: Arc<RwLock<HashSet<PlayerId>>>,
     /// Serializes periodic and shutdown flushes against per-player logout saves.
     persistence_lock: Arc<Mutex<()>>,
     /// Serializes account replacement and character deletion with game entry.
@@ -362,6 +366,7 @@ impl GameState {
             housing_io,
             dirty_players: Arc::new(RwLock::new(HashSet::new())),
             dirty_inventories: Arc::new(RwLock::new(HashSet::new())),
+            party_position_dirty: Arc::new(RwLock::new(HashSet::new())),
             persistence_lock: Arc::new(Mutex::new(())),
             character_session_lock: Arc::new(Mutex::new(())),
             open_doors: Arc::new(RwLock::new(HashSet::new())),

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -1,4 +1,4 @@
-use crate::types::{PlayerId, ServerMessage};
+use crate::types::{Player, PlayerId, ServerMessage};
 use onlinerpg_shared::messages::{
     PartyMember, PartyMemberPosition, PARTY_INVITE_TTL, PARTY_SUMMON_TTL,
 };
@@ -75,6 +75,25 @@ enum Removal {
     Disbanded {
         last: PlayerId,
     },
+}
+
+/// Every member's location, the recipient included — the client filters
+/// itself out, so one payload serves the whole party.
+fn member_positions(
+    players: &HashMap<PlayerId, Player>,
+    member_ids: &[PlayerId],
+) -> Vec<PartyMemberPosition> {
+    member_ids
+        .iter()
+        .filter_map(|id| {
+            players.get(id).map(|p| PartyMemberPosition {
+                id: *id,
+                x: p.position.x,
+                z: p.position.z,
+                floor_level: p.floor_level,
+            })
+        })
+        .collect()
 }
 
 impl super::GameState {
@@ -668,8 +687,9 @@ impl super::GameState {
         format!("Party: {}", names.join(", "))
     }
 
-    /// Answer a positions poll: where the sender's other members are.
-    /// Rate-limited per connection before this is called.
+    /// Answer a map-open snapshot request: where the sender's party is now.
+    /// Steady-state updates ride `tick_party_positions`; rate-limited per
+    /// connection before this is called.
     pub async fn send_party_positions(&self, player_id: &PlayerId) {
         let member_ids = {
             let parties = self.parties.read().await;
@@ -678,23 +698,63 @@ impl super::GameState {
                 .map(|party| party.members.clone())
                 .unwrap_or_default()
         };
-        let members: Vec<PartyMemberPosition> = {
+        let members = {
             let players = self.players.read().await;
-            member_ids
-                .iter()
-                .filter(|id| *id != player_id)
-                .filter_map(|id| {
-                    players.get(id).map(|p| PartyMemberPosition {
-                        id: *id,
-                        x: p.position.x,
-                        z: p.position.z,
-                        floor_level: p.floor_level,
-                    })
-                })
-                .collect()
+            member_positions(&players, &member_ids)
         };
         self.send_direct_message(player_id, ServerMessage::PartyPositions { members })
             .await;
+    }
+
+    /// Queue `player_id` for the next party-position push. Called on every
+    /// relocation; partyless entries are dropped by the tick.
+    pub(crate) async fn mark_party_position_dirty(&self, player_id: &PlayerId) {
+        self.party_position_dirty.write().await.insert(*player_id);
+    }
+
+    /// Push fresh positions to every party a queued player belongs to: one
+    /// message per party, serialized once for all members. Parties with no
+    /// queued relocation send nothing, and lock traffic is per tick, not per
+    /// client (one dirty drain, one `parties` read, one `players` read).
+    pub async fn tick_party_positions(&self) {
+        let moved: Vec<PlayerId> = {
+            let mut dirty = self.party_position_dirty.write().await;
+            if dirty.is_empty() {
+                return;
+            }
+            dirty.drain().collect()
+        };
+        let rosters: Vec<Vec<PlayerId>> = {
+            let parties = self.parties.read().await;
+            let party_ids: HashSet<u64> = moved
+                .iter()
+                .filter_map(|id| parties.member_of.get(id).copied())
+                .collect();
+            party_ids
+                .iter()
+                .filter_map(|id| parties.parties.get(id).map(|p| p.members.clone()))
+                .collect()
+        };
+        if rosters.is_empty() {
+            return;
+        }
+        let payloads: Vec<(Vec<PlayerId>, Vec<PartyMemberPosition>)> = {
+            let players = self.players.read().await;
+            rosters
+                .into_iter()
+                .map(|ids| {
+                    let members = member_positions(&players, &ids);
+                    (ids, members)
+                })
+                .collect()
+        };
+        for (member_ids, members) in payloads {
+            self.send_direct_message_to_players(
+                &member_ids,
+                ServerMessage::PartyPositions { members },
+            )
+            .await;
+        }
     }
 
     async fn broadcast_party_state(&self, leader_id: PlayerId, member_ids: &[PlayerId]) {
@@ -712,6 +772,11 @@ impl super::GameState {
         };
         let msg = ServerMessage::PartyState { leader_id, members };
         self.send_direct_message_to_players(member_ids, msg).await;
+        // A reshaped party should not wait a relocation for fresh markers.
+        self.party_position_dirty
+            .write()
+            .await
+            .extend(member_ids.iter().copied());
     }
 
     async fn send_party_cleared(&self, player_id: &PlayerId) {

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -1213,6 +1213,13 @@ impl super::GameState {
         self.move_player_spatial_cell(player_id, &old_position, &new_position)
             .await;
         self.mark_dirty(player_id).await;
+        // Rotation-only moves are exempt: markers draw x/z and floor.
+        if old_position.x != new_position.x
+            || old_position.z != new_position.z
+            || old_floor != floor_level
+        {
+            self.mark_party_position_dirty(player_id).await;
+        }
         if old_position != new_position {
             self.check_dungeon_discovery(player_id, &new_position).await;
         }

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -533,7 +533,7 @@ async fn self_and_unknown_invites_are_rejected() {
 }
 
 #[tokio::test]
-async fn positions_cover_members_beyond_aoi_and_skip_self() {
+async fn positions_cover_members_beyond_aoi_including_self() {
     let game_state = make_test_game_state("party_positions");
     let mut alice_rx = add(&game_state, "alice", 0.0).await;
     // Far outside the AOI on purpose: distance must not filter positions.
@@ -549,14 +549,223 @@ async fn positions_cover_members_beyond_aoi_and_skip_self() {
     game_state.send_party_positions(&pid("alice")).await;
     match alice_rx.try_recv() {
         Ok(ServerMessage::PartyPositions { members }) => {
+            // The payload is party-wide, requester included (clients filter
+            // themselves), and never leaks other parties.
             let ids: Vec<_> = members.iter().map(|m| m.id).collect();
-            assert_eq!(ids, [pid("bob")]);
-            assert_eq!(members[0].x, 500.0);
-            assert_eq!(members[0].floor_level, 0);
+            assert_eq!(ids, [pid("alice"), pid("bob")]);
+            assert_eq!(members[1].x, 500.0);
+            assert_eq!(members[1].floor_level, 0);
         }
         other => panic!("Expected positions, got {:?}", other),
     }
     assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn position_tick_pushes_a_relocated_party_to_every_member() {
+    let game_state = make_test_game_state("party_positions_tick");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 500.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    // Flush the formation-queued push; an unchanged party then stays silent.
+    game_state.tick_party_positions().await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    game_state.tick_party_positions().await;
+    assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    assert!(matches!(bob_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+
+    game_state
+        .teleport_player(&pid("bob"), pos(40.0), 0.0, 0)
+        .await;
+    // Clear the teleport's own AOI fanout; the push comes from the tick.
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    game_state.tick_party_positions().await;
+    for rx in [&mut alice_rx, &mut bob_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PartyPositions { members }) => {
+                assert_eq!(members.len(), 2);
+                let bob = members.iter().find(|m| m.id == pid("bob")).unwrap();
+                assert_eq!(bob.x, 40.0);
+            }
+            other => panic!("Expected pushed positions, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test]
+async fn position_tick_pushes_only_the_relocated_party() {
+    let game_state = make_test_game_state("party_positions_tick_isolation");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 500.0).await;
+    let mut carol_rx = add(&game_state, "carol", 10.0).await;
+    let mut dave_rx = add(&game_state, "dave", 15.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    form_party(&game_state, "carol", "dave").await;
+    // Flush both formation pushes.
+    game_state.tick_party_positions().await;
+    for rx in [&mut alice_rx, &mut bob_rx, &mut carol_rx, &mut dave_rx] {
+        drain(rx);
+    }
+
+    game_state
+        .teleport_player(&pid("bob"), pos(40.0), 0.0, 0)
+        .await;
+    for rx in [&mut alice_rx, &mut bob_rx, &mut carol_rx, &mut dave_rx] {
+        drain(rx);
+    }
+    game_state.tick_party_positions().await;
+    // The relocated party gets exactly its own roster…
+    for rx in [&mut alice_rx, &mut bob_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PartyPositions { members }) => {
+                let ids: Vec<_> = members.iter().map(|m| m.id).collect();
+                assert_eq!(ids, [pid("alice"), pid("bob")]);
+            }
+            other => panic!("Expected isolated push, got {:?}", other),
+        }
+    }
+    // …and the unmoved party hears nothing.
+    assert!(matches!(carol_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    assert!(matches!(dave_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn leave_queues_a_position_push_without_the_leaver() {
+    let game_state = make_test_game_state("party_positions_leave_push");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 5.0).await;
+    add(&game_state, "carol", 10.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state.invite_to_party(&pid("alice"), "carol").await;
+    game_state
+        .respond_to_party_invite(&pid("carol"), &pid("alice"), true)
+        .await;
+    game_state.tick_party_positions().await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    game_state.leave_party(&pid("carol")).await;
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    game_state.tick_party_positions().await;
+    for rx in [&mut alice_rx, &mut bob_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PartyPositions { members }) => {
+                let ids: Vec<_> = members.iter().map(|m| m.id).collect();
+                assert_eq!(ids, [pid("alice"), pid("bob")]);
+            }
+            other => panic!("Expected post-leave push, got {:?}", other),
+        }
+    }
+}
+
+#[tokio::test]
+async fn floor_only_relocation_queues_a_push() {
+    let game_state = make_test_game_state("party_positions_floor_push");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state.tick_party_positions().await;
+    drain(&mut alice_rx);
+
+    // Same x/z, new floor: descending stairs must re-push (markers draw
+    // x/z and floor).
+    game_state
+        .teleport_player(&pid("bob"), pos(5.0), 0.0, -1)
+        .await;
+    drain(&mut alice_rx);
+    game_state.tick_party_positions().await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => {
+            let bob = members.iter().find(|m| m.id == pid("bob")).unwrap();
+            assert_eq!(bob.floor_level, -1);
+        }
+        other => panic!("Expected floor-change push, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn z_only_relocation_queues_a_push() {
+    let game_state = make_test_game_state("party_positions_z_push");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state.tick_party_positions().await;
+    drain(&mut alice_rx);
+
+    // Due-north movement: x and floor unchanged, only z moves.
+    game_state
+        .teleport_player(
+            &pid("bob"),
+            Position {
+                x: 5.0,
+                y: 0.0,
+                z: 30.0,
+            },
+            0.0,
+            0,
+        )
+        .await;
+    drain(&mut alice_rx);
+    game_state.tick_party_positions().await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => {
+            let bob = members.iter().find(|m| m.id == pid("bob")).unwrap();
+            assert_eq!(bob.z, 30.0);
+        }
+        other => panic!("Expected z-change push, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn rotation_only_updates_do_not_queue_a_push() {
+    let game_state = make_test_game_state("party_positions_rotation");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 5.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state.tick_party_positions().await;
+    drain(&mut alice_rx);
+
+    // Turning in place (a fishing cast facing, e.g.) must not re-push.
+    game_state
+        .teleport_player(&pid("bob"), pos(5.0), 1.0, 0)
+        .await;
+    // Clear the teleport's own AOI fanout; only the tick sends positions.
+    drain(&mut alice_rx);
+    game_state.tick_party_positions().await;
+    assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn position_tick_ignores_partyless_movers() {
+    let game_state = make_test_game_state("party_positions_solo");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    game_state
+        .teleport_player(&pid("alice"), pos(10.0), 0.0, 0)
+        .await;
+    drain(&mut alice_rx);
+    game_state.tick_party_positions().await;
+    assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+}
+
+#[tokio::test]
+async fn party_formation_queues_a_position_push() {
+    let game_state = make_test_game_state("party_positions_form_push");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    add(&game_state, "bob", 500.0).await;
+    form_party(&game_state, "alice", "bob").await;
+    drain(&mut alice_rx);
+
+    game_state.tick_party_positions().await;
+    match alice_rx.try_recv() {
+        Ok(ServerMessage::PartyPositions { members }) => {
+            let ids: Vec<_> = members.iter().map(|m| m.id).collect();
+            assert_eq!(ids, [pid("alice"), pid("bob")]);
+        }
+        other => panic!("Expected formation push, got {:?}", other),
+    }
 }
 
 #[tokio::test]
@@ -590,9 +799,8 @@ async fn positions_report_dungeon_floor() {
     game_state.send_party_positions(&pid("alice")).await;
     match alice_rx.try_recv() {
         Ok(ServerMessage::PartyPositions { members }) => {
-            let ids: Vec<_> = members.iter().map(|m| m.id).collect();
-            assert_eq!(ids, [pid("bob")]);
-            assert_eq!(members[0].floor_level, -2);
+            let bob = members.iter().find(|m| m.id == pid("bob")).unwrap();
+            assert_eq!(bob.floor_level, -2);
         }
         other => panic!("Expected positions, got {:?}", other),
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -393,6 +393,19 @@ async fn main() -> ExitCode {
         },
     ));
 
+    // Push party positions to members whose party relocated since the last
+    // tick; 3s matches the freshness of the world map's former poll.
+    let game_state_for_party_positions = Arc::clone(&game_state);
+    background.spawn(run_ticks(
+        "party positions",
+        Duration::from_secs(3),
+        drain_shutdown.clone(),
+        move || {
+            let game_state = Arc::clone(&game_state_for_party_positions);
+            async move { game_state.tick_party_positions().await }
+        },
+    ));
+
     // Every 10s, top up each player's ambient monsters toward their caps.
     let game_state_for_spawns = Arc::clone(&game_state);
     background.spawn(run_ticks(

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -44,7 +44,9 @@ pub const NPC_TOKEN_PATH_FROM_ROOT: &str = "data/npc_token";
 ///      GroundItemSpawned no longer carries source_monster_id.
 /// v15: DungeonDiscoveries snapshot for per-character world-map markers.
 /// v16: hunger (HungerUpdate) + campfires (Campfire* / Grill*) — doc/HUNGER.md.
-pub const PROTOCOL_VERSION: u32 = 16;
+/// v17: PartyPositions pushed server-side on relocation (was a poll answer)
+///      and now includes the recipient; clients filter themselves.
+pub const PROTOCOL_VERSION: u32 = 17;
 
 /// WebSocket close code sent when the handshake is refused (wrong protocol
 /// version, or traffic before `ClientInfo`). Lives outside the serialized

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -377,8 +377,9 @@ pub enum ClientMessage {
     /// Leave the current party. The leader leaving promotes the earliest
     /// remaining member; a party reduced to one member disbands.
     PartyLeave,
-    /// Ask where the sender's party members are (world-map markers). Poll,
-    /// not push: positions flow only while someone is looking at a map.
+    /// Ask where the sender's party members are right now (map open). A
+    /// one-shot snapshot: steady-state updates are pushed by the server's
+    /// party-position tick whenever a member relocates.
     RequestPartyPositions,
     /// Cast the equipped fishing rod at a water point. The server validates
     /// rod, range, floor and water (water-field depth at the point) and
@@ -566,9 +567,11 @@ pub enum ServerMessage {
         leader_id: PlayerId,
         members: Vec<PartyMember>,
     },
-    /// Direct answer to `RequestPartyPositions`: the other members' locations
-    /// with no AOI cut — the point is members beyond it. Empty when the
-    /// sender is not in a party.
+    /// Party member locations with no AOI cut — the point is members beyond
+    /// it. Pushed to the whole party when a member relocates, and sent
+    /// directly as the answer to `RequestPartyPositions`. Includes the
+    /// recipient (one payload serves every member; clients filter
+    /// themselves); empty when the requester is not in a party.
     PartyPositions {
         members: Vec<PartyMemberPosition>,
     },


### PR DESCRIPTION
## Summary

Follow-up to the transport discussion on #77: party member positions now ride a push path instead of per-client polling.

- Every relocation (x/z or floor change; rotation-only turns exempt) queues the mover in a dirty set, and a 3s server tick sends one `PartyPositions` payload per affected party — serialized once for all members via the existing shared-bytes fanout. Parties with no movement send nothing.
- Membership changes (join/leave/disband) queue a push the same way, so markers refresh within one tick of a roster change.
- The payload now includes the recipient, so a single message serves the whole party; clients filter themselves (`applyPartyPositions` in `partyStore.ts`).
- `RequestPartyPositions` remains as the map-open snapshot behind the existing 2s clamp, so an opening map does not wait for the next tick.
- `PROTOCOL_VERSION` bumped to 17 — the message's meaning and delivery model changed, per the contract in `shared/src/lib.rs`.

At the 5,000-player target the worst case drops from ~1,667 answered polls per second (each taking the global `players` read lock) to one batched pass per 3s tick (one `parties` read + one `players` read total, regardless of client count).

The world map now consumes the push (its 3s `setInterval` and 10s age gate are gone); the store shape is ready for minimap party markers to build on (@simulacre7).

New admin teleports from #86 (`/summon`, `/goto`) funnel through the same relocation path, so they trigger pushes with no extra handling.

## Test plan

- [x] `cargo test --workspace` — 8 new tests: tick pushes to every member, cross-party isolation (an unmoved party hears nothing and payloads never cross party boundaries), partyless movers dropped, formation/leave queue a push (leave payload excludes the leaver), rotation-only exempt, floor-only and z-only relocations push. The x/z/floor legs of the dirty condition were each verified by mutation (deleting a leg makes exactly one new test fail).
- [x] Client vitest — `applyPartyPositions` suite: self filtered, no-roster push dropped (crossing a disband), unknown self id filters nothing.
- [x] `cargo fmt` / `clippy` / `svelte-check` clean; branch rebased on current master.
- [x] Live E2E against a running server with two WebSocket clients: party formation triggers an unsolicited push, movement pushes the new position without any request, a quiet party stays silent for 8s, and the map-open snapshot still answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)