### PR TITLE
Stack purchased, granted and picked-up items into existing bag entries

### DIFF
--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -38,6 +38,32 @@ fn enchant_success_bp(enchant: i32) -> u32 {
     }
 }
 
+/// The one bag-insert rule for every acquisition path (buying, loot, grilling,
+/// pickup, login load): units join an existing same-def, same-enchant entry
+/// when the def is stackable, and take their own slot otherwise. `instance_id`
+/// goes unused when the unit stacks.
+pub(super) fn stack_into_bag(
+    bag: &mut Vec<ItemInstance>,
+    stackable: bool,
+    item_def_id: &str,
+    enchant: i32,
+    instance_id: u64,
+    quantity: u32,
+) {
+    match bag
+        .iter_mut()
+        .find(|item| stackable && item.item_def_id == item_def_id && item.enchant == enchant)
+    {
+        Some(stack) => stack.quantity += quantity,
+        None => bag.push(ItemInstance {
+            instance_id,
+            item_def_id: item_def_id.to_string(),
+            quantity,
+            enchant,
+        }),
+    }
+}
+
 /// Remove one unit of `instance_id` from the bag, dropping the instance when
 /// the stack empties.
 fn consume_one(inv: &mut PlayerInventory, instance_id: u64) {
@@ -208,12 +234,20 @@ impl super::GameState {
                         }
                     }
                     None => {
-                        inventory.bag.push(ItemInstance {
+                        // Merging here also heals bags saved before trading
+                        // and pickup learned to stack.
+                        let stackable = self
+                            .item_defs
+                            .get(&row.item_def_id)
+                            .is_some_and(|d| d.stackable);
+                        stack_into_bag(
+                            &mut inventory.bag,
+                            stackable,
+                            &row.item_def_id,
+                            row.enchant,
                             instance_id,
-                            item_def_id: row.item_def_id,
-                            quantity: row.quantity,
-                            enchant: row.enchant,
-                        });
+                            row.quantity,
+                        );
                     }
                 }
             }
@@ -263,10 +297,10 @@ impl super::GameState {
     }
 
     pub async fn give_item(&self, player_id: &PlayerId, item_def_id: &str) -> bool {
-        if self.item_defs.get(item_def_id).is_none() {
+        let Some(stackable) = self.item_defs.get(item_def_id).map(|d| d.stackable) else {
             warn!("give_item: unknown item_def_id {:?}", item_def_id);
             return false;
-        }
+        };
 
         let instance_id = self.next_instance_id().await;
         let snapshot = {
@@ -275,12 +309,7 @@ impl super::GameState {
                 Some(inv) => inv,
                 None => return false,
             };
-            inv.bag.push(ItemInstance {
-                instance_id,
-                item_def_id: item_def_id.to_string(),
-                quantity: 1,
-                enchant: 0,
-            });
+            stack_into_bag(&mut inv.bag, stackable, item_def_id, 0, instance_id, 1);
             inv.clone()
         };
 
@@ -312,31 +341,25 @@ impl super::GameState {
             Bagged(PlayerInventory),
             Overweight,
         }
-        let placement =
-            {
-                let mut inventories = self.inventories.write().await;
-                let Some(inv) = inventories.get_mut(player_id) else {
-                    return;
-                };
-                if self.calc_total_weight(inv) + def_weight > max_weight {
-                    Placement::Overweight
-                } else {
-                    match inv.bag.iter_mut().find(|item| {
-                        stackable && item.item_def_id == item_def_id && item.enchant == 0
-                    }) {
-                        Some(stack) => stack.quantity += 1,
-                        None => {
-                            inv.bag.push(ItemInstance {
-                                instance_id: reserved_instance_id,
-                                item_def_id: item_def_id.to_string(),
-                                quantity: 1,
-                                enchant: 0,
-                            });
-                        }
-                    }
-                    Placement::Bagged(inv.clone())
-                }
+        let placement = {
+            let mut inventories = self.inventories.write().await;
+            let Some(inv) = inventories.get_mut(player_id) else {
+                return;
             };
+            if self.calc_total_weight(inv) + def_weight > max_weight {
+                Placement::Overweight
+            } else {
+                stack_into_bag(
+                    &mut inv.bag,
+                    stackable,
+                    item_def_id,
+                    0,
+                    reserved_instance_id,
+                    1,
+                );
+                Placement::Bagged(inv.clone())
+            }
+        };
 
         match placement {
             Placement::Bagged(snapshot) => {
@@ -949,6 +972,9 @@ impl super::GameState {
         let position = self
             .loot_drop_position(player_position, floor_level, preferred)
             .await;
+        // For the unit that splits off a stack — the stack keeps its own id.
+        // Reserved outside the lock like award_item; unused otherwise.
+        let split_instance_id = self.next_instance_id().await;
 
         let (snapshot, dropped, dropped_from_off_hand) = {
             let mut inventories = self.inventories.write().await;
@@ -959,7 +985,18 @@ impl super::GameState {
 
             let (dropped, dropped_from_off_hand) =
                 if let Some(idx) = inv.bag.iter().position(|i| i.instance_id == instance_id) {
-                    (inv.bag.remove(idx), false)
+                    if inv.bag[idx].quantity > 1 {
+                        inv.bag[idx].quantity -= 1;
+                        let unit = ItemInstance {
+                            instance_id: split_instance_id,
+                            item_def_id: inv.bag[idx].item_def_id.clone(),
+                            quantity: 1,
+                            enchant: inv.bag[idx].enchant,
+                        };
+                        (unit, false)
+                    } else {
+                        (inv.bag.remove(idx), false)
+                    }
                 } else if let Some(slot) = inv
                     .equipped
                     .iter()
@@ -980,7 +1017,7 @@ impl super::GameState {
         };
 
         let ground_item = GroundItem {
-            instance_id,
+            instance_id: dropped.instance_id,
             item_def_id: dropped.item_def_id,
             position,
             floor_level,
@@ -1071,6 +1108,10 @@ impl super::GameState {
         }
 
         let item_weight = self.item_defs.weight(&ground_item.item_def_id);
+        let stackable = self
+            .item_defs
+            .get(&ground_item.item_def_id)
+            .is_some_and(|d| d.stackable);
         let max_weight = self.max_carry_weight(player_id).await;
 
         // Acquire write lock for both weight check and mutation atomically
@@ -1101,12 +1142,14 @@ impl super::GameState {
                         .await;
                     return;
                 }
-                inv.bag.push(ItemInstance {
+                stack_into_bag(
+                    &mut inv.bag,
+                    stackable,
+                    &ground_item.item_def_id,
+                    ground_item.enchant,
                     instance_id,
-                    item_def_id: ground_item.item_def_id,
-                    quantity: 1,
-                    enchant: ground_item.enchant,
-                });
+                    1,
+                );
                 inv.clone()
             } else {
                 return;

--- a/server/src/game_state/tests/inventory_tests.rs
+++ b/server/src/game_state/tests/inventory_tests.rs
@@ -1,0 +1,93 @@
+use super::*;
+use crate::game_state::inventory::stack_into_bag;
+
+#[test]
+fn stack_into_bag_merges_only_same_def_and_enchant() {
+    let mut bag = Vec::new();
+    stack_into_bag(&mut bag, true, "apple", 0, 1, 1);
+    stack_into_bag(&mut bag, true, "apple", 0, 2, 1);
+    stack_into_bag(&mut bag, true, "apple", 1, 3, 1);
+    stack_into_bag(&mut bag, false, "torch", 0, 4, 1);
+    stack_into_bag(&mut bag, false, "torch", 0, 5, 1);
+
+    assert_eq!(bag.len(), 4, "merge only the same-def same-enchant pair");
+    assert_eq!(bag[0].item_def_id, "apple");
+    assert_eq!(bag[0].quantity, 2);
+    assert_eq!(bag[1].enchant, 1);
+    assert_eq!(bag[1].quantity, 1);
+}
+
+/// give_item feeds /give, dungeon chest loot, and grilling — repeated grants
+/// of a stackable must share one bag entry.
+#[tokio::test]
+async fn give_item_stacks_repeated_grants() {
+    let game_state = make_test_game_state("give_item_stacks");
+    game_state.add_player(make_player("eater", 0.0, 0.0)).await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        inventories.insert(pid("eater"), Default::default());
+    }
+
+    assert!(game_state.give_item(&pid("eater"), "grilled_minnow").await);
+    assert!(game_state.give_item(&pid("eater"), "grilled_minnow").await);
+    assert!(game_state.give_item(&pid("eater"), "fishing_rod").await);
+    assert!(game_state.give_item(&pid("eater"), "fishing_rod").await);
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("eater")].bag;
+    let fish: Vec<_> = bag
+        .iter()
+        .filter(|i| i.item_def_id == "grilled_minnow")
+        .collect();
+    assert_eq!(fish.len(), 1);
+    assert_eq!(fish[0].quantity, 2);
+    let rods: Vec<_> = bag
+        .iter()
+        .filter(|i| i.item_def_id == "fishing_rod")
+        .collect();
+    assert_eq!(rods.len(), 2, "non-stackables keep their own slots");
+}
+
+/// Dropping from a stack must shed exactly one unit — before the stacking fix
+/// a whole entry was removed and every unit above the first was destroyed.
+#[tokio::test]
+async fn dropping_from_a_stack_sheds_one_unit() {
+    let game_state = make_test_game_state("drop_stack_unit");
+    game_state
+        .add_player(make_player("dropper", 0.0, 0.0))
+        .await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        let mut inv: onlinerpg_shared::inventory::PlayerInventory = Default::default();
+        inv.bag.push(bag_item(11, "apple", 3));
+        inventories.insert(pid("dropper"), inv);
+    }
+
+    game_state.drop_item(&pid("dropper"), 11).await;
+
+    {
+        let inventories = game_state.inventories.read().await;
+        let bag = &inventories[&pid("dropper")].bag;
+        assert_eq!(bag.len(), 1, "the stack must survive the drop");
+        assert_eq!(bag[0].quantity, 2);
+        assert_eq!(bag[0].instance_id, 11, "the stack keeps its id");
+    }
+    {
+        let ground_items = game_state.ground_items.read().await;
+        assert_eq!(ground_items.len(), 1, "exactly one unit hits the ground");
+        let dropped = ground_items.values().next().unwrap();
+        assert_eq!(dropped.item.item_def_id, "apple");
+        assert_ne!(
+            dropped.item.instance_id, 11,
+            "the shed unit needs its own id"
+        );
+    }
+
+    // Draining the stack unit by unit ends with an empty bag, nothing lost.
+    game_state.drop_item(&pid("dropper"), 11).await;
+    game_state.drop_item(&pid("dropper"), 11).await;
+    assert!(game_state.inventories.read().await[&pid("dropper")]
+        .bag
+        .is_empty());
+    assert_eq!(game_state.ground_items.read().await.len(), 3);
+}

--- a/server/src/game_state/tests/mod.rs
+++ b/server/src/game_state/tests/mod.rs
@@ -19,6 +19,7 @@ mod dungeon_tests;
 mod enchant_tests;
 mod fishing_tests;
 mod hunger_tests;
+mod inventory_tests;
 mod movement_tests;
 mod party_tests;
 mod persistence_tests;

--- a/server/src/game_state/tests/persistence_tests.rs
+++ b/server/src/game_state/tests/persistence_tests.rs
@@ -214,3 +214,71 @@ async fn open_door_state_is_stamped_onto_served_house_data() {
     game_state.apply_open_door_state(&mut served).await;
     assert!(!served[0].rooms[0].wall_north[0].is_open);
 }
+
+/// Bags saved before trading/pickup learned to stack hold one row per unit;
+/// the login load must merge them (same def, same enchant) so old characters
+/// heal on their next session.
+#[tokio::test]
+async fn login_load_merges_legacy_split_stacks() {
+    let auth = make_test_auth("load_merges_stacks");
+    let account = auth.login_npc("npc_stack_merge").unwrap();
+    let record = create_test_character(&auth, &account, "Stacker");
+    let split_row = |enchant: i32| crate::auth::ItemRow {
+        item_def_id: "apple".to_string(),
+        quantity: 1,
+        equip_slot: None,
+        enchant,
+    };
+    let torch_row = || crate::auth::ItemRow {
+        item_def_id: "torch".to_string(),
+        quantity: 1,
+        equip_slot: None,
+        enchant: 0,
+    };
+    auth.save_batch(
+        &[],
+        &[(
+            record.id,
+            vec![
+                split_row(0),
+                split_row(0),
+                split_row(1),
+                torch_row(),
+                torch_row(),
+            ],
+        )],
+        &[],
+        &[],
+        None,
+    )
+    .unwrap();
+
+    let game_state = make_test_game_state("load_merges_stacks");
+    let p = pid("loader");
+    game_state.add_player(make_player("loader", 0.0, 0.0)).await;
+    game_state
+        .register_player_character(&p, record.id, 0, attrs_with_cha(12), 0, None)
+        .await;
+    game_state.load_player_inventory(&p, record.id, &auth).await;
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&p].bag;
+    let apples: Vec<_> = bag
+        .iter()
+        .filter(|i| i.item_def_id == "apple" && i.enchant == 0)
+        .collect();
+    assert_eq!(apples.len(), 1, "split enchant-0 apples must merge on load");
+    assert_eq!(apples[0].quantity, 2);
+    assert_eq!(
+        bag.iter()
+            .filter(|i| i.item_def_id == "apple" && i.enchant == 1)
+            .count(),
+        1,
+        "a different enchant must keep its own slot"
+    );
+    assert_eq!(
+        bag.iter().filter(|i| i.item_def_id == "torch").count(),
+        2,
+        "non-stackables must not merge on load"
+    );
+}

--- a/server/src/game_state/tests/pickup_tests.rs
+++ b/server/src/game_state/tests/pickup_tests.rs
@@ -178,3 +178,42 @@ async fn pickup_animation_is_not_sent_beyond_the_delivery_radius() {
         );
     }
 }
+
+#[tokio::test]
+async fn picked_up_stackable_joins_the_existing_stack() {
+    let game_state = make_test_game_state("pickup_stacks");
+    game_state.add_player(make_player("picker", 0.0, 0.0)).await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        let mut inv: onlinerpg_shared::inventory::PlayerInventory = Default::default();
+        inv.bag.push(bag_item(11, "apple", 1));
+        inventories.insert(pid("picker"), inv);
+    }
+    {
+        let mut ground_items = game_state.ground_items.write().await;
+        ground_items.insert(
+            42,
+            ServerGroundItem {
+                item: GroundItem {
+                    instance_id: 42,
+                    item_def_id: "apple".to_string(),
+                    position: Position {
+                        x: 0.5,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    floor_level: 0,
+                    enchant: 0,
+                },
+                dropped_at_ms: 0,
+            },
+        );
+    }
+
+    game_state.pickup_item(&pid("picker"), 42).await;
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("picker")].bag;
+    assert_eq!(bag.len(), 1, "the picked-up apple must join the stack");
+    assert_eq!(bag[0].quantity, 2);
+}

--- a/server/src/game_state/tests/trading_tests/buyback_tests.rs
+++ b/server/src/game_state/tests/trading_tests/buyback_tests.rs
@@ -49,6 +49,35 @@ async fn sell_to_merchant_records_buyback_and_restores_item() {
 }
 
 #[tokio::test]
+async fn buyback_returns_the_unit_into_its_stack() {
+    let game_state = make_test_game_state("buyback_stacks");
+    let (_buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 0).await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        let mut inv: onlinerpg_shared::inventory::PlayerInventory = Default::default();
+        inv.bag.push(bag_item(7, "apple", 2));
+        inventories.insert(pid("buyer"), inv);
+    }
+
+    game_state
+        .sell_item(&pid("buyer"), &pid("npc_rica"), 7)
+        .await;
+    let entry_id = {
+        let buybacks = game_state.buybacks.read().await;
+        buybacks[&(1, "Rica".to_string())][0].entry.entry_id
+    };
+
+    game_state
+        .buyback_item(&pid("buyer"), &pid("npc_rica"), entry_id)
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("buyer")].bag;
+    assert_eq!(bag.len(), 1, "the bought-back apple must rejoin its stack");
+    assert_eq!(bag[0].quantity, 2);
+}
+
+#[tokio::test]
 async fn buyback_rejects_without_enough_gold() {
     let game_state = make_test_game_state("buyback_no_gold");
     let (mut buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 0).await;

--- a/server/src/game_state/tests/trading_tests/merchant_tests.rs
+++ b/server/src/game_state/tests/trading_tests/merchant_tests.rs
@@ -252,6 +252,33 @@ async fn buy_item_applies_deal_once() {
 }
 
 #[tokio::test]
+async fn bought_stackables_merge_into_one_bag_entry() {
+    let game_state = make_test_game_state("buy_stacks");
+    let (_buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 1_000).await;
+    {
+        let mut inventories = game_state.inventories.write().await;
+        inventories.insert(pid("buyer"), Default::default());
+    }
+
+    for _ in 0..2 {
+        game_state
+            .buy_item(&pid("buyer"), &pid("npc_rica"), "apple")
+            .await;
+        game_state
+            .buy_item(&pid("buyer"), &pid("npc_rica"), "torch")
+            .await;
+    }
+
+    let inventories = game_state.inventories.read().await;
+    let bag = &inventories[&pid("buyer")].bag;
+    let apples: Vec<_> = bag.iter().filter(|i| i.item_def_id == "apple").collect();
+    assert_eq!(apples.len(), 1, "stackable purchases must share one entry");
+    assert_eq!(apples[0].quantity, 2);
+    let torches: Vec<_> = bag.iter().filter(|i| i.item_def_id == "torch").collect();
+    assert_eq!(torches.len(), 2, "non-stackables keep their own slots");
+}
+
+#[tokio::test]
 async fn sell_item_applies_deal_bonus() {
     let game_state = make_test_game_state("sell_with_deal");
     let (_buyer_rx, _npc_rx) = setup_haggle(&game_state, 18, 0).await;

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -1,12 +1,12 @@
 use crate::merchant_defs::{merchant_defs, MerchantDefinition};
 use crate::npc_defs::{npc_defs, NpcDefinition};
 use crate::types::{PlayerId, ServerMessage};
-use onlinerpg_shared::inventory::ItemInstance;
 use onlinerpg_shared::messages::{BuybackEntry, DealKind, StockEntry};
 use tracing::info;
 
 use super::combat::reachable_dist_sq;
 use super::deals::{buy_price, deal_half_band_pct, resident_half_band_pct, sell_payout};
+use super::inventory::stack_into_bag;
 use super::StoredBuyback;
 
 /// Maximum distance between player and trader for any shop interaction.
@@ -446,6 +446,7 @@ impl super::GameState {
         let price = buy_price(base_price, deal.as_ref().map_or(0, |d| d.modifier_pct));
 
         let item_weight = self.item_defs.weight(item_def_id);
+        let stackable = self.item_defs.get(item_def_id).is_some_and(|d| d.stackable);
         let max_weight = self.max_carry_weight(player_id).await;
         let instance_id = self.next_instance_id().await;
 
@@ -541,12 +542,7 @@ impl super::GameState {
             };
 
             let inv = inventories.get_mut(player_id).expect("checked above");
-            inv.bag.push(ItemInstance {
-                instance_id,
-                item_def_id: item_def_id.to_string(),
-                quantity: 1,
-                enchant: 0,
-            });
+            stack_into_bag(&mut inv.bag, stackable, item_def_id, 0, instance_id, 1);
             let snapshot = inv.clone();
 
             *gold_map.get_mut(player_id).expect("checked above") -= price;
@@ -757,12 +753,18 @@ impl super::GameState {
                 }
                 // Keep the sold unit's enchantment: a +3 sword stays +3 in
                 // the resident's bag.
-                npc_inv.bag.push(ItemInstance {
-                    instance_id: npc_instance_id,
-                    item_def_id: item_def_id.clone(),
-                    quantity: 1,
-                    enchant: sold_enchant,
-                });
+                let stackable = self
+                    .item_defs
+                    .get(&item_def_id)
+                    .is_some_and(|d| d.stackable);
+                stack_into_bag(
+                    &mut npc_inv.bag,
+                    stackable,
+                    &item_def_id,
+                    sold_enchant,
+                    npc_instance_id,
+                    1,
+                );
                 Some(npc_inv.clone())
             } else {
                 None
@@ -998,12 +1000,18 @@ impl super::GameState {
             };
 
             let inv = inventories.get_mut(player_id).expect("checked above");
-            inv.bag.push(ItemInstance {
-                instance_id: entry.entry_id,
-                item_def_id: entry.item_def_id.clone(),
-                quantity: 1,
-                enchant: entry.enchant,
-            });
+            let stackable = self
+                .item_defs
+                .get(&entry.item_def_id)
+                .is_some_and(|d| d.stackable);
+            stack_into_bag(
+                &mut inv.bag,
+                stackable,
+                &entry.item_def_id,
+                entry.enchant,
+                entry.entry_id,
+                1,
+            );
             let snapshot = inv.clone();
             *gold_map.get_mut(player_id).expect("checked above") -= entry.price;
             (snapshot, buyback)


### PR DESCRIPTION
## Summary

Items defined `stackable` in items.csv (food, potions, scrolls, campfire kits, grilled fish) only actually stacked when awarded by fishing (`award_item`). Every other acquisition path pushed a fresh one-unit slot:

| Path | Before |
|---|---|
| Merchant buy (`buy_item`) | one slot per unit |
| Buyback (`buyback_item`) | one slot per unit |
| Resident receiving a sold item | one slot per unit |
| `give_item` — `/give`, dungeon chest loot, grilling | one slot per unit |
| Ground pickup (`pickup_item`) | one slot per unit |

Buying five apples ate five bag slots.

## Fix

One rule now serves every path: `stack_into_bag` (inventory.rs) joins a unit onto an existing same-def, same-enchant entry when the def is stackable, and gives it its own slot otherwise. `award_item` was refactored onto the same helper, and the login load merges through it too — bags saved before this fix heal on the next session.

**Follow-up bug caught during review:** with stacks now routine, `drop_item` became lossy — it removed the whole bag entry but spawned a single ground item, silently destroying every unit above the first (`GroundItem` has no quantity). It now sheds exactly one unit (fresh instance id) and keeps the stack, mirroring `consume_one`.

Non-stackable items (weapons, armor, tools) keep one slot per instance, and enchanted items never merge across enchant levels.

## Tests

Seven regression tests: merchant buy merges / non-stackables split, buyback rejoins the stack, pickup joins the stack, `give_item` stacks repeated grants, login-load merges legacy split rows (different enchants stay split), dropping from a stack sheds one unit and drains without loss, plus a unit test on the insert rule. Full server suite: 314 passed.

Live-checked against a local server: two bought apples share one entry (qty 2); dropping sheds exactly one.

No protocol change — `PartyPositions`-style bump is not needed since `InventoryUpdated` already carried quantities.

## Before / After

| Before | After |
| :---: | :---: |
| <img width="341" height="666" alt="Before: stackable items occupy separate inventory slots" src="https://github.com/user-attachments/assets/026c7dfd-6ad2-4fec-8041-b87c0978386b" /> | <img width="348" height="694" alt="After: matching stackable items share one slot and display quantity badges" src="https://github.com/user-attachments/assets/8f767f46-f690-4b95-be68-ed0db27bc69a" /> |
| Stackable items occupy one slot per unit. | Matching stackable items share one slot and display quantity badges. |
