### PR TITLE
Rework inventory: auto-sort, batch sell/buy/drop, multi-select

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -88,10 +88,14 @@ Available action types (use EXACTLY these field names):
   To cross the room to the great chest instead of the small one at your feet:
   {"type": "open_chest", "chest": "great"}
 
-- Sell one bag item to a nearby merchant. You walk to them first; the
-  merchant pays their rate and your gold updates. One item per action —
-  repeat for more. Equipped gear must be taken off before selling:
+- Sell one or more units of a bag item to a nearby merchant. You walk to
+  them first; the merchant pays their rate and your gold updates. Defaults
+  to 1 unit; add "qty" for more, or "qty": "all" to sell every unit you
+  have. Selling more than you actually own fails outright — nothing is
+  sold. Equipped gear must be taken off before selling:
   {"type": "sell", "item": "goblin_sword", "merchant": "Rica"}
+  {"type": "sell", "item": "healing_potion", "merchant": "Rica", "qty": 5}
+  {"type": "sell", "item": "healing_potion", "merchant": "Rica", "qty": "all"}
 
 - Buy one item from a merchant's catalog at base price. You walk to them
   first; the item lands in your bag if your gold covers it. What each
@@ -99,10 +103,14 @@ Available action types (use EXACTLY these field names):
   One unit per action — repeat for more:
   {"type": "buy", "item": "healing_potion", "merchant": "Rica"}
 
-- Drop one bag item on the ground where you stand (e.g. to shed weight
-  for better loot). A stacked item drops the WHOLE stack, and anyone can
-  pick it up afterwards:
+- Drop one or more units of a bag item on the ground where you stand (e.g.
+  to shed weight for better loot), and anyone can pick it up afterwards.
+  Defaults to 1 unit; add "qty" for more, or "qty": "all" to drop every
+  unit you have. Dropping more than you actually own fails outright —
+  nothing is dropped:
   {"type": "drop", "item": "goblin_sword"}
+  {"type": "drop", "item": "old_boot", "qty": 2}
+  {"type": "drop", "item": "old_boot", "qty": "all"}
 
 - Buy back one item you sold to that merchant this session, for exactly
   what they paid you (undo a mis-sell). The [Buyback] event after each

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -147,14 +147,18 @@ pub(super) enum AgentAction {
         )]
         item: PickupRef,
     },
-    /// Sell one bag item to a nearby merchant, walking up to them first.
-    /// The server owns pricing, proximity and wallet checks.
+    /// Sell one or more units of a bag item to a nearby merchant, walking up
+    /// to them first. The server owns pricing, proximity and wallet checks.
     #[serde(rename = "sell", alias = "sell_item")]
     Sell {
         #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
         item: String,
         #[serde(alias = "npc", alias = "to", alias = "merchant_name", alias = "target")]
         merchant: String,
+        /// How many units to sell: a positive count, or "all". Defaults to 1
+        /// when omitted.
+        #[serde(default, alias = "amount", alias = "count")]
+        qty: Option<Qty>,
     },
     /// Buy one catalog item from a nearby merchant, walking up to them
     /// first. The server owns catalog, pricing and gold checks.
@@ -170,12 +174,16 @@ pub(super) enum AgentAction {
         )]
         merchant: String,
     },
-    /// Drop one bag item on the ground where you stand. Stricter than the
-    /// web client: worn gear must be taken off first.
+    /// Drop one or more units of a bag item on the ground where you stand.
+    /// Stricter than the web client: worn gear must be taken off first.
     #[serde(rename = "drop", alias = "drop_item", alias = "discard")]
     Drop {
         #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
         item: String,
+        /// How many units to drop: a positive count, or "all". Defaults to 1
+        /// when omitted.
+        #[serde(default, alias = "amount", alias = "count")]
+        qty: Option<Qty>,
     },
     /// Repurchase an item sold to this merchant this session, at the exact
     /// payout price. The server owns the entry list and gold checks.
@@ -224,6 +232,29 @@ pub(super) fn asks_for_great_chest(chest: Option<&str>) -> bool {
             .iter()
             .any(|k| c.contains(k))
     })
+}
+
+/// How a sell/drop action names an amount: an explicit count, or the
+/// literal "all" of whatever is currently owned — resolved against the live
+/// bag at dispatch time (`Self::resolve`), not fixed when the LLM composed
+/// the action.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub(super) enum Qty {
+    Count(u32),
+    Named(String),
+}
+
+impl Qty {
+    /// The concrete count this resolves to given `available` units actually
+    /// owned, or `None` if it isn't a positive count or the word "all".
+    pub(super) fn resolve(&self, available: u32) -> Option<u32> {
+        match self {
+            Self::Count(n) if *n > 0 => Some(*n),
+            Self::Named(s) if s.trim().eq_ignore_ascii_case("all") => Some(available),
+            _ => None,
+        }
+    }
 }
 
 /// How a pickup names its target: the instance id from the world state
@@ -537,6 +568,58 @@ mod tests {
     }
 
     #[test]
+    fn sell_and_drop_qty_defaults_to_none() {
+        let AgentAction::Sell { qty, .. } = parse_single_action(
+            r#"{"actions": [{"type": "sell", "item": "torch", "merchant": "Rica"}]}"#,
+        ) else {
+            panic!("expected Sell");
+        };
+        assert!(qty.is_none());
+
+        let AgentAction::Drop { qty, .. } =
+            parse_single_action(r#"{"actions": [{"type": "drop", "item": "torch"}]}"#)
+        else {
+            panic!("expected Drop");
+        };
+        assert!(qty.is_none());
+    }
+
+    #[test]
+    fn sell_and_drop_parse_a_numeric_qty() {
+        let AgentAction::Sell { qty, .. } = parse_single_action(
+            r#"{"actions": [{"type": "sell", "item": "torch", "merchant": "Rica", "qty": 5}]}"#,
+        ) else {
+            panic!("expected Sell");
+        };
+        assert_eq!(qty.unwrap().resolve(100), Some(5));
+
+        let AgentAction::Drop { qty, .. } =
+            parse_single_action(r#"{"actions": [{"type": "drop", "item": "torch", "amount": 3}]}"#)
+        else {
+            panic!("expected Drop");
+        };
+        assert_eq!(qty.unwrap().resolve(100), Some(3));
+    }
+
+    #[test]
+    fn sell_qty_accepts_the_word_all() {
+        let AgentAction::Sell { qty, .. } = parse_single_action(
+            r#"{"actions": [{"type": "sell", "item": "torch", "merchant": "Rica", "qty": "all"}]}"#,
+        ) else {
+            panic!("expected Sell");
+        };
+        assert_eq!(qty.unwrap().resolve(7), Some(7));
+    }
+
+    #[test]
+    fn qty_resolve_rejects_zero_and_unknown_words() {
+        assert_eq!(Qty::Count(0).resolve(10), None);
+        assert_eq!(Qty::Named("some".to_string()).resolve(10), None);
+        // Case-insensitive, tolerates surrounding whitespace.
+        assert_eq!(Qty::Named(" ALL ".to_string()).resolve(4), Some(4));
+    }
+
+    #[test]
     fn pickup_parses_instance_id_as_number() {
         for json in [
             r#"{"actions": [{"type": "pickup", "item": 6043}]}"#,
@@ -578,7 +661,7 @@ mod tests {
             r#"{"actions": [{"type": "sell_item", "item_id": "goblin_sword", "npc": "Rica"}]}"#,
             r#"{"actions": [{"type": "sell", "name": "goblin_sword", "to": "Rica"}]}"#,
         ] {
-            let AgentAction::Sell { item, merchant } = parse_single_action(json) else {
+            let AgentAction::Sell { item, merchant, .. } = parse_single_action(json) else {
                 panic!("expected Sell for {json}");
             };
             assert_eq!((item.as_str(), merchant.as_str()), ("goblin_sword", "Rica"));
@@ -623,7 +706,7 @@ mod tests {
             r#"{"actions": [{"type": "drop_item", "item_def_id": "torch"}]}"#,
             r#"{"actions": [{"type": "discard", "name": "torch"}]}"#,
         ] {
-            let AgentAction::Drop { item } = parse_single_action(json) else {
+            let AgentAction::Drop { item, .. } = parse_single_action(json) else {
                 panic!("expected Drop for {json}");
             };
             assert_eq!(item, "torch");

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -10,11 +10,12 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use crate::dungeon::ChestKind;
-use crate::state::{Carried, SharedState};
+use crate::state::{Carried, CarriedBagCopies, SharedState};
+use onlinerpg_shared::messages::BagLineItem;
 
 use super::action::{
     action_to_command, asks_for_great_chest, parse_agent_response, resolve_move_goal, AgentAction,
-    PickupRef,
+    PickupRef, Qty,
 };
 use super::combat::{
     approach_player, chase_monster, chest_arrive_range, walk_to_ground_item, walk_to_point,
@@ -49,6 +50,42 @@ fn unreachable_note(monster_id: &str, loss: &LostReason) -> String {
              behind walls or on another floor. Pick a reachable monster."
         ),
     }
+}
+
+/// Resolves a sell/drop qty request against the item's available bag
+/// copies (`None` means the default of 1) into concrete
+/// `(instance_id, qty)` lines, greedily filled across however many separate
+/// copies that takes. `Err` carries a user-facing reason (bad qty value, or
+/// not enough units) with no unit word — callers already know whether this
+/// is a sell or a drop.
+pub(super) fn resolve_qty_lines(
+    copies: &[(u64, u32)],
+    qty: Option<&Qty>,
+) -> Result<Vec<BagLineItem>, String> {
+    let available: u32 = copies.iter().map(|(_, q)| q).sum();
+    let requested = match qty {
+        None => 1,
+        Some(q) => q
+            .resolve(available)
+            .ok_or_else(|| "qty must be a positive number or \"all\"".to_string())?,
+    };
+    if requested > available {
+        return Err(format!("only {available} left, not {requested}"));
+    }
+    let mut need = requested;
+    let mut lines = Vec::new();
+    for (instance_id, remaining) in copies {
+        if need == 0 {
+            break;
+        }
+        let take = need.min(*remaining);
+        lines.push(BagLineItem {
+            instance_id: *instance_id,
+            qty: take,
+        });
+        need -= take;
+    }
+    Ok(lines)
 }
 
 /// Parse and execute the agent's response.
@@ -330,63 +367,102 @@ pub(super) async fn handle_response(
             continue;
         }
 
-        // Sell a bag item: resolve the merchant, walk up to them, and send
-        // the sale. The server owns pricing, proximity and wallet checks and
-        // answers with GoldUpdate/InventoryUpdated.
-        if let AgentAction::Sell { item, merchant } = action {
+        // Sell one or more units of a bag item: resolve the merchant, walk up
+        // to them, and send the sale as one all-or-nothing batch. The server
+        // owns pricing, proximity and wallet checks and answers with
+        // GoldUpdate/InventoryUpdated.
+        if let AgentAction::Sell {
+            item,
+            merchant,
+            qty,
+        } = action
+        {
             let Some((merchant_id, _)) = reach_merchant(state, "SellFailed", merchant).await else {
                 continue;
             };
             let mut s = state.lock().await;
-            let Some((def_id, placed)) = s.find_carried_bag_first(item, &spent_units) else {
+            let Some(copies) = s.find_carried_bag_copies(item, &spent_units) else {
                 s.push_agent_event(format!(
                     "[SellFailed] Nothing called '{item}' is left in your bag."
                 ));
                 continue;
             };
-            let Carried::InBag(instance_id) = placed else {
+            let CarriedBagCopies::InBag { def_id, copies } = copies else {
+                let CarriedBagCopies::WornOnly { def_id } = copies else {
+                    unreachable!("InBag already matched above")
+                };
                 s.push_agent_event(format!(
                     "[SellFailed] {def_id} is equipped — worn gear is not for sale."
                 ));
                 continue;
             };
-            let cmd = onlinerpg_shared::ClientMessage::SellItem {
+            let lines = match resolve_qty_lines(&copies, qty.as_ref()) {
+                Ok(lines) => lines,
+                Err(reason) => {
+                    s.push_agent_event(format!("[SellFailed] {def_id}: {reason}."));
+                    continue;
+                }
+            };
+            let total: u32 = lines.iter().map(|l| l.qty).sum();
+            let cmd = onlinerpg_shared::ClientMessage::SellItems {
                 merchant_player_id: merchant_id,
-                instance_id,
+                items: lines.clone(),
             };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send sell: {e}");
             } else {
-                // One unit off the stack, not the whole instance.
-                *spent_units.entry(instance_id).or_default() += 1;
-                info!("Agent selling {def_id} [id {instance_id}] to {merchant}");
+                for line in &lines {
+                    *spent_units.entry(line.instance_id).or_default() += line.qty;
+                }
+                info!(
+                    "Agent selling {total}x {def_id} [{} instance(s)] to {merchant}",
+                    lines.len()
+                );
             }
             continue;
         }
 
-        // Drop a bag item where we stand. Stricter than the web client:
-        // worn gear must be taken off first.
-        if let AgentAction::Drop { item } = action {
+        // Drop one or more units of a bag item where we stand, as one
+        // all-or-nothing batch. Stricter than the web client: worn gear must
+        // be taken off first.
+        if let AgentAction::Drop { item, qty } = action {
             let mut s = state.lock().await;
-            let Some((def_id, placed)) = s.find_carried_bag_first(item, &spent_units) else {
+            let Some(copies) = s.find_carried_bag_copies(item, &spent_units) else {
                 s.push_agent_event(format!(
                     "[DropFailed] Nothing called '{item}' is left in your bag."
                 ));
                 continue;
             };
-            let Carried::InBag(instance_id) = placed else {
+            let CarriedBagCopies::InBag { def_id, copies } = copies else {
+                let CarriedBagCopies::WornOnly { def_id } = copies else {
+                    unreachable!("InBag already matched above")
+                };
                 s.push_agent_event(format!(
                     "[DropFailed] {def_id} is equipped — worn gear cannot be dropped."
                 ));
                 continue;
             };
-            let cmd = onlinerpg_shared::ClientMessage::DropItem { instance_id };
+            let lines = match resolve_qty_lines(&copies, qty.as_ref()) {
+                Ok(lines) => lines,
+                Err(reason) => {
+                    s.push_agent_event(format!("[DropFailed] {def_id}: {reason}."));
+                    continue;
+                }
+            };
+            let total: u32 = lines.iter().map(|l| l.qty).sum();
+            let cmd = onlinerpg_shared::ClientMessage::DropItems {
+                items: lines.clone(),
+            };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send drop: {e}");
             } else {
-                // A drop puts the whole stack on the ground.
-                spent_units.insert(instance_id, u32::MAX);
-                info!("Agent dropped {def_id} [id {instance_id}]");
+                for line in &lines {
+                    *spent_units.entry(line.instance_id).or_default() += line.qty;
+                }
+                info!(
+                    "Agent dropped {total}x {def_id} [{} instance(s)]",
+                    lines.len()
+                );
             }
             continue;
         }
@@ -970,6 +1046,77 @@ mod tests {
             s.remember_ground_item(item);
         }
         s
+    }
+
+    #[test]
+    fn resolve_qty_lines_defaults_to_one_unit_from_the_first_copy() {
+        let lines = resolve_qty_lines(&[(1, 3), (2, 2)], None).unwrap();
+        assert_eq!(
+            lines,
+            vec![BagLineItem {
+                instance_id: 1,
+                qty: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn resolve_qty_lines_spans_several_copies_when_one_is_not_enough() {
+        // Two separately-picked-up non-stackable copies (qty 1 each) plus a
+        // fragmented stack — asking for 3 should drain the first two copies
+        // fully before touching the third.
+        let lines = resolve_qty_lines(&[(1, 1), (2, 1), (3, 5)], Some(&Qty::Count(3))).unwrap();
+        assert_eq!(
+            lines,
+            vec![
+                BagLineItem {
+                    instance_id: 1,
+                    qty: 1
+                },
+                BagLineItem {
+                    instance_id: 2,
+                    qty: 1
+                },
+                BagLineItem {
+                    instance_id: 3,
+                    qty: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_qty_lines_all_takes_every_copy_in_full() {
+        let lines =
+            resolve_qty_lines(&[(1, 3), (2, 2)], Some(&Qty::Named("all".to_string()))).unwrap();
+        assert_eq!(
+            lines,
+            vec![
+                BagLineItem {
+                    instance_id: 1,
+                    qty: 3
+                },
+                BagLineItem {
+                    instance_id: 2,
+                    qty: 2
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_qty_lines_rejects_more_than_is_available() {
+        let err = resolve_qty_lines(&[(1, 3), (2, 2)], Some(&Qty::Count(10))).unwrap_err();
+        assert_eq!(err, "only 5 left, not 10");
+    }
+
+    #[test]
+    fn resolve_qty_lines_rejects_a_bad_qty_value() {
+        let err = resolve_qty_lines(&[(1, 3)], Some(&Qty::Count(0))).unwrap_err();
+        assert!(err.contains("positive number"), "{err}");
+
+        let err = resolve_qty_lines(&[(1, 3)], Some(&Qty::Named("half".to_string()))).unwrap_err();
+        assert!(err.contains("positive number"), "{err}");
     }
 
     #[test]

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -57,6 +57,22 @@ pub enum Carried {
     InBag(u64),
 }
 
+/// Result of looking up every bag copy of a named item, for actions that can
+/// request more than one unit (sell/drop with a qty). See
+/// `AgentState::find_carried_bag_copies`.
+pub enum CarriedBagCopies {
+    /// At least one bag copy has unspent quantity this turn. `copies` is
+    /// (instance_id, remaining_qty) pairs — several entries when the same
+    /// item_def_id is fragmented across separate stacks or individually
+    /// picked-up non-stackable copies.
+    InBag {
+        def_id: String,
+        copies: Vec<(u64, u32)>,
+    },
+    /// Known only as an equipped item — no bag copy to sell/drop.
+    WornOnly { def_id: String },
+}
+
 /// How urgently an event needs LLM attention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventUrgency {
@@ -1895,27 +1911,34 @@ impl SharedState {
             .map(|(id, p)| (*id, p.is_official_npc))
     }
 
-    /// Like [`Self::find_carried`], but bag items win over worn ones —
-    /// selling should reach the spare in the bag, not the equipped copy.
-    ///
+    /// Every bag copy of the resolved item still available this turn.
     /// `spent` counts the units of each instance already given away earlier
     /// this turn, keyed by instance id: the bag snapshot only refreshes when
     /// InventoryUpdated arrives, and a stack survives a sale one unit at a
     /// time, so an instance stays sellable until its whole quantity is gone.
-    pub fn find_carried_bag_first(
+    pub fn find_carried_bag_copies(
         &self,
         asked: &str,
         spent: &HashMap<u64, u32>,
-    ) -> Option<(String, Carried)> {
+    ) -> Option<CarriedBagCopies> {
         let (id, placed) = self.find_carried(asked)?;
-        if let Some(item) = self.self_bag.iter().find(|i| {
-            i.item_def_id == id && spent.get(&i.instance_id).copied().unwrap_or(0) < i.quantity
-        }) {
-            return Some((id, Carried::InBag(item.instance_id)));
+        let copies: Vec<(u64, u32)> = self
+            .self_bag
+            .iter()
+            .filter(|i| i.item_def_id == id)
+            .filter_map(|i| {
+                let already = spent.get(&i.instance_id).copied().unwrap_or(0);
+                let remaining = i.quantity.saturating_sub(already);
+                (remaining > 0).then_some((i.instance_id, remaining))
+            })
+            .collect();
+        if !copies.is_empty() {
+            return Some(CarriedBagCopies::InBag { def_id: id, copies });
         }
         match placed {
-            Carried::Worn(_) => Some((id, placed)),
-            // Every bag copy was already spent this turn.
+            Carried::Worn(_) => Some(CarriedBagCopies::WornOnly { def_id: id }),
+            // Every bag copy was already spent this turn — same outcome as
+            // not finding it at all.
             Carried::InBag(_) => None,
         }
     }
@@ -2468,19 +2491,78 @@ pub(crate) mod tests {
 
         let mut spent: HashMap<u64, u32> = HashMap::new();
         for unit in 1..=3 {
-            let placed = s
-                .find_carried_bag_first("healing_potion", &spent)
-                .unwrap_or_else(|| panic!("unit {unit} of 3 should still be in the bag"))
-                .1;
-            assert!(matches!(placed, Carried::InBag(7)));
+            let copies = s
+                .find_carried_bag_copies("healing_potion", &spent)
+                .unwrap_or_else(|| panic!("unit {unit} of 3 should still be in the bag"));
+            let CarriedBagCopies::InBag { copies, .. } = copies else {
+                panic!("expected InBag");
+            };
+            assert_eq!(copies, vec![(7, 4 - unit)]);
             *spent.entry(7).or_default() += 1;
         }
-        assert!(s.find_carried_bag_first("healing_potion", &spent).is_none());
+        assert!(s
+            .find_carried_bag_copies("healing_potion", &spent)
+            .is_none());
 
         let dropped = HashMap::from([(7, u32::MAX)]);
         assert!(s
-            .find_carried_bag_first("healing_potion", &dropped)
+            .find_carried_bag_copies("healing_potion", &dropped)
             .is_none());
+    }
+
+    /// A stack fragmented across two separate bag entries (e.g. two
+    /// non-stackable pickups sharing an item_def_id, or a stack that never
+    /// merged) is gathered as one pool spanning both instances.
+    #[test]
+    fn fragmented_stacks_are_gathered_across_every_instance() {
+        let (mut s, _rx) = test_state();
+        s.self_bag = vec![
+            onlinerpg_shared::inventory::ItemInstance {
+                instance_id: 1,
+                item_def_id: "old_boot".to_string(),
+                quantity: 1,
+                enchant: 0,
+            },
+            onlinerpg_shared::inventory::ItemInstance {
+                instance_id: 2,
+                item_def_id: "old_boot".to_string(),
+                quantity: 1,
+                enchant: 0,
+            },
+        ];
+
+        let CarriedBagCopies::InBag { def_id, copies } = s
+            .find_carried_bag_copies("old_boot", &HashMap::new())
+            .unwrap()
+        else {
+            panic!("expected InBag");
+        };
+        assert_eq!(def_id, "old_boot");
+        assert_eq!(copies, vec![(1, 1), (2, 1)]);
+    }
+
+    /// Worn-only items report `WornOnly`, not `None` — the caller needs to
+    /// tell "nothing by that name" apart from "you're wearing it".
+    #[test]
+    fn worn_only_item_is_not_a_bag_copy() {
+        let (mut s, _rx) = test_state();
+        s.self_equipped.insert(
+            onlinerpg_shared::inventory::EquipSlot::MainHand,
+            onlinerpg_shared::inventory::ItemInstance {
+                instance_id: 9,
+                item_def_id: "iron_sword".to_string(),
+                quantity: 1,
+                enchant: 0,
+            },
+        );
+
+        let CarriedBagCopies::WornOnly { def_id } = s
+            .find_carried_bag_copies("iron_sword", &HashMap::new())
+            .unwrap()
+        else {
+            panic!("expected WornOnly");
+        };
+        assert_eq!(def_id, "iron_sword");
     }
 
     /// Standing where the chest room is, on the deepest floor.

--- a/client/src/lib/components/DragGhost.svelte
+++ b/client/src/lib/components/DragGhost.svelte
@@ -3,24 +3,68 @@
 </script>
 
 {#if $dragMeta}
-  <img
-    class="drag-ghost"
-    src="/items/{$dragMeta.icon}"
-    alt=""
-    style="left:{$dragPos.x}px;top:{$dragPos.y}px"
-  />
+  <div class="drag-ghost-wrap" style="left:{$dragPos.x}px;top:{$dragPos.y}px">
+    {#if $dragMeta.groupItems && $dragMeta.groupItems.length > 0}
+      <div class="drag-ghost-group">
+        {#each $dragMeta.groupItems as item, i (i)}
+          <div class="drag-ghost-item">
+            <img
+              class="drag-ghost drag-ghost-small"
+              src="/items/{item.icon}"
+              alt=""
+            />
+            <span class="drag-ghost-qty">x{item.quantity}</span>
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <img class="drag-ghost" src="/items/{$dragMeta.icon}" alt="" />
+    {/if}
+  </div>
 {/if}
 
 <style>
-  .drag-ghost {
+  .drag-ghost-wrap {
     position: fixed;
-    width: 48px;
-    height: 48px;
     transform: translate(-50%, -50%);
-    image-rendering: pixelated;
     pointer-events: none;
     z-index: 100;
+  }
+
+  .drag-ghost {
+    display: block;
+    width: 48px;
+    height: 48px;
+    image-rendering: pixelated;
     opacity: 0.85;
     filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6));
+  }
+
+  .drag-ghost-group {
+    display: flex;
+    gap: 4px;
+  }
+
+  .drag-ghost-item {
+    position: relative;
+  }
+
+  .drag-ghost-small {
+    width: 36px;
+    height: 36px;
+  }
+
+  .drag-ghost-qty {
+    position: absolute;
+    bottom: -4px;
+    right: -4px;
+    background: rgba(6, 10, 14, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
+    padding: 0 4px;
+    font-family: 'Courier New', monospace;
+    font-size: 10px;
+    font-weight: 700;
+    color: #fff;
   }
 </style>

--- a/client/src/lib/components/InventoryPanel.svelte
+++ b/client/src/lib/components/InventoryPanel.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { inventoryStore, playerGold } from '../stores/inventoryStore'
   import type { ItemInstance } from '../stores/inventoryStore'
-  import { getItemDef, isConsumable } from '../data/itemDefs'
+  import {
+    getItemDef,
+    isConsumable,
+    type ItemDefinition,
+  } from '../data/itemDefs'
   import GoldAmount from './GoldAmount.svelte'
   import { networkManager } from '../network/socket'
   import type { CharacterAttributes, EquipSlot } from '../network/networkTypes'
@@ -15,6 +19,10 @@
   } from '../stores/dragStore'
   import { itemTooltip } from '../actions/itemTooltip'
   import { buildInventorySlots } from './inventorySlots'
+  import { sortBag } from './inventorySort'
+  import { groupBagForSelection, splitGroupQty } from './inventoryGroups'
+  import QuantityPopup from './QuantityPopup.svelte'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
 
   interface Props {
     visible: boolean
@@ -41,12 +49,73 @@
     return total
   })
 
-  const slots = $derived(buildInventorySlots($inventoryStore.bag))
+  const slots = $derived(buildInventorySlots(sortBag($inventoryStore.bag)))
 
   let panelEl = $state<HTMLDivElement | null>(null)
+  let pendingDrop = $state<{ slot: ItemInstance; def: ItemDefinition } | null>(
+    null
+  )
+
+  /** Select mode: bulk-drop several different non-stackable items at once
+   *  (junk, unique gear) in a single drag. Stackable stacks keep the
+   *  separate single-drag + quantity-popup flow above and are inert here. */
+  let selectMode = $state(false)
+  const selected = new SvelteSet<number>()
+
+  // Closing the panel must not leave Select mode (and a stale selection)
+  // armed for whenever it's reopened.
+  $effect(() => {
+    if (!visible) {
+      selectMode = false
+      selected.clear()
+    }
+  })
+
+  function isSelectable(slot: ItemInstance): boolean {
+    return getItemDef(slot.item_def_id)?.stackable !== true
+  }
+
+  function toggleSelectMode() {
+    selectMode = !selectMode
+    selected.clear()
+  }
+
+  function toggleSelected(slot: ItemInstance) {
+    if (!isSelectable(slot)) return
+    if (selected.has(slot.instance_id)) selected.delete(slot.instance_id)
+    else selected.add(slot.instance_id)
+  }
+
+  /** Splits a requested quantity across whichever real bag instances back
+   *  this (possibly merged-for-display) stack, since a merged slot's own
+   *  instance_id may not itself hold that many units. */
+  function dropQty(slot: ItemInstance, qty: number) {
+    const stackable = getItemDef(slot.item_def_id)?.stackable === true
+    const key = stackable
+      ? `${slot.item_def_id}:${slot.enchant}`
+      : `unique:${slot.instance_id}`
+    const group = groupBagForSelection($inventoryStore.bag).find(
+      (g) => g.key === key
+    )
+    if (!group) return
+    const lines = splitGroupQty(group, Math.min(qty, group.totalQty))
+    networkManager.sendDropItems(
+      lines.map((l) => ({ instance_id: l.instanceId, qty: l.qty }))
+    )
+  }
+
+  function confirmPendingDrop(qty: number) {
+    if (!pendingDrop) return
+    dropQty(pendingDrop.slot, qty)
+    pendingDrop = null
+  }
+
+  function cancelPendingDrop() {
+    pendingDrop = null
+  }
 
   function onDblClick(slot: ItemInstance | null) {
-    if (!slot) return
+    if (!slot || selectMode) return
     const def = getItemDef(slot.item_def_id)
     if (def?.equipSlot) {
       networkManager.sendEquipItem(slot.instance_id)
@@ -55,8 +124,72 @@
     }
   }
 
+  /** Drags the current Select-mode selection as a group, adding the dragged
+   *  slot to it first if it wasn't already selected. A plain click (no drag)
+   *  toggles the slot instead — routed through `startDrag`'s own click
+   *  callback rather than a separate native `onclick`, since pointer capture
+   *  keeps the browser's click event targeted here even after a completed
+   *  drag, which would otherwise re-select the item this same gesture just
+   *  dropped. */
+  function onGroupPointerDown(e: PointerEvent, slot: ItemInstance) {
+    const def = getItemDef(slot.item_def_id)
+    const groupIds = new SvelteSet(selected)
+    groupIds.add(slot.instance_id)
+    // Several selected instances can share the same item_def_id (e.g. two
+    // separately-caught, non-stackable old_boot entries) — consolidate them
+    // into one ghost icon with a summed quantity rather than one icon per
+    // instance.
+    const byDefId = new SvelteMap<string, { icon: string; quantity: number }>()
+    for (const id of groupIds) {
+      const item = $inventoryStore.bag.find((i) => i.instance_id === id)
+      if (!item) continue
+      const existing = byDefId.get(item.item_def_id)
+      if (existing) {
+        existing.quantity += item.quantity
+      } else {
+        byDefId.set(item.item_def_id, {
+          icon: getItemDef(item.item_def_id)?.icon ?? FALLBACK_ICON,
+          quantity: item.quantity,
+        })
+      }
+    }
+    const groupItems = [...byDefId.values()]
+
+    startDrag(
+      e,
+      {
+        instanceId: slot.instance_id,
+        defId: slot.item_def_id,
+        // Group drags never equip, regardless of drop position.
+        equipSlot: null,
+        source: { type: 'bag' },
+        icon: def?.icon ?? FALLBACK_ICON,
+        groupItems,
+      },
+      (x, y) => {
+        if (
+          panelEl &&
+          !pointInRect(x, y, panelEl.getBoundingClientRect()) &&
+          !isOverAnyDialog(x, y)
+        ) {
+          networkManager.sendDropItems(
+            [...groupIds].map((instance_id) => ({ instance_id, qty: 1 }))
+          )
+          selected.clear()
+        }
+      },
+      () => toggleSelected(slot)
+    )
+  }
+
   function onPointerDown(e: PointerEvent, slot: ItemInstance) {
     if (e.button !== 0) return
+    if (selectMode) {
+      if (!isSelectable(slot)) return
+      e.preventDefault()
+      onGroupPointerDown(e, slot)
+      return
+    }
     e.preventDefault()
     const def = getItemDef(slot.item_def_id)
 
@@ -86,7 +219,11 @@
           !pointInRect(x, y, panelEl.getBoundingClientRect()) &&
           !isOverAnyDialog(x, y)
         ) {
-          networkManager.sendDropItem(slot.instance_id)
+          if (slot.quantity > 1 && def) {
+            pendingDrop = { slot, def }
+          } else {
+            networkManager.sendDropItem(slot.instance_id)
+          }
         }
       }
     )
@@ -108,21 +245,32 @@
       <span class="weight-display">
         {(currentWeight / 10).toFixed(1)} / {(maxWeight / 10).toFixed(1)} kg
       </span>
+      <button
+        class="select-btn"
+        class:active={selectMode}
+        title="Select multiple items to drop"
+        onclick={toggleSelectMode}
+      >
+        {selectMode ? 'Cancel' : 'Select'}
+      </button>
       <button class="close-btn" onclick={onClose}>&times;</button>
     </div>
 
     <div class="bag-grid">
       {#each slots as slot, i (slot?.instance_id ?? `empty-${i}`)}
         {@const def = slot ? getItemDef(slot.item_def_id) : null}
+        {@const locked = selectMode && slot !== null && !isSelectable(slot)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
           class="grid-cell"
+          class:selected={slot !== null && selected.has(slot.instance_id)}
+          class:locked
           use:itemTooltip={def && slot
             ? { def, item: slot, side: 'left' }
             : null}
           ondblclick={() => onDblClick(slot)}
           onpointerdown={(e: PointerEvent) => {
-            if (slot) onPointerDown(e, slot)
+            if (slot && !locked) onPointerDown(e, slot)
           }}
         >
           {#if def}
@@ -139,11 +287,23 @@
           {#if slot && slot.quantity > 1}
             <span class="item-qty">{slot.quantity}</span>
           {/if}
+          {#if slot !== null && selected.has(slot.instance_id)}
+            <span class="item-selected-check">&check;</span>
+          {/if}
         </div>
       {/each}
     </div>
   </div>
 {/if}
+
+<QuantityPopup
+  visible={pendingDrop !== null}
+  itemName={pendingDrop?.def.name ?? ''}
+  icon={pendingDrop?.def.icon ?? ''}
+  max={pendingDrop?.slot.quantity ?? 1}
+  onConfirm={confirmPendingDrop}
+  onCancel={cancelPendingDrop}
+/>
 
 <style>
   .inventory-panel {
@@ -214,6 +374,29 @@
     color: #ffd700;
   }
 
+  .select-btn {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    color: #9fb2c3;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 2px 6px;
+  }
+
+  .select-btn:hover {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  .select-btn.active {
+    background: rgba(120, 60, 60, 0.85);
+    border-color: rgba(220, 140, 140, 0.45);
+    color: #fff;
+  }
+
   .bag-grid {
     display: grid;
     grid-template-columns: repeat(5, var(--inventory-slot-size));
@@ -257,6 +440,26 @@
     justify-content: center;
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 4px;
+  }
+
+  .grid-cell.selected {
+    border-color: rgba(220, 140, 140, 0.7);
+    background: rgba(120, 60, 60, 0.25);
+  }
+
+  .grid-cell.locked {
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  .item-selected-check {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: #f0b8b8;
+    text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
   }
 
   .item-icon {

--- a/client/src/lib/components/QuantityPopup.svelte
+++ b/client/src/lib/components/QuantityPopup.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  interface Props {
+    visible: boolean
+    itemName: string
+    icon: string
+    max: number
+    onConfirm: (qty: number) => void
+    onCancel: () => void
+  }
+
+  let { visible, itemName, icon, max, onConfirm, onCancel }: Props = $props()
+
+  let qty = $state(1)
+
+  $effect(() => {
+    if (visible) qty = max
+  })
+
+  function clamp(n: number): number {
+    if (!Number.isFinite(n)) return 1
+    return Math.min(max, Math.max(1, Math.round(n)))
+  }
+
+  function onInput(e: Event) {
+    const value = Number((e.target as HTMLInputElement).value)
+    qty = clamp(value)
+  }
+
+  /** +/- buttons wrap around instead of stopping at the ends: one past max
+   *  loops to 1, one below 1 loops to max — quicker than clamping when the
+   *  player actually wants the far end (e.g. tapping minus once from a
+   *  freshly-opened "all 5" popup to get back to "all 5" after overshooting
+   *  to 1). Typing a number directly still clamps (see `onInput`). */
+  function step(delta: number) {
+    const zeroBased = qty - 1 + delta
+    qty = (((zeroBased % max) + max) % max) + 1
+  }
+
+  function confirm() {
+    onConfirm(clamp(qty))
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') confirm()
+    else if (e.key === 'Escape') onCancel()
+  }
+</script>
+
+{#if visible}
+  <div
+    class="quantity-overlay"
+    role="dialog"
+    aria-label="Choose quantity"
+    tabindex="-1"
+    onkeydown={onKeydown}
+  >
+    <div class="quantity-popup">
+      <div class="popup-header">
+        <img class="item-icon" src="/items/{icon}" alt="" draggable="false" />
+        <span class="item-name">{itemName}</span>
+      </div>
+      <div class="qty-row">
+        <button class="step-btn" onclick={() => step(-1)}>−</button>
+        <input
+          class="qty-input"
+          type="number"
+          min="1"
+          {max}
+          value={qty}
+          oninput={onInput}
+        />
+        <button class="step-btn" onclick={() => step(1)}>+</button>
+      </div>
+      <div class="max-note">of {max}</div>
+      <div class="popup-actions">
+        <button class="cancel-btn" onclick={onCancel}>Cancel</button>
+        <button class="confirm-btn" onclick={confirm}>Confirm</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .quantity-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.35);
+    pointer-events: auto;
+  }
+
+  .quantity-popup {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    background: rgba(6, 10, 14, 0.95);
+    color: #e6edf3;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    min-width: 200px;
+  }
+
+  .popup-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .item-icon {
+    width: 28px;
+    height: 28px;
+    image-rendering: pixelated;
+    flex-shrink: 0;
+  }
+
+  .item-name {
+    font-weight: 700;
+    color: #f0c040;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .qty-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .step-btn {
+    width: 32px;
+    height: 32px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    color: #e6edf3;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .step-btn:hover {
+    background: rgba(255, 255, 255, 0.16);
+  }
+
+  .qty-input {
+    flex: 1;
+    min-width: 0;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    color: #e6edf3;
+    font-family: inherit;
+    font-size: 14px;
+    padding: 6px 4px;
+  }
+
+  .max-note {
+    text-align: center;
+    color: #6b7d8d;
+  }
+
+  .popup-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .cancel-btn,
+  .confirm-btn {
+    border-radius: 4px;
+    padding: 6px 14px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .cancel-btn {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: #9fb2c3;
+  }
+
+  .cancel-btn:hover {
+    color: #fff;
+  }
+
+  .confirm-btn {
+    background: rgba(60, 90, 60, 0.85);
+    color: #d6f0d6;
+    border: 1px solid rgba(140, 220, 140, 0.35);
+  }
+
+  .confirm-btn:hover {
+    background: rgba(80, 120, 80, 0.95);
+    color: #fff;
+  }
+
+  @media (max-width: 600px), (pointer: coarse) {
+    .step-btn {
+      width: 40px;
+      height: 40px;
+    }
+  }
+</style>

--- a/client/src/lib/components/TradeWindow.svelte
+++ b/client/src/lib/components/TradeWindow.svelte
@@ -10,21 +10,28 @@
   import { gameStore } from '../stores/gameStore'
   import { remotePlayerManager } from '../managers/remotePlayerManager'
   import { inventoryStore, playerGold } from '../stores/inventoryStore'
-  import type { ItemInstance } from '../stores/inventoryStore'
   import { getItemDef, type ItemDefinition } from '../data/itemDefs'
   import { getNpcCapabilities } from '../data/traderDefs'
   import { MAX_TRADE_DISTANCE_METERS } from '../data/tradeConstants'
   import GoldAmount from './GoldAmount.svelte'
   import { itemTooltip } from '../actions/itemTooltip'
   import { networkManager } from '../network/socket'
+  import QuantityPopup from './QuantityPopup.svelte'
+  import {
+    groupBagForSelection,
+    createGroupAllocator,
+    type SelectableGroup,
+  } from './inventoryGroups'
 
   const session = $derived($shopSession)
 
   interface CartEntry {
     kind: 'buy' | 'sell' | 'buyback'
     itemDefId: string
-    /** Bag instance backing a sell entry; absent for buy entries. */
-    instanceId?: number
+    /** Bag group backing a sell entry (same key as `sellEntries`); absent
+     *  for buy entries. May span several real instances (fragmented same-def
+     *  stacks), split out again at confirm time via `splitGroupQty`. */
+    groupKey?: string
     /** Buyback entry backing a buyback entry; absent otherwise. */
     entryId?: number
     qty: number
@@ -37,7 +44,20 @@
     dealPct?: number
   }
 
+  /** A row awaiting a quantity choice, shown via QuantityPopup. Clicking a
+   *  buy/sell row with more than one unit available opens this instead of
+   *  stacking one unit per click. */
+  interface PendingAdd {
+    kind: 'buy' | 'sell'
+    itemDefId: string
+    groupKey?: string
+    def: ItemDefinition
+    max: number
+    unitPrice: number
+  }
+
   let cart = $state<CartEntry[]>([])
+  let pendingAdd = $state<PendingAdd | null>(null)
   let portraitFailed = $state(false)
   let now = $state(Date.now())
 
@@ -89,16 +109,18 @@
   })
 
   // Residents only buy their wishlist; merchants buy anything priced.
-  const sellEntries = $derived.by(() => {
+  // Grouped/sorted the same way the bag grid is: same-def stackable stacks
+  // (potions, scrolls, food) merge into one row instead of one per fragment.
+  const sellEntries = $derived.by((): SelectableGroup[] => {
     if (!session) return []
     const wishlist = session.wishlist
-    return $inventoryStore.bag
-      .map((item) => ({ item, def: getItemDef(item.item_def_id) }))
-      .filter(
-        (entry): entry is { item: ItemInstance; def: ItemDefinition } =>
-          (entry.def?.basePrice ?? 0) > 0 &&
-          (wishlist.length === 0 || wishlist.includes(entry.item.item_def_id))
+    return groupBagForSelection($inventoryStore.bag).filter((group) => {
+      const basePrice = getItemDef(group.itemDefId)?.basePrice ?? 0
+      return (
+        basePrice > 0 &&
+        (wishlist.length === 0 || wishlist.includes(group.itemDefId))
       )
+    })
   })
 
   /** Live haggled modifier for an item, 0 when none (or expired). */
@@ -148,7 +170,14 @@
   const netCost = $derived(buyTotal - sellTotal)
   const canConfirm = $derived(cart.length > 0 && netCost <= $playerGold)
 
-  function addBuy(itemDefId: string, def: ItemDefinition) {
+  /** Buying a catalog item has no owned "stack" to bound quantity by, so the
+   *  popup caps at what the player can currently afford — a UX convenience
+   *  only; the server re-validates gold/weight for real on confirm. */
+  function affordableQty(unitPrice: number): number {
+    return Math.max(1, Math.floor($playerGold / Math.max(1, unitPrice)))
+  }
+
+  function addBuy(itemDefId: string, def: ItemDefinition, stockMax?: number) {
     // The first added unit carries any haggled deal (single-use server-side).
     const pct = dealPct(itemDefId, 'buy')
     const hasDealEntry = cart.some(
@@ -164,52 +193,91 @@
       })
       return
     }
+    const unitPrice = def.basePrice ?? 0
+    const max =
+      stockMax !== undefined
+        ? Math.max(1, stockMax - reservedBuyQty(itemDefId))
+        : affordableQty(unitPrice)
+    if (max <= 1) {
+      addBuyUnits(itemDefId, unitPrice, 1)
+      return
+    }
+    pendingAdd = { kind: 'buy', itemDefId, def, max, unitPrice }
+  }
+
+  function addBuyUnits(itemDefId: string, unitPrice: number, qty: number) {
     const existing = cart.find(
       (e) => e.kind === 'buy' && e.itemDefId === itemDefId && !e.dealPct
     )
     if (existing) {
-      existing.qty += 1
+      existing.qty += qty
     } else {
-      cart.push({
-        kind: 'buy',
-        itemDefId,
-        qty: 1,
-        unitPrice: def.basePrice ?? 0,
-      })
+      cart.push({ kind: 'buy', itemDefId, qty, unitPrice })
     }
   }
 
-  function addSell(item: ItemInstance, def: ItemDefinition) {
-    const pct = dealPct(item.item_def_id, 'sell')
+  function addSell(group: SelectableGroup, def: ItemDefinition) {
+    const pct = dealPct(group.itemDefId, 'sell')
     const hasDealEntry = cart.some(
-      (e) => e.kind === 'sell' && e.itemDefId === item.item_def_id && e.dealPct
+      (e) => e.kind === 'sell' && e.itemDefId === group.itemDefId && e.dealPct
     )
     if (pct !== 0 && !hasDealEntry) {
       cart.push({
         kind: 'sell',
-        itemDefId: item.item_def_id,
-        instanceId: item.instance_id,
+        itemDefId: group.itemDefId,
+        groupKey: group.key,
         qty: 1,
         unitPrice: sellPrice(def, pct),
         dealPct: pct,
       })
       return
     }
+    const max = group.totalQty - reservedQty(group.key)
+    if (max <= 0) return
+    const unitPrice = sellPrice(def, 0)
+    if (max <= 1) {
+      addSellUnits(group.itemDefId, group.key, unitPrice, 1)
+      return
+    }
+    pendingAdd = {
+      kind: 'sell',
+      itemDefId: group.itemDefId,
+      groupKey: group.key,
+      def,
+      max,
+      unitPrice,
+    }
+  }
+
+  function addSellUnits(
+    itemDefId: string,
+    groupKey: string,
+    unitPrice: number,
+    qty: number
+  ) {
     const existing = cart.find(
-      (e) =>
-        e.kind === 'sell' && e.instanceId === item.instance_id && !e.dealPct
+      (e) => e.kind === 'sell' && e.groupKey === groupKey && !e.dealPct
     )
     if (existing) {
-      if (reservedQty(item.instance_id) < item.quantity) existing.qty += 1
-    } else if (reservedQty(item.instance_id) < item.quantity) {
-      cart.push({
-        kind: 'sell',
-        itemDefId: item.item_def_id,
-        instanceId: item.instance_id,
-        qty: 1,
-        unitPrice: sellPrice(def, 0),
-      })
+      existing.qty += qty
+    } else {
+      cart.push({ kind: 'sell', itemDefId, groupKey, qty, unitPrice })
     }
+  }
+
+  function confirmPendingAdd(qty: number) {
+    if (!pendingAdd) return
+    const { kind, itemDefId, groupKey, unitPrice } = pendingAdd
+    if (kind === 'buy') {
+      addBuyUnits(itemDefId, unitPrice, qty)
+    } else if (groupKey !== undefined) {
+      addSellUnits(itemDefId, groupKey, unitPrice, qty)
+    }
+    pendingAdd = null
+  }
+
+  function cancelPendingAdd() {
+    pendingAdd = null
   }
 
   function addBuyback(entry: BuybackEntry) {
@@ -235,10 +303,10 @@
     }
   }
 
-  /** Units of this bag item already reserved in the cart. */
-  function reservedQty(instanceId: number): number {
+  /** Units of this bag group already reserved in the cart. */
+  function reservedQty(groupKey: string): number {
     return cart
-      .filter((e) => e.kind === 'sell' && e.instanceId === instanceId)
+      .filter((e) => e.kind === 'sell' && e.groupKey === groupKey)
       .reduce((sum, e) => sum + e.qty, 0)
   }
 
@@ -249,32 +317,46 @@
       .reduce((sum, e) => sum + e.qty, 0)
   }
 
-  function onConfirm() {
-    if (!session || !canConfirm) return
-    // Deal entries go first so the server applies the single-use modifier
-    // to the unit the cart priced with it.
-    const ordered = [...cart].sort(
+  /** Deal entries first, so the server's single-use modifier lands on the
+   *  unit the cart priced with it. */
+  function dealsFirst(entries: CartEntry[]): CartEntry[] {
+    return [...entries].sort(
       (a, b) => Number(Boolean(b.dealPct)) - Number(Boolean(a.dealPct))
     )
-    // Sells go first so their proceeds can fund the buys.
-    for (const entry of ordered) {
-      if (entry.kind !== 'sell' || entry.instanceId === undefined) continue
-      const owned = $inventoryStore.bag.find(
-        (i) => i.instance_id === entry.instanceId
-      )
-      const qty = Math.min(entry.qty, owned?.quantity ?? 0)
-      for (let i = 0; i < qty; i++) {
-        networkManager.sendSellItem(session.merchantPlayerId, entry.instanceId)
-      }
+  }
+
+  function onConfirm() {
+    if (!session || !canConfirm) return
+    // A shared allocator so a deal-priced row and a plain row for the same
+    // item def (same group) deplete one pool instead of each independently
+    // draining the group's full instance list.
+    const allocator = createGroupAllocator(sellEntries)
+    const sellItems = dealsFirst(cart.filter((e) => e.kind === 'sell'))
+      .filter((e) => e.groupKey !== undefined)
+      .flatMap((e) => {
+        const group = sellEntries.find((g) => g.key === e.groupKey)
+        if (!group) return []
+        return allocator
+          .take(group, e.qty)
+          .map((l) => ({ instance_id: l.instanceId, qty: l.qty }))
+      })
+    const buyItems = dealsFirst(cart.filter((e) => e.kind === 'buy')).map(
+      (e) => ({ item_def_id: e.itemDefId, qty: e.qty })
+    )
+    const buybackIds = cart
+      .filter((e) => e.kind === 'buyback' && e.entryId !== undefined)
+      .map((e) => e.entryId!)
+
+    // Sells first so their proceeds can fund the buys — each is its own
+    // all-or-nothing batch; the connection processes them in send order.
+    if (sellItems.length > 0) {
+      networkManager.sendSellItems(session.merchantPlayerId, sellItems)
     }
-    for (const entry of ordered) {
-      if (entry.kind === 'buy') {
-        for (let i = 0; i < entry.qty; i++) {
-          networkManager.sendBuyItem(session.merchantPlayerId, entry.itemDefId)
-        }
-      } else if (entry.kind === 'buyback' && entry.entryId !== undefined) {
-        networkManager.sendBuybackItem(session.merchantPlayerId, entry.entryId)
-      }
+    if (buyItems.length > 0) {
+      networkManager.sendBuyItems(session.merchantPlayerId, buyItems)
+    }
+    if (buybackIds.length > 0) {
+      networkManager.sendBuybackItems(session.merchantPlayerId, buybackIds)
     }
     cart = []
   }
@@ -340,7 +422,7 @@
               <button
                 class="item-row"
                 disabled={reservedBuyQty(entry.itemDefId) >= entry.quantity}
-                onclick={() => addBuy(entry.itemDefId, def)}
+                onclick={() => addBuy(entry.itemDefId, def, entry.quantity)}
                 use:itemTooltip={{ def, side: 'left' }}
               >
                 <img
@@ -404,7 +486,7 @@
         </div>
         <div class="column-title">Cart</div>
         <div class="item-list">
-          {#each cart as entry (entry.kind + ':' + (entry.instanceId ?? entry.entryId ?? entry.itemDefId) + (entry.dealPct ? ':deal' : ''))}
+          {#each cart as entry (entry.kind + ':' + (entry.groupKey ?? entry.entryId ?? entry.itemDefId) + (entry.dealPct ? ':deal' : ''))}
             {@const def = getItemDef(entry.itemDefId)}
             {#if def}
               <button
@@ -472,33 +554,45 @@
       <div class="trade-column">
         <div class="column-title">Sell ({session.sellRatePercent}%)</div>
         <div class="item-list">
-          {#each sellEntries as { item, def } (item.instance_id)}
-            {@const reserved = reservedQty(item.instance_id)}
-            {@const pct = dealPct(item.item_def_id, 'sell')}
-            <button
-              class="item-row"
-              disabled={reserved >= item.quantity}
-              onclick={() => addSell(item, def)}
-              use:itemTooltip={{ def, item, side: 'right' }}
-            >
-              <img
-                class="item-icon"
-                src="/items/{def.icon}"
-                alt=""
-                draggable="false"
-              />
-              <span class="item-name">
-                {def.name}{item.quantity > 1 ? ` ×${item.quantity}` : ''}
-              </span>
-              {#if pct !== 0}
-                <span class="deal-badge" class:markup={isMarkup('sell', pct)}
-                  >{pct > 0 ? '+' : ''}{pct}%</span
-                >
-              {/if}
-              <span class="item-price"
-                ><GoldAmount copper={sellPrice(def, pct)} /></span
+          {#each sellEntries as group (group.key)}
+            {@const def = getItemDef(group.itemDefId)}
+            {#if def}
+              {@const reserved = reservedQty(group.key)}
+              {@const pct = dealPct(group.itemDefId, 'sell')}
+              <button
+                class="item-row"
+                disabled={reserved >= group.totalQty}
+                onclick={() => addSell(group, def)}
+                use:itemTooltip={{
+                  def,
+                  item: {
+                    instance_id: group.instances[0].instanceId,
+                    item_def_id: group.itemDefId,
+                    quantity: group.totalQty,
+                    enchant: group.enchant,
+                  },
+                  side: 'right',
+                }}
               >
-            </button>
+                <img
+                  class="item-icon"
+                  src="/items/{def.icon}"
+                  alt=""
+                  draggable="false"
+                />
+                <span class="item-name">
+                  {def.name}{group.totalQty > 1 ? ` ×${group.totalQty}` : ''}
+                </span>
+                {#if pct !== 0}
+                  <span class="deal-badge" class:markup={isMarkup('sell', pct)}
+                    >{pct > 0 ? '+' : ''}{pct}%</span
+                  >
+                {/if}
+                <span class="item-price"
+                  ><GoldAmount copper={sellPrice(def, pct)} /></span
+                >
+              </button>
+            {/if}
           {:else}
             <div class="empty-note">Nothing to sell</div>
           {/each}
@@ -507,6 +601,15 @@
     </div>
   </div>
 {/if}
+
+<QuantityPopup
+  visible={pendingAdd !== null}
+  itemName={pendingAdd?.def.name ?? ''}
+  icon={pendingAdd?.def.icon ?? ''}
+  max={pendingAdd?.max ?? 1}
+  onConfirm={confirmPendingAdd}
+  onCancel={cancelPendingAdd}
+/>
 
 <style>
   .trade-window {

--- a/client/src/lib/components/inventoryGroups.ts
+++ b/client/src/lib/components/inventoryGroups.ts
@@ -1,0 +1,121 @@
+import type { ItemInstance } from '../network/networkTypes'
+import { getItemDef } from '../data/itemDefs'
+import { CATEGORY_ORDER, categoryOf } from './inventorySort'
+
+/** One backing bag entry behind a displayed group. The server may hold the
+ *  same item_def_id/enchant as several separate stacks (e.g. repeated
+ *  purchases don't always merge), so a group's displayed total can span
+ *  multiple real instance ids. */
+export interface SelectableGroup {
+  key: string
+  itemDefId: string
+  enchant: number
+  totalQty: number
+  instances: { instanceId: number; quantity: number }[]
+}
+
+/** Groups the bag the same way `sortBag` does for display (merging same
+ *  item_def_id/enchant stacks, sorted by category/name/qty), but keeps the
+ *  backing instance ids and their individual quantities instead of
+ *  collapsing to one representative instance. Selection UIs that let a
+ *  player request "N of this pile" need that breakdown to split the request
+ *  across however many real stacks actually back it. */
+export function groupBagForSelection(
+  bag: readonly ItemInstance[]
+): SelectableGroup[] {
+  const groups = new Map<string, SelectableGroup>()
+  for (const item of bag) {
+    const stackable = getItemDef(item.item_def_id)?.stackable === true
+    const key = stackable
+      ? `${item.item_def_id}:${item.enchant}`
+      : `unique:${item.instance_id}`
+    const existing = groups.get(key)
+    if (existing) {
+      existing.totalQty += item.quantity
+      existing.instances.push({
+        instanceId: item.instance_id,
+        quantity: item.quantity,
+      })
+    } else {
+      groups.set(key, {
+        key,
+        itemDefId: item.item_def_id,
+        enchant: item.enchant,
+        totalQty: item.quantity,
+        instances: [{ instanceId: item.instance_id, quantity: item.quantity }],
+      })
+    }
+  }
+
+  return [...groups.values()].sort((a, b) => {
+    const categoryDiff =
+      CATEGORY_ORDER.indexOf(categoryOf(a.itemDefId)) -
+      CATEGORY_ORDER.indexOf(categoryOf(b.itemDefId))
+    if (categoryDiff !== 0) return categoryDiff
+
+    const nameA = getItemDef(a.itemDefId)?.name ?? a.itemDefId
+    const nameB = getItemDef(b.itemDefId)?.name ?? b.itemDefId
+    const nameDiff = nameA.localeCompare(nameB)
+    if (nameDiff !== 0) return nameDiff
+
+    return b.totalQty - a.totalQty
+  })
+}
+
+/** Splits a requested quantity across a group's backing instances,
+ *  greedily draining each stack in turn. `qty` must not exceed
+ *  `group.totalQty` minus anything already reserved by the caller.
+ *
+ *  Only safe for a single request per group. If several separate requests
+ *  can target the *same* group (e.g. a haggled-deal cart row and a plain
+ *  cart row for the same item def), calling this once per request each
+ *  starts from the group's full, undrained instance list and can
+ *  double-allocate the same instance's capacity across requests — use
+ *  `createGroupAllocator` for that case instead. */
+export function splitGroupQty(
+  group: SelectableGroup,
+  qty: number
+): { instanceId: number; qty: number }[] {
+  const lines: { instanceId: number; qty: number }[] = []
+  let remaining = qty
+  for (const inst of group.instances) {
+    if (remaining <= 0) break
+    const take = Math.min(remaining, inst.quantity)
+    if (take > 0) lines.push({ instanceId: inst.instanceId, qty: take })
+    remaining -= take
+  }
+  return lines
+}
+
+/** Tracks remaining per-instance capacity across several `take()` calls
+ *  against the same set of groups, so multiple cart rows for one group
+ *  (e.g. a deal-priced row plus a plain row) deplete a shared pool instead
+ *  of each independently draining the group's full, undrained instances. */
+export function createGroupAllocator(groups: readonly SelectableGroup[]) {
+  const remaining = new Map<number, number>()
+  for (const group of groups) {
+    for (const inst of group.instances) {
+      remaining.set(inst.instanceId, inst.quantity)
+    }
+  }
+  return {
+    take(
+      group: SelectableGroup,
+      qty: number
+    ): { instanceId: number; qty: number }[] {
+      const lines: { instanceId: number; qty: number }[] = []
+      let need = qty
+      for (const inst of group.instances) {
+        if (need <= 0) break
+        const avail = remaining.get(inst.instanceId) ?? 0
+        const take = Math.min(need, avail)
+        if (take > 0) {
+          lines.push({ instanceId: inst.instanceId, qty: take })
+          remaining.set(inst.instanceId, avail - take)
+          need -= take
+        }
+      }
+      return lines
+    },
+  }
+}

--- a/client/src/lib/components/inventorySort.test.ts
+++ b/client/src/lib/components/inventorySort.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import type { ItemInstance } from '../network/networkTypes'
+import { sortBag } from './inventorySort'
+
+function makeItem(
+  overrides: Partial<ItemInstance> & { instance_id: number }
+): ItemInstance {
+  return {
+    item_def_id: 'iron_sword',
+    quantity: 1,
+    enchant: 0,
+    ...overrides,
+  }
+}
+
+describe('sortBag', () => {
+  it('merges stackable stacks of the same item and enchant', () => {
+    const bag = [
+      makeItem({ instance_id: 1, item_def_id: 'healing_potion', quantity: 30 }),
+      makeItem({ instance_id: 2, item_def_id: 'healing_potion', quantity: 70 }),
+    ]
+
+    const result = sortBag(bag)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].quantity).toBe(100)
+  })
+
+  it('keeps different enchant levels of the same item separate', () => {
+    const bag = [
+      makeItem({ instance_id: 1, item_def_id: 'iron_sword', enchant: 0 }),
+      makeItem({ instance_id: 2, item_def_id: 'iron_sword', enchant: 1 }),
+    ]
+
+    const result = sortBag(bag)
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not merge duplicate non-stackable items', () => {
+    const bag = [
+      makeItem({ instance_id: 1, item_def_id: 'iron_sword' }),
+      makeItem({ instance_id: 2, item_def_id: 'iron_sword' }),
+    ]
+
+    const result = sortBag(bag)
+
+    expect(result).toHaveLength(2)
+    expect(result.every((item) => item.quantity === 1)).toBe(true)
+  })
+
+  it('groups by equip slot category before consumables/misc', () => {
+    const bag = [
+      makeItem({ instance_id: 1, item_def_id: 'healing_potion', quantity: 1 }),
+      makeItem({ instance_id: 2, item_def_id: 'leather_helmet' }),
+      makeItem({ instance_id: 3, item_def_id: 'iron_sword' }),
+    ]
+
+    const result = sortBag(bag)
+
+    expect(result.map((item) => item.item_def_id)).toEqual([
+      'leather_helmet',
+      'iron_sword',
+      'healing_potion',
+    ])
+  })
+
+  it('sorts same-category items alphabetically by name', () => {
+    const bag = [
+      makeItem({ instance_id: 1, item_def_id: 'worn_iron_sword' }),
+      makeItem({ instance_id: 2, item_def_id: 'iron_sword' }),
+    ]
+
+    const result = sortBag(bag)
+
+    expect(result.map((item) => item.item_def_id)).toEqual([
+      'iron_sword',
+      'worn_iron_sword',
+    ])
+  })
+})

--- a/client/src/lib/components/inventorySort.ts
+++ b/client/src/lib/components/inventorySort.ts
@@ -1,0 +1,63 @@
+import type { EquipSlot, ItemInstance } from '../network/networkTypes'
+import { getItemDef, isConsumable } from '../data/itemDefs'
+
+export type Category = EquipSlot | 'consumable' | 'misc'
+
+// Mirrors the equip-slot ordering used in CharacterPanel's paperdoll layout.
+export const CATEGORY_ORDER: Category[] = [
+  'head',
+  'main_hand',
+  'off_hand',
+  'chest',
+  'ear',
+  'neck',
+  'belt',
+  'pants',
+  'boots',
+  'ring',
+  'ring_left',
+  'hands',
+  'back',
+  'shirt',
+  'consumable',
+  'misc',
+]
+
+export function categoryOf(itemDefId: string): Category {
+  const def = getItemDef(itemDefId)
+  if (def?.equipSlot) return def.equipSlot
+  if (def && isConsumable(def)) return 'consumable'
+  return 'misc'
+}
+
+/** Merges same-item/enchant stackable stacks, then groups by equip slot,
+ *  name, and quantity. Client-side only; does not touch server state. */
+export function sortBag(bag: readonly ItemInstance[]): ItemInstance[] {
+  const merged = new Map<string, ItemInstance>()
+  for (const item of bag) {
+    const stackable = getItemDef(item.item_def_id)?.stackable === true
+    const key = stackable
+      ? `${item.item_def_id}:${item.enchant}`
+      : `unique:${item.instance_id}`
+    const existing = merged.get(key)
+    if (existing) {
+      existing.quantity += item.quantity
+    } else {
+      merged.set(key, { ...item })
+    }
+  }
+
+  return [...merged.values()].sort((a, b) => {
+    const categoryDiff =
+      CATEGORY_ORDER.indexOf(categoryOf(a.item_def_id)) -
+      CATEGORY_ORDER.indexOf(categoryOf(b.item_def_id))
+    if (categoryDiff !== 0) return categoryDiff
+
+    const nameA = getItemDef(a.item_def_id)?.name ?? a.item_def_id
+    const nameB = getItemDef(b.item_def_id)?.name ?? b.item_def_id
+    const nameDiff = nameA.localeCompare(nameB)
+    if (nameDiff !== 0) return nameDiff
+
+    return b.quantity - a.quantity
+  })
+}

--- a/client/src/lib/network/networkTypes.ts
+++ b/client/src/lib/network/networkTypes.ts
@@ -187,6 +187,7 @@ export type ClientMessage =
   | { EquipItem: { instance_id: number } }
   | { UnequipItem: { slot: EquipSlot } }
   | { DropItem: { instance_id: number } }
+  | { DropItems: { items: BagLineItem[] } }
   | 'PickupStarted'
   | { PickupItem: { instance_id: number } }
   | { UseItem: { instance_id: number } }
@@ -195,7 +196,23 @@ export type ClientMessage =
   | { BuyItem: { merchant_player_id: number; item_def_id: string } }
   | { SellItem: { merchant_player_id: number; instance_id: number } }
   | { BuybackItem: { merchant_player_id: number; entry_id: number } }
+  | { BuyItems: { merchant_player_id: number; items: TradeLineItem[] } }
+  | { SellItems: { merchant_player_id: number; items: BagLineItem[] } }
+  | { BuybackItems: { merchant_player_id: number; entry_ids: number[] } }
   | { EnvReport: ClientEnvReport }
+
+/** One line of a batched `BuyItems` request: buy `qty` units of one item def. */
+export type TradeLineItem = {
+  item_def_id: string
+  qty: number
+}
+
+/** One line of a batched `SellItems`/`DropItems` request: act on `qty` units
+ *  of one bag stack. */
+export type BagLineItem = {
+  instance_id: number
+  qty: number
+}
 
 export type EquipSlot =
   | 'head'

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -1,7 +1,9 @@
 import type {
+  BagLineItem,
   FishingAction,
   Position,
   PositionCorrection,
+  TradeLineItem,
 } from './networkTypes'
 import { hmrSingleton } from '../utils/hmr'
 import type { MonsterData } from '../types/Monster'
@@ -589,6 +591,14 @@ class NetworkManager {
     this.sendMessage({ DropItem: { instance_id: instanceId } })
   }
 
+  sendDropItems(items: BagLineItem[]) {
+    const valid = items.filter((i) =>
+      this.isNetworkableInstanceId(i.instance_id, 'drop')
+    )
+    if (valid.length === 0) return
+    this.sendMessage({ DropItems: { items: valid } })
+  }
+
   /// Sent at the pickup clip's first frame so nearby players see the crouch
   /// from the top; `sendPickupItem` follows at the grab moment.
   sendPickupStarted() {
@@ -654,6 +664,33 @@ class NetworkManager {
   sendBuybackItem(merchantPlayerId: number, entryId: number) {
     this.sendMessage({
       BuybackItem: { merchant_player_id: merchantPlayerId, entry_id: entryId },
+    })
+  }
+
+  sendBuyItems(merchantPlayerId: number, items: TradeLineItem[]) {
+    if (items.length === 0) return
+    this.sendMessage({
+      BuyItems: { merchant_player_id: merchantPlayerId, items },
+    })
+  }
+
+  sendSellItems(merchantPlayerId: number, items: BagLineItem[]) {
+    const valid = items.filter((i) =>
+      this.isNetworkableInstanceId(i.instance_id, 'sell')
+    )
+    if (valid.length === 0) return
+    this.sendMessage({
+      SellItems: { merchant_player_id: merchantPlayerId, items: valid },
+    })
+  }
+
+  sendBuybackItems(merchantPlayerId: number, entryIds: number[]) {
+    if (entryIds.length === 0) return
+    this.sendMessage({
+      BuybackItems: {
+        merchant_player_id: merchantPlayerId,
+        entry_ids: entryIds,
+      },
     })
   }
 

--- a/client/src/lib/stores/dragStore.ts
+++ b/client/src/lib/stores/dragStore.ts
@@ -10,6 +10,10 @@ export type DragMeta = {
   equipSlot: EquipSlot | null
   source: { type: 'bag' } | { type: 'equipped'; slot: EquipSlot }
   icon: string
+  /** Set when dragging a multi-item Select-mode selection instead of a
+   *  single slot, so the ghost can show one icon + quantity per item
+   *  instead of the single main icon. */
+  groupItems?: { icon: string; quantity: number }[]
 }
 
 export const dragMeta = writable<DragMeta | null>(null)
@@ -78,7 +82,15 @@ const DRAG_THRESHOLD_SQ = 64
 export function startDrag(
   e: PointerEvent,
   meta: DragMeta,
-  onDrop: (x: number, y: number) => void
+  onDrop: (x: number, y: number) => void,
+  /** Fired instead of `onDrop` when the pointer never moved past the drag
+   *  threshold (a plain tap/click). Callers must not *also* bind a native
+   *  `click` handler for this: pointer capture keeps the browser's own click
+   *  event targeted at this element even after a real drag ends elsewhere,
+   *  so a separate click listener fires a spurious extra toggle right after
+   *  a completed drag — this callback is gated on this gesture's own
+   *  `started` flag instead, which never has that false positive. */
+  onClick?: () => void
 ) {
   const target = e.currentTarget as HTMLElement
   target.setPointerCapture(e.pointerId)
@@ -113,13 +125,18 @@ export function startDrag(
     if (target.hasPointerCapture(ue.pointerId)) {
       target.releasePointerCapture(ue.pointerId)
     }
-    if (started && ue.type !== 'pointercancel') {
-      // Quickslot drops work from every drag source and win over the source's
-      // own targets, so resolve them here — the bar's highlight uses the same
-      // test, and no call site can implement (or forget) it differently.
-      const qsIndex = quickslotAt(ue.clientX, ue.clientY)
-      if (qsIndex >= 0) assignQuickslot(qsIndex, meta.defId)
-      else onDrop(ue.clientX, ue.clientY)
+    if (ue.type !== 'pointercancel') {
+      if (started) {
+        // Quickslot drops work from every drag source and win over the
+        // source's own targets, so resolve them here — the bar's highlight
+        // uses the same test, and no call site can implement (or forget) it
+        // differently.
+        const qsIndex = quickslotAt(ue.clientX, ue.clientY)
+        if (qsIndex >= 0) assignQuickslot(qsIndex, meta.defId)
+        else onDrop(ue.clientX, ue.clientY)
+      } else {
+        onClick?.()
+      }
     }
     dragMeta.set(null)
   }

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1477,6 +1477,12 @@ async fn handle_client_message(
             }
         }
 
+        ClientMessage::DropItems { items } => {
+            if let Some(id) = &state.player_id {
+                game_state.drop_items(id, items).await;
+            }
+        }
+
         ClientMessage::PickupStarted => {
             if let Some(id) = &state.player_id {
                 game_state.broadcast_pickup_animation(id).await;
@@ -1572,6 +1578,35 @@ async fn handle_client_message(
             if let Some(id) = &state.player_id {
                 game_state
                     .buyback_item(id, &merchant_player_id, entry_id)
+                    .await;
+            }
+        }
+
+        ClientMessage::BuyItems {
+            merchant_player_id,
+            items,
+        } => {
+            if let Some(id) = &state.player_id {
+                game_state.buy_items(id, &merchant_player_id, items).await;
+            }
+        }
+
+        ClientMessage::SellItems {
+            merchant_player_id,
+            items,
+        } => {
+            if let Some(id) = &state.player_id {
+                game_state.sell_items(id, &merchant_player_id, items).await;
+            }
+        }
+
+        ClientMessage::BuybackItems {
+            merchant_player_id,
+            entry_ids,
+        } => {
+            if let Some(id) = &state.player_id {
+                game_state
+                    .buyback_items(id, &merchant_player_id, entry_ids)
                     .await;
             }
         }

--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use crate::auth::{AuthService, ItemRow};
 use crate::item_defs::UseEffect;
 use crate::types::{PlayerId, ServerMessage};
 use crate::world_config::world_config;
 use onlinerpg_shared::inventory::{EquipSlot, GroundItem, ItemInstance, PlayerInventory};
+use onlinerpg_shared::messages::BagLineItem;
 use rand::Rng;
 use tracing::{info, warn};
 
@@ -996,6 +999,109 @@ impl super::GameState {
         // Dropping the equipped rod is as much "putting it away" as
         // unequipping it — same mid-session abort.
         self.abort_fishing_if_rod_lost(player_id).await;
+    }
+
+    /// Drop multiple bag stacks (partial quantities allowed) in one
+    /// all-or-nothing transaction: every line is validated against the bag
+    /// before anything is removed. Bag-only — unlike `drop_item`, there is no
+    /// equipped-slot fallback, since batch selection only ever offers bag
+    /// items. `GroundItem` has no quantity field, so each unit lands as its
+    /// own scattered ground item rather than one N-quantity entity.
+    pub async fn drop_items(&self, player_id: &PlayerId, items: Vec<BagLineItem>) {
+        if items.is_empty() {
+            return;
+        }
+        let (player_position, rotation, floor_level) = {
+            let players = self.players.read().await;
+            match players.get(player_id) {
+                Some(p) => (p.position, p.rotation, p.floor_level),
+                None => return,
+            }
+        };
+
+        struct Plan {
+            instance_id: u64,
+            qty: u32,
+            item_def_id: String,
+            enchant: i32,
+        }
+
+        let mut reserved: HashMap<u64, u32> = HashMap::new();
+        let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
+
+        let snapshot = {
+            let mut inventories = self.inventories.write().await;
+            let Some(inv) = inventories.get_mut(player_id) else {
+                return;
+            };
+
+            for req in &items {
+                if req.qty == 0 {
+                    continue;
+                }
+                let Some(item) = inv.bag.iter().find(|i| i.instance_id == req.instance_id) else {
+                    drop(inventories);
+                    self.send_system_message(player_id, "Item not found").await;
+                    return;
+                };
+                let already = *reserved.get(&req.instance_id).unwrap_or(&0);
+                if already + req.qty > item.quantity {
+                    drop(inventories);
+                    self.send_system_message(player_id, "Not enough of that item")
+                        .await;
+                    return;
+                }
+                reserved.insert(req.instance_id, already + req.qty);
+                plans.push(Plan {
+                    instance_id: req.instance_id,
+                    qty: req.qty,
+                    item_def_id: item.item_def_id.clone(),
+                    enchant: item.enchant,
+                });
+            }
+            if plans.is_empty() {
+                drop(inventories);
+                return;
+            }
+
+            // Every line is now guaranteed to apply cleanly — mutate.
+            for plan in &plans {
+                let idx = inv
+                    .bag
+                    .iter()
+                    .position(|i| i.instance_id == plan.instance_id)
+                    .expect("checked above");
+                if inv.bag[idx].quantity > plan.qty {
+                    inv.bag[idx].quantity -= plan.qty;
+                } else {
+                    inv.bag.remove(idx);
+                }
+            }
+            inv.clone()
+        };
+
+        self.mark_inventory_dirty(player_id).await;
+        self.send_inventory_snapshot(player_id, snapshot).await;
+
+        let total_units: u32 = plans.iter().map(|p| p.qty).sum();
+        let mut next_ground_id = self.reserve_instance_ids(total_units as u64).await;
+        for plan in &plans {
+            for _ in 0..plan.qty {
+                let preferred = drop_landing_position(player_position, rotation);
+                let position = self
+                    .loot_drop_position(player_position, floor_level, preferred)
+                    .await;
+                self.spawn_ground_item(GroundItem {
+                    instance_id: next_ground_id,
+                    item_def_id: plan.item_def_id.clone(),
+                    position,
+                    floor_level,
+                    enchant: plan.enchant,
+                })
+                .await;
+                next_ground_id += 1;
+            }
+        }
     }
 
     pub async fn debug_drop_item(&self, player_id: &PlayerId, item_def_id: &str) {

--- a/server/src/game_state/tests/trading_tests/batch_tests.rs
+++ b/server/src/game_state/tests/trading_tests/batch_tests.rs
@@ -1,0 +1,298 @@
+use super::*;
+use onlinerpg_shared::messages::{BagLineItem, TradeLineItem};
+
+// --- Batched sell/buy/drop (bag-cleanup UX: quantity popups + one
+// all-or-nothing round trip instead of N single-unit calls) ---
+
+#[tokio::test]
+async fn sell_items_batch_sells_partial_quantity_and_records_one_buyback_per_unit() {
+    let game_state = make_test_game_state("batch_sell_partial");
+    game_state
+        .add_player(make_npc("npc_rica", "Rica", 0.0, 0.0))
+        .await;
+    game_state.add_player(make_player("seller", 1.0, 0.0)).await;
+    game_state
+        .register_player_character(&pid("seller"), 1, 0, attrs_with_cha(10), 0, None)
+        .await;
+    game_state.inventories.write().await.insert(
+        pid("seller"),
+        PlayerInventory {
+            bag: vec![bag_item(7, "healing_potion", 5)],
+            ..Default::default()
+        },
+    );
+
+    // Rica: 40% sell rate, healing_potion base 600 -> 240/unit.
+    game_state
+        .sell_items(
+            &pid("seller"),
+            &pid("npc_rica"),
+            vec![BagLineItem {
+                instance_id: 7,
+                qty: 3,
+            }],
+        )
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 720);
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("seller")].bag;
+    assert_eq!(bag.len(), 1, "the remaining 2 units stay as one stack");
+    assert_eq!(bag[0].quantity, 2);
+}
+
+#[tokio::test]
+async fn sell_items_batch_is_all_or_nothing_when_a_line_is_invalid() {
+    let game_state = make_test_game_state("batch_sell_atomic");
+    game_state
+        .add_player(make_npc("npc_rica", "Rica", 0.0, 0.0))
+        .await;
+    game_state.add_player(make_player("seller", 1.0, 0.0)).await;
+    game_state
+        .register_player_character(&pid("seller"), 1, 0, attrs_with_cha(10), 0, None)
+        .await;
+    game_state.inventories.write().await.insert(
+        pid("seller"),
+        PlayerInventory {
+            bag: vec![bag_item(7, "healing_potion", 5)],
+            ..Default::default()
+        },
+    );
+    let mut seller_rx = game_state.register_direct_channel(&pid("seller")).await;
+
+    // Second line references an instance_id that doesn't exist in the bag.
+    game_state
+        .sell_items(
+            &pid("seller"),
+            &pid("npc_rica"),
+            vec![
+                BagLineItem {
+                    instance_id: 7,
+                    qty: 3,
+                },
+                BagLineItem {
+                    instance_id: 999,
+                    qty: 1,
+                },
+            ],
+        )
+        .await;
+
+    assert_eq!(
+        game_state.get_player_gold(&pid("seller")).await,
+        0,
+        "no partial payout"
+    );
+    let inventories = game_state.inventories.read().await;
+    assert_eq!(
+        inventories[&pid("seller")].bag[0].quantity,
+        5,
+        "the valid line must not apply either"
+    );
+    match seller_rx.try_recv() {
+        Ok(ServerMessage::TradeError { .. }) => {}
+        other => panic!("Expected TradeError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn sell_items_batch_resident_is_all_or_nothing_on_insufficient_wallet() {
+    let game_state = make_test_game_state("batch_sell_resident_atomic");
+    game_state
+        .add_player(make_npc("npc_karl", "Karl", 0.0, 0.0))
+        .await;
+    game_state.add_player(make_player("seller", 1.0, 0.0)).await;
+    game_state
+        .register_player_character(&pid("seller"), 1, 0, attrs_with_cha(10), 0, None)
+        .await;
+    game_state
+        .register_player_character(&pid("npc_karl"), 2, 0, attrs_with_cha(10), 100, None)
+        .await;
+    // Torches aren't stackable, so two purchased separately stay as two
+    // instances; Karl's wishlist pays 60 each (base 50 @ 120%) — 120 total,
+    // more than his 100-copper wallet.
+    game_state.inventories.write().await.insert(
+        pid("seller"),
+        PlayerInventory {
+            bag: vec![bag_item(1, "torch", 1), bag_item(2, "torch", 1)],
+            ..Default::default()
+        },
+    );
+    game_state
+        .inventories
+        .write()
+        .await
+        .insert(pid("npc_karl"), PlayerInventory::default());
+
+    game_state
+        .sell_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![
+                BagLineItem {
+                    instance_id: 1,
+                    qty: 1,
+                },
+                BagLineItem {
+                    instance_id: 2,
+                    qty: 1,
+                },
+            ],
+        )
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 0);
+    assert_eq!(game_state.get_player_gold(&pid("npc_karl")).await, 100);
+    let inventories = game_state.inventories.read().await;
+    assert_eq!(
+        inventories[&pid("seller")].bag.len(),
+        2,
+        "both torches kept"
+    );
+    assert!(inventories[&pid("npc_karl")].bag.is_empty());
+}
+
+#[tokio::test]
+async fn buy_items_batch_merges_stackables_and_splits_non_stackables() {
+    let game_state = make_test_game_state("batch_buy");
+    game_state
+        .add_player(make_npc("npc_rica", "Rica", 0.0, 0.0))
+        .await;
+    game_state.add_player(make_player("buyer", 1.0, 0.0)).await;
+    game_state
+        .register_player_character(&pid("buyer"), 1, 0, attrs_with_cha(10), 10_000, None)
+        .await;
+    game_state.inventories.write().await.insert(
+        pid("buyer"),
+        PlayerInventory {
+            bag: vec![bag_item(5, "healing_potion", 2)],
+            ..Default::default()
+        },
+    );
+
+    game_state
+        .buy_items(
+            &pid("buyer"),
+            &pid("npc_rica"),
+            vec![
+                TradeLineItem {
+                    item_def_id: "healing_potion".to_string(),
+                    qty: 3,
+                },
+                TradeLineItem {
+                    item_def_id: "torch".to_string(),
+                    qty: 2,
+                },
+            ],
+        )
+        .await;
+
+    // healing_potion (600 * 3) + torch (50 * 2) = 1900.
+    assert_eq!(
+        game_state.get_player_gold(&pid("buyer")).await,
+        10_000 - 1_900
+    );
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("buyer")].bag;
+    let potion = bag
+        .iter()
+        .find(|i| i.item_def_id == "healing_potion")
+        .expect("existing stack kept");
+    assert_eq!(
+        potion.instance_id, 5,
+        "merged into the existing stack, not a new one"
+    );
+    assert_eq!(potion.quantity, 5);
+    let torches: Vec<_> = bag.iter().filter(|i| i.item_def_id == "torch").collect();
+    assert_eq!(
+        torches.len(),
+        2,
+        "non-stackable units stay as separate instances"
+    );
+    assert!(torches.iter().all(|t| t.quantity == 1));
+}
+
+#[tokio::test]
+async fn drop_items_batch_drops_partial_quantity_and_spawns_one_ground_item_per_unit() {
+    let game_state = make_test_game_state("batch_drop_partial");
+    game_state.add_player(make_player("owner", 1.0, 0.0)).await;
+    game_state.inventories.write().await.insert(
+        pid("owner"),
+        PlayerInventory {
+            bag: vec![bag_item(20, "healing_potion", 5), bag_item(21, "torch", 1)],
+            ..Default::default()
+        },
+    );
+
+    game_state
+        .drop_items(
+            &pid("owner"),
+            vec![
+                BagLineItem {
+                    instance_id: 20,
+                    qty: 3,
+                },
+                BagLineItem {
+                    instance_id: 21,
+                    qty: 1,
+                },
+            ],
+        )
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("owner")].bag;
+    assert_eq!(bag.len(), 1, "the torch stack is fully consumed");
+    assert_eq!(bag[0].item_def_id, "healing_potion");
+    assert_eq!(bag[0].quantity, 2);
+    drop(inventories);
+
+    let ground_items = game_state.ground_items.read().await;
+    assert_eq!(
+        ground_items.len(),
+        4,
+        "3 potions + 1 torch land as 4 separate ground items"
+    );
+    let potions = ground_items
+        .values()
+        .filter(|gi| gi.item.item_def_id == "healing_potion")
+        .count();
+    assert_eq!(potions, 3);
+}
+
+#[tokio::test]
+async fn drop_items_batch_is_all_or_nothing_when_quantity_exceeds_the_stack() {
+    let game_state = make_test_game_state("batch_drop_atomic");
+    game_state.add_player(make_player("owner", 1.0, 0.0)).await;
+    game_state.inventories.write().await.insert(
+        pid("owner"),
+        PlayerInventory {
+            bag: vec![bag_item(30, "healing_potion", 2)],
+            ..Default::default()
+        },
+    );
+    let mut owner_rx = game_state.register_direct_channel(&pid("owner")).await;
+
+    game_state
+        .drop_items(
+            &pid("owner"),
+            vec![BagLineItem {
+                instance_id: 30,
+                qty: 5,
+            }],
+        )
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    assert_eq!(
+        inventories[&pid("owner")].bag[0].quantity,
+        2,
+        "nothing dropped"
+    );
+    drop(inventories);
+    assert!(game_state.ground_items.read().await.is_empty());
+    match owner_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { .. }) => {}
+        other => panic!("Expected SystemMessage, got {:?}", other),
+    }
+}

--- a/server/src/game_state/tests/trading_tests/mod.rs
+++ b/server/src/game_state/tests/trading_tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod batch_tests;
 mod buyback_tests;
 mod merchant_tests;
 mod resident_tests;

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -1,12 +1,14 @@
+use std::collections::HashMap;
+
 use crate::merchant_defs::{merchant_defs, MerchantDefinition};
 use crate::npc_defs::{npc_defs, NpcDefinition};
 use crate::types::{PlayerId, ServerMessage};
 use onlinerpg_shared::inventory::ItemInstance;
-use onlinerpg_shared::messages::{BuybackEntry, DealKind, StockEntry};
+use onlinerpg_shared::messages::{BagLineItem, BuybackEntry, DealKind, StockEntry, TradeLineItem};
 use tracing::info;
 
 use super::combat::reachable_dist_sq;
-use super::deals::{buy_price, deal_half_band_pct, resident_half_band_pct, sell_payout};
+use super::deals::{buy_price, deal_half_band_pct, resident_half_band_pct, sell_payout, DealEntry};
 use super::StoredBuyback;
 
 /// Maximum distance between player and trader for any shop interaction.
@@ -601,6 +603,288 @@ impl super::GameState {
         .await;
     }
 
+    /// Buy multiple units, possibly of different items, in one all-or-nothing
+    /// transaction: every line is validated (catalog/wishlist membership,
+    /// resident stock, carry weight, player gold) before anything is
+    /// mutated. Mirrors `buy_item`'s per-unit rules, generalized to N lines,
+    /// and merges each purchase into an existing matching bag stack instead
+    /// of always creating a new one-unit entry.
+    pub async fn buy_items(
+        &self,
+        player_id: &PlayerId,
+        npc_player_id: &PlayerId,
+        items: Vec<TradeLineItem>,
+    ) {
+        if items.is_empty() {
+            return;
+        }
+        let def = match self.validate_trader(player_id, npc_player_id).await {
+            Ok(def) => def,
+            Err(reason) => return self.send_trade_error(player_id, reason).await,
+        };
+        let npc_name = def.npc_name().to_string();
+        let is_resident = matches!(def, TraderDef::Resident(_));
+
+        struct Plan {
+            item_def_id: String,
+            qty: u32,
+            base_price: i64,
+            deal_taken: Option<DealEntry>,
+            price: i64,
+        }
+
+        let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
+        let mut requested: HashMap<String, u32> = HashMap::new();
+        for req in &items {
+            if req.qty == 0 {
+                continue;
+            }
+            match &def {
+                TraderDef::Merchant(m) => {
+                    if !m.sells(&req.item_def_id) {
+                        return self
+                            .send_trade_error(player_id, "The merchant does not sell that item")
+                            .await;
+                    }
+                }
+                TraderDef::Resident(r) => {
+                    if r.wants(&req.item_def_id) {
+                        return self
+                            .send_trade_error(player_id, "They won't part with that")
+                            .await;
+                    }
+                }
+            }
+            let Some(base_price) = self
+                .item_defs
+                .get(&req.item_def_id)
+                .and_then(|item| item.base_price)
+            else {
+                return self
+                    .send_trade_error(player_id, "That item has no price")
+                    .await;
+            };
+            *requested.entry(req.item_def_id.clone()).or_insert(0) += req.qty;
+            plans.push(Plan {
+                item_def_id: req.item_def_id.clone(),
+                qty: req.qty,
+                base_price,
+                deal_taken: None,
+                price: 0,
+            });
+        }
+        if plans.is_empty() {
+            return;
+        }
+
+        let mut gold_map = self.player_gold.write().await;
+        let mut inventories = self.inventories.write().await;
+
+        if inventories.get(player_id).is_none() {
+            drop(inventories);
+            drop(gold_map);
+            return self.send_trade_error(player_id, "Player not found").await;
+        }
+
+        if is_resident {
+            let Some(npc_inv) = inventories.get(npc_player_id) else {
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "They have nothing to sell")
+                    .await;
+            };
+            for (item_def_id, qty) in &requested {
+                let available: u32 = npc_inv
+                    .bag
+                    .iter()
+                    .filter(|i| &i.item_def_id == item_def_id)
+                    .map(|i| i.quantity)
+                    .sum();
+                if available < *qty {
+                    drop(inventories);
+                    drop(gold_map);
+                    return self
+                        .send_trade_error(player_id, "They are out of that item")
+                        .await;
+                }
+            }
+        }
+
+        let max_weight = self.max_carry_weight(player_id).await;
+        let added_weight: f32 = plans
+            .iter()
+            .map(|p| self.item_defs.weight(&p.item_def_id) * p.qty as f32)
+            .sum();
+        if self.calc_total_weight(&inventories[player_id]) + added_weight > max_weight {
+            drop(inventories);
+            drop(gold_map);
+            return self.send_trade_error(player_id, "Too heavy to carry").await;
+        }
+
+        let mut total_price: i64 = 0;
+        for plan in &mut plans {
+            let deal = self
+                .take_deal(player_id, &npc_name, &plan.item_def_id, DealKind::Buy)
+                .await;
+            let deal_units: u32 = if deal.is_some() { 1 } else { 0 };
+            let normal_units = plan.qty - deal_units;
+            let price = buy_price(plan.base_price, deal.as_ref().map_or(0, |d| d.modifier_pct))
+                * deal_units as i64
+                + buy_price(plan.base_price, 0) * normal_units as i64;
+            plan.deal_taken = deal;
+            plan.price = price;
+            total_price += price;
+        }
+
+        let gold = gold_map.get(player_id).copied().unwrap_or(0);
+        if gold < total_price {
+            for plan in &plans {
+                self.restore_deal(
+                    player_id,
+                    &npc_name,
+                    &plan.item_def_id,
+                    DealKind::Buy,
+                    plan.deal_taken.clone(),
+                )
+                .await;
+            }
+            drop(inventories);
+            drop(gold_map);
+            return self.send_trade_error(player_id, "Not enough gold").await;
+        }
+
+        // Every line is now guaranteed to apply cleanly — mutate.
+        if is_resident {
+            let npc_inv = inventories.get_mut(npc_player_id).expect("checked above");
+            for (item_def_id, mut remaining) in requested {
+                while remaining > 0 {
+                    let idx = npc_inv
+                        .bag
+                        .iter()
+                        .position(|i| i.item_def_id == item_def_id)
+                        .expect("availability checked above");
+                    let take = remaining.min(npc_inv.bag[idx].quantity);
+                    if npc_inv.bag[idx].quantity > take {
+                        npc_inv.bag[idx].quantity -= take;
+                    } else {
+                        npc_inv.bag.remove(idx);
+                    }
+                    remaining -= take;
+                }
+            }
+        }
+
+        {
+            let inv = inventories.get_mut(player_id).expect("checked above");
+            for plan in &plans {
+                let stackable = self
+                    .item_defs
+                    .get(&plan.item_def_id)
+                    .map(|d| d.stackable)
+                    .unwrap_or(false);
+                let existing = stackable.then(|| {
+                    inv.bag
+                        .iter_mut()
+                        .find(|i| i.item_def_id == plan.item_def_id && i.enchant == 0)
+                });
+                match existing.flatten() {
+                    Some(stack) => stack.quantity += plan.qty,
+                    // Non-stackable items (e.g. weapons) always take one bag
+                    // slot per unit, so N units become N separate instances
+                    // instead of one instance with quantity N.
+                    None if !stackable => {
+                        for _ in 0..plan.qty {
+                            let instance_id = self.next_instance_id().await;
+                            inv.bag.push(ItemInstance {
+                                instance_id,
+                                item_def_id: plan.item_def_id.clone(),
+                                quantity: 1,
+                                enchant: 0,
+                            });
+                        }
+                    }
+                    None => {
+                        let instance_id = self.next_instance_id().await;
+                        inv.bag.push(ItemInstance {
+                            instance_id,
+                            item_def_id: plan.item_def_id.clone(),
+                            quantity: plan.qty,
+                            enchant: 0,
+                        });
+                    }
+                }
+            }
+        }
+
+        let snapshot = inventories.get(player_id).expect("checked above").clone();
+        let npc_snapshot = is_resident.then(|| {
+            inventories
+                .get(npc_player_id)
+                .expect("checked above")
+                .clone()
+        });
+
+        *gold_map.get_mut(player_id).expect("checked above") -= total_price;
+        if is_resident {
+            *gold_map.entry(*npc_player_id).or_insert(0) += total_price;
+        }
+        drop(inventories);
+        drop(gold_map);
+
+        let player_name = self.player_name_of(player_id).await;
+        for plan in &plans {
+            if let Some(entry) = &plan.deal_taken {
+                info!(
+                    target: "deal",
+                    "deal redeemed: npc={npc_name} player={player_name} item={} kind=Buy \
+                     modifier={} base={} paid={}",
+                    plan.item_def_id, entry.modifier_pct, plan.base_price, plan.price
+                );
+                self.send_deal_cleared(player_id, npc_player_id, &plan.item_def_id, DealKind::Buy)
+                    .await;
+            }
+            info!(
+                "{player_name} bought {}x{} from {npc_name} for {}",
+                plan.qty, plan.item_def_id, plan.price
+            );
+        }
+
+        self.mark_dirty(player_id).await;
+        self.mark_inventory_dirty(player_id).await;
+        self.send_direct_message(
+            player_id,
+            ServerMessage::InventoryUpdated {
+                inventory: snapshot,
+            },
+        )
+        .await;
+        self.send_gold_update(player_id).await;
+
+        if let Some(npc_snapshot) = npc_snapshot {
+            self.mark_dirty(npc_player_id).await;
+            self.mark_inventory_dirty(npc_player_id).await;
+            self.send_direct_message(
+                npc_player_id,
+                ServerMessage::InventoryUpdated {
+                    inventory: npc_snapshot,
+                },
+            )
+            .await;
+            self.send_gold_update(npc_player_id).await;
+        }
+        for plan in &plans {
+            self.send_trade_notice(
+                npc_player_id,
+                player_name.clone(),
+                &plan.item_def_id,
+                DealKind::Buy,
+                plan.price,
+            )
+            .await;
+        }
+    }
+
     /// Sell one unit of a bag item to a trading NPC. Merchants pay
     /// `base_price * sell_rate_percent / 100` and the item vanishes;
     /// residents only buy wishlist items, pay their premium rate out of a
@@ -853,6 +1137,308 @@ impl super::GameState {
         .await;
     }
 
+    /// Sell multiple bag stacks in one all-or-nothing transaction: every line
+    /// is validated (ownership, quantity, wishlist, resident carry weight,
+    /// resident wallet) before anything is mutated, so a big cart either
+    /// completes in full or leaves the player's bag/gold untouched. Mirrors
+    /// `sell_item`'s per-unit rules, generalized to N stacks; deals are
+    /// single-use per item def, so within one batch only the first line
+    /// touching a given item def can redeem one.
+    pub async fn sell_items(
+        &self,
+        player_id: &PlayerId,
+        npc_player_id: &PlayerId,
+        items: Vec<BagLineItem>,
+    ) {
+        if items.is_empty() {
+            return;
+        }
+        let def = match self.validate_trader(player_id, npc_player_id).await {
+            Ok(def) => def,
+            Err(reason) => return self.send_trade_error(player_id, reason).await,
+        };
+        let npc_name = def.npc_name().to_string();
+        let is_resident = matches!(def, TraderDef::Resident(_));
+        let rate = match &def {
+            TraderDef::Merchant(m) => m.sell_rate_percent,
+            TraderDef::Resident(r) => r.wishlist_rate_percent,
+        };
+
+        struct Plan {
+            instance_id: u64,
+            qty: u32,
+            item_def_id: String,
+            enchant: i32,
+            base_price: i64,
+            deal_taken: Option<DealEntry>,
+            payout: i64,
+        }
+
+        let mut gold_map = self.player_gold.write().await;
+        let mut inventories = self.inventories.write().await;
+
+        if !gold_map.contains_key(player_id) {
+            drop(inventories);
+            drop(gold_map);
+            return self.send_trade_error(player_id, "Player not found").await;
+        }
+
+        let mut reserved: HashMap<u64, u32> = HashMap::new();
+        let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
+        for req in &items {
+            if req.qty == 0 {
+                continue;
+            }
+            let Some(item) = inventories
+                .get(player_id)
+                .and_then(|inv| inv.bag.iter().find(|i| i.instance_id == req.instance_id))
+            else {
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "Item not found in bag")
+                    .await;
+            };
+            let already_reserved = *reserved.get(&req.instance_id).unwrap_or(&0);
+            if already_reserved + req.qty > item.quantity {
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "Not enough of that item")
+                    .await;
+            }
+            reserved.insert(req.instance_id, already_reserved + req.qty);
+
+            let item_def_id = item.item_def_id.clone();
+            let enchant = item.enchant;
+            let Some(base_price) = self.item_defs.get(&item_def_id).and_then(|d| d.base_price)
+            else {
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "They will not buy that")
+                    .await;
+            };
+            if let TraderDef::Resident(r) = &def {
+                if !r.wants(&item_def_id) {
+                    drop(inventories);
+                    drop(gold_map);
+                    return self
+                        .send_trade_error(player_id, "They have no use for that")
+                        .await;
+                }
+            }
+            plans.push(Plan {
+                instance_id: req.instance_id,
+                qty: req.qty,
+                item_def_id,
+                enchant,
+                base_price,
+                deal_taken: None,
+                payout: 0,
+            });
+        }
+        if plans.is_empty() {
+            drop(inventories);
+            drop(gold_map);
+            return;
+        }
+
+        if is_resident {
+            let npc_max_weight = self.max_carry_weight(npc_player_id).await;
+            let Some(npc_inv) = inventories.get(npc_player_id) else {
+                drop(inventories);
+                drop(gold_map);
+                return self.send_trade_error(player_id, "Trader not found").await;
+            };
+            let added_weight: f32 = plans
+                .iter()
+                .map(|p| self.item_defs.weight(&p.item_def_id) * p.qty as f32)
+                .sum();
+            if self.calc_total_weight(npc_inv) + added_weight > npc_max_weight {
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "They cannot carry any more")
+                    .await;
+            }
+        }
+
+        // Redeem any single-use deals now (each is consumed at most once
+        // across the whole batch) and price every line; restore them all if
+        // the resident wallet check below then fails.
+        let mut total_payout: i64 = 0;
+        for plan in &mut plans {
+            let deal = self
+                .take_deal(player_id, &npc_name, &plan.item_def_id, DealKind::Sell)
+                .await;
+            let deal_units: u32 = if deal.is_some() { 1 } else { 0 };
+            let normal_units = plan.qty - deal_units;
+            let payout = sell_payout(
+                plan.base_price,
+                rate,
+                deal.as_ref().map_or(0, |d| d.modifier_pct),
+            ) * deal_units as i64
+                + sell_payout(plan.base_price, rate, 0) * normal_units as i64;
+            plan.deal_taken = deal;
+            plan.payout = payout;
+            total_payout += payout;
+        }
+
+        if is_resident {
+            let npc_gold = gold_map.get(npc_player_id).copied().unwrap_or(0);
+            if npc_gold < total_payout {
+                for plan in &plans {
+                    self.restore_deal(
+                        player_id,
+                        &npc_name,
+                        &plan.item_def_id,
+                        DealKind::Sell,
+                        plan.deal_taken.clone(),
+                    )
+                    .await;
+                }
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "They cannot afford that right now")
+                    .await;
+            }
+        }
+
+        // Every line is now guaranteed to apply cleanly — mutate.
+        for plan in &plans {
+            let inv = inventories.get_mut(player_id).expect("checked above");
+            let idx = inv
+                .bag
+                .iter()
+                .position(|i| i.instance_id == plan.instance_id)
+                .expect("checked above");
+            if inv.bag[idx].quantity > plan.qty {
+                inv.bag[idx].quantity -= plan.qty;
+            } else {
+                inv.bag.remove(idx);
+            }
+
+            if is_resident {
+                let npc_instance_id = self.next_instance_id().await;
+                let npc_inv = inventories.get_mut(npc_player_id).expect("checked above");
+                npc_inv.bag.push(ItemInstance {
+                    instance_id: npc_instance_id,
+                    item_def_id: plan.item_def_id.clone(),
+                    quantity: plan.qty,
+                    enchant: plan.enchant,
+                });
+            }
+        }
+
+        let snapshot = inventories.get(player_id).expect("checked above").clone();
+        let npc_snapshot = is_resident.then(|| {
+            inventories
+                .get(npc_player_id)
+                .expect("checked above")
+                .clone()
+        });
+
+        *gold_map.get_mut(player_id).expect("checked above") += total_payout;
+        if is_resident {
+            *gold_map.get_mut(npc_player_id).expect("checked above") -= total_payout;
+        }
+        drop(inventories);
+        drop(gold_map);
+
+        // Merchants keep no stock, so each sold unit becomes a separate
+        // buyback entry at its normal per-unit price — same granularity as a
+        // single-item sell, just recorded once per plan line instead of
+        // requiring N round trips. The one discounted/bonus unit a deal
+        // applied to is intentionally not separately buyback-able at its
+        // haggled price; the normal rate is what repurchasing costs.
+        let mut latest_buyback = None;
+        if !is_resident {
+            for plan in &plans {
+                let unit_price = sell_payout(plan.base_price, rate, 0);
+                for _ in 0..plan.qty {
+                    let entry_id = self.next_instance_id().await;
+                    latest_buyback = Some(
+                        self.record_buyback(
+                            player_id,
+                            &npc_name,
+                            BuybackEntry {
+                                entry_id,
+                                item_def_id: plan.item_def_id.clone(),
+                                enchant: plan.enchant,
+                                price: unit_price,
+                            },
+                        )
+                        .await,
+                    );
+                }
+            }
+        }
+        if let Some(buyback) = latest_buyback {
+            self.send_direct_message(
+                player_id,
+                ServerMessage::BuybackUpdated {
+                    merchant_player_id: *npc_player_id,
+                    buyback,
+                },
+            )
+            .await;
+        }
+
+        let player_name = self.player_name_of(player_id).await;
+        for plan in &plans {
+            if let Some(entry) = &plan.deal_taken {
+                info!(
+                    target: "deal",
+                    "deal redeemed: npc={npc_name} player={player_name} item={} kind=Sell \
+                     modifier={} base={} paid={}",
+                    plan.item_def_id, entry.modifier_pct, plan.base_price, plan.payout
+                );
+                self.send_deal_cleared(player_id, npc_player_id, &plan.item_def_id, DealKind::Sell)
+                    .await;
+            }
+            info!(
+                "{player_name} sold {}x{} to {npc_name} for {}",
+                plan.qty, plan.item_def_id, plan.payout
+            );
+        }
+
+        self.mark_dirty(player_id).await;
+        self.mark_inventory_dirty(player_id).await;
+        self.send_direct_message(
+            player_id,
+            ServerMessage::InventoryUpdated {
+                inventory: snapshot,
+            },
+        )
+        .await;
+        self.send_gold_update(player_id).await;
+
+        if let Some(npc_snapshot) = npc_snapshot {
+            self.mark_dirty(npc_player_id).await;
+            self.mark_inventory_dirty(npc_player_id).await;
+            self.send_direct_message(
+                npc_player_id,
+                ServerMessage::InventoryUpdated {
+                    inventory: npc_snapshot,
+                },
+            )
+            .await;
+            self.send_gold_update(npc_player_id).await;
+        }
+        for plan in &plans {
+            self.send_trade_notice(
+                npc_player_id,
+                player_name.clone(),
+                &plan.item_def_id,
+                DealKind::Sell,
+                plan.payout,
+            )
+            .await;
+        }
+    }
+
     /// The character behind a live player session, if any.
     pub(crate) async fn character_id_of(&self, player_id: &PlayerId) -> Option<i64> {
         let characters = self.player_characters.read().await;
@@ -1040,5 +1626,177 @@ impl super::GameState {
             entry.price,
         )
         .await;
+    }
+
+    /// Repurchase multiple buyback entries in one all-or-nothing transaction:
+    /// every entry must still be present and unexpired, and the combined
+    /// price/weight must fit, before any of them are taken.
+    pub async fn buyback_items(
+        &self,
+        player_id: &PlayerId,
+        npc_player_id: &PlayerId,
+        entry_ids: Vec<u64>,
+    ) {
+        if entry_ids.is_empty() {
+            return;
+        }
+        let unique: std::collections::HashSet<u64> = entry_ids.iter().copied().collect();
+        if unique.len() != entry_ids.len() {
+            return self
+                .send_trade_error(player_id, "Duplicate item in request")
+                .await;
+        }
+
+        let def = match self.validate_trader(player_id, npc_player_id).await {
+            Ok(def) => def,
+            Err(reason) => return self.send_trade_error(player_id, reason).await,
+        };
+        let TraderDef::Merchant(def) = def else {
+            return self
+                .send_trade_error(player_id, "They have nothing to buy back")
+                .await;
+        };
+        let npc_name = def.npc_name.clone();
+        let Some(char_id) = self.character_id_of(player_id).await else {
+            return;
+        };
+
+        let now_ms = Self::now_ms();
+        self.sweep_buybacks(now_ms).await;
+
+        let entries: Vec<BuybackEntry> = {
+            let buybacks = self.buybacks.read().await;
+            let Some(list) = buybacks.get(&(char_id, npc_name.clone())) else {
+                return self
+                    .send_trade_error(player_id, "That item is no longer available")
+                    .await;
+            };
+            let mut resolved = Vec::with_capacity(entry_ids.len());
+            for id in &entry_ids {
+                let Some(stored) = list
+                    .iter()
+                    .find(|s| s.entry.entry_id == *id && s.expires_at_ms > now_ms)
+                else {
+                    return self
+                        .send_trade_error(player_id, "That item is no longer available")
+                        .await;
+                };
+                resolved.push(stored.entry.clone());
+            }
+            resolved
+        };
+
+        let total_price: i64 = entries.iter().map(|e| e.price).sum();
+        let added_weight: f32 = entries
+            .iter()
+            .map(|e| self.item_defs.weight(&e.item_def_id))
+            .sum();
+        let max_weight = self.max_carry_weight(player_id).await;
+
+        let (snapshot, buyback) = {
+            let mut gold_map = self.player_gold.write().await;
+            let Some(gold) = gold_map.get(player_id).copied() else {
+                drop(gold_map);
+                return;
+            };
+            if gold < total_price {
+                drop(gold_map);
+                return self.send_trade_error(player_id, "Not enough gold").await;
+            }
+
+            let mut inventories = self.inventories.write().await;
+            if inventories.get(player_id).is_none() {
+                drop(inventories);
+                drop(gold_map);
+                return;
+            }
+            if self.calc_total_weight(&inventories[player_id]) + added_weight > max_weight {
+                drop(inventories);
+                drop(gold_map);
+                return self.send_trade_error(player_id, "Too heavy to carry").await;
+            }
+
+            // Re-validate every entry is still present before removing any of
+            // them, so a concurrent repurchase racing this one can't leave the
+            // batch half-applied.
+            let mut buybacks = self.buybacks.write().await;
+            let Some(list) = buybacks.get_mut(&(char_id, npc_name.clone())) else {
+                drop(buybacks);
+                drop(inventories);
+                drop(gold_map);
+                return self
+                    .send_trade_error(player_id, "That item is no longer available")
+                    .await;
+            };
+            let mut indices = Vec::with_capacity(entry_ids.len());
+            for id in &entry_ids {
+                let Some(idx) = list
+                    .iter()
+                    .position(|s| s.entry.entry_id == *id && s.expires_at_ms > now_ms)
+                else {
+                    drop(buybacks);
+                    drop(inventories);
+                    drop(gold_map);
+                    return self
+                        .send_trade_error(player_id, "That item is no longer available")
+                        .await;
+                };
+                indices.push(idx);
+            }
+            indices.sort_unstable_by(|a, b| b.cmp(a));
+            for idx in indices {
+                list.remove(idx);
+            }
+            let buyback = list.iter().map(|s| s.entry.clone()).collect::<Vec<_>>();
+
+            let inv = inventories.get_mut(player_id).expect("checked above");
+            for entry in &entries {
+                inv.bag.push(ItemInstance {
+                    instance_id: entry.entry_id,
+                    item_def_id: entry.item_def_id.clone(),
+                    quantity: 1,
+                    enchant: entry.enchant,
+                });
+            }
+            let snapshot = inv.clone();
+            *gold_map.get_mut(player_id).expect("checked above") -= total_price;
+            (snapshot, buyback)
+        };
+
+        let player_name = self.player_name_of(player_id).await;
+        for entry in &entries {
+            info!(
+                "{player_name} bought back {} from {npc_name} for {}",
+                entry.item_def_id, entry.price
+            );
+        }
+        self.mark_dirty(player_id).await;
+        self.mark_inventory_dirty(player_id).await;
+        self.send_direct_message(
+            player_id,
+            ServerMessage::InventoryUpdated {
+                inventory: snapshot,
+            },
+        )
+        .await;
+        self.send_gold_update(player_id).await;
+        self.send_direct_message(
+            player_id,
+            ServerMessage::BuybackUpdated {
+                merchant_player_id: *npc_player_id,
+                buyback,
+            },
+        )
+        .await;
+        for entry in &entries {
+            self.send_trade_notice(
+                npc_player_id,
+                player_name.clone(),
+                &entry.item_def_id,
+                DealKind::Buy,
+                entry.price,
+            )
+            .await;
+        }
     }
 }

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -91,7 +91,7 @@ pub struct TradeLineItem {
 
 /// One line of a batched `SellItems` or `DropItems` request: act on `qty`
 /// units of one bag stack.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BagLineItem {
     pub instance_id: u64,
     pub qty: u32,

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -82,6 +82,21 @@ pub struct BuybackEntry {
     pub price: i64,
 }
 
+/// One line of a batched `BuyItems` request: buy `qty` units of one item def.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeLineItem {
+    pub item_def_id: String,
+    pub qty: u32,
+}
+
+/// One line of a batched `SellItems` or `DropItems` request: act on `qty`
+/// units of one bag stack.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BagLineItem {
+    pub instance_id: u64,
+    pub qty: u32,
+}
+
 /// One party member as listed in `PartyState`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartyMember {
@@ -303,6 +318,12 @@ pub enum ClientMessage {
     DropItem {
         instance_id: u64,
     },
+    /// Drop multiple bag stacks (partial quantities allowed) in one
+    /// all-or-nothing transaction, so a multi-item bag cleanup round-trips
+    /// once instead of once per stack.
+    DropItems {
+        items: Vec<BagLineItem>,
+    },
     /// The pickup crouch started. Sent at the clip's first frame, whereas
     /// `PickupItem` waits for the grab moment ~35% in, so nearby players see
     /// the whole animation instead of joining it late.
@@ -339,6 +360,23 @@ pub enum ClientMessage {
     BuybackItem {
         merchant_player_id: PlayerId,
         entry_id: u64,
+    },
+    /// Buy multiple units, possibly of different items, in one all-or-nothing
+    /// transaction (see `SellItems` for the mirror).
+    BuyItems {
+        merchant_player_id: PlayerId,
+        items: Vec<TradeLineItem>,
+    },
+    /// Sell multiple bag stacks (partial quantities allowed) in one
+    /// all-or-nothing transaction.
+    SellItems {
+        merchant_player_id: PlayerId,
+        items: Vec<BagLineItem>,
+    },
+    /// Repurchase multiple buyback entries at once, all-or-nothing.
+    BuybackItems {
+        merchant_player_id: PlayerId,
+        entry_ids: Vec<u64>,
     },
     /// NPC-only (LLM haggling): offer a price modifier on one item to a
     /// nearby player. The server clamps the modifier to the player's price


### PR DESCRIPTION
## Summary

Bag stays always sorted (category → name → qty).
<img width="382" height="766" alt="Screenshot 2026-08-04 at 12 07 15 AM" src="https://github.com/user-attachments/assets/240d577f-6f3b-41e4-ba93-3a46d36cab06" />

New Select mode lets you bulk-drop several different non-stackable items in one drag; the drag ghost shows one icon + quantity per item, consolidating duplicate item defs (e.g. two old_boot pickups) into one `xN` icon instead of one icon per instance.
<img width="1200" alt="Screenshot 2026-08-03 at 11 44 15 PM" src="https://github.com/user-attachments/assets/1b24a189-22ad-4cde-b2cf-ff3e351d17a3" />
<img width="1200" alt="Screenshot 2026-08-03 at 11 44 28 PM" src="https://github.com/user-attachments/assets/de2a27fc-946f-4180-93c0-b24dd44ba389" />

Dropping a stack now also uses the quantity popup.
<img width="1200" alt="Screenshot 2026-08-03 at 11 45 28 PM" src="https://github.com/user-attachments/assets/d4957275-87fc-494a-94f2-6400c9a9777e" />
<img width="1200" alt="Screenshot 2026-08-03 at 11 45 33 PM" src="https://github.com/user-attachments/assets/7c104d46-7af2-4270-af42-2465c9470ae2" />

Bag and the sell window stays always sorted (category → name → qty).
<img width="1200" alt="Screenshot 2026-08-03 at 11 49 29 PM" src="https://github.com/user-attachments/assets/1472daa4-a6bc-45a3-b3a6-a6d901332e8f" />

Trade window Buy/Sell/Buyback now use a quantity popup instead of click-to-stack.
<img width="1200" alt="Screenshot 2026-08-03 at 11 49 42 PM" src="https://github.com/user-attachments/assets/76cd2785-cfd2-45f8-94bb-fd8d69c930f1" />

---

agent-client: sell/drop a specified quantity

The LLM's `sell`/`drop` actions could only ever act on one unit at a time, with repeated calls as the only way to do more. Both now take an optional `qty` — a positive count, or `"all"` of whatever is currently owned — resolved against the live bag when the action runs. Omitting it keeps the existing default of 1.

```json
{"type": "sell", "item": "healing_potion", "merchant": "Rica", "qty": 5}
{"type": "drop", "item": "old_boot", "qty": "all"}
```