### PR TITLE
Fix resident purchase enchantment loss

### DIFF
--- a/server/src/game_state/tests/trading_tests/batch_tests.rs
+++ b/server/src/game_state/tests/trading_tests/batch_tests.rs
@@ -197,6 +197,48 @@ async fn buy_items_batch_merges_stackables_and_splits_non_stackables() {
     assert!(torches.iter().all(|t| t.quantity == 1));
 }
 
+#[tokio::test]
+async fn buy_items_batch_preserves_resident_enchantments_lowest_first() {
+    let game_state = make_test_game_state("batch_buy_resident_enchantments");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![
+            enchanted_bag_item(11, "spear", 1, 3),
+            bag_item(12, "spear", 1),
+            enchanted_bag_item(13, "spear", 1, 1),
+        ],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 10_000);
+
+    game_state
+        .buy_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![TradeLineItem {
+                item_def_id: "spear".to_string(),
+                qty: 2,
+            }],
+        )
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    let buyer_bag = &inventories[&pid("seller")].bag;
+    assert_eq!(buyer_bag.len(), 2);
+    let mut buyer_enchants: Vec<_> = buyer_bag.iter().map(|item| item.enchant).collect();
+    buyer_enchants.sort_unstable();
+    assert_eq!(buyer_enchants, vec![0, 1]);
+    let npc_bag = &inventories[&pid("npc_karl")].bag;
+    assert_eq!(npc_bag.len(), 1);
+    assert_eq!(npc_bag[0].enchant, 3);
+}
+
 /// The resident's receipt draws from a range reserved before the locks, so
 /// every unit must still land on its own id. (No wishlist item is stackable,
 /// so the merge branch is unreachable from data alone.)

--- a/server/src/game_state/tests/trading_tests/batch_tests.rs
+++ b/server/src/game_state/tests/trading_tests/batch_tests.rs
@@ -239,6 +239,155 @@ async fn buy_items_batch_preserves_resident_enchantments_lowest_first() {
     assert_eq!(npc_bag[0].enchant, 3);
 }
 
+#[tokio::test]
+async fn buy_items_batch_takes_only_the_requested_units_from_a_resident_stack() {
+    let game_state = make_test_game_state("batch_buy_resident_partial_stack");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![bag_item(11, "healing_potion", 5)],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 10_000);
+
+    game_state
+        .buy_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![TradeLineItem {
+                item_def_id: "healing_potion".to_string(),
+                qty: 2,
+            }],
+        )
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 8_800);
+    let inventories = game_state.inventories.read().await;
+    let buyer_bag = &inventories[&pid("seller")].bag;
+    assert_eq!(buyer_bag.len(), 1);
+    assert_eq!(buyer_bag[0].quantity, 2, "only the paid-for units transfer");
+    let npc_bag = &inventories[&pid("npc_karl")].bag;
+    assert_eq!(npc_bag.len(), 1);
+    assert_eq!(npc_bag[0].quantity, 3);
+}
+
+/// A resident line can fan out into several bag inserts (one per stock entry),
+/// and each insert must consume its own slice of the reserved id range.
+#[tokio::test]
+async fn buy_items_batch_gives_each_bought_unit_its_own_id() {
+    let game_state = make_test_game_state("batch_buy_resident_ids");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![
+            enchanted_bag_item(11, "spear", 1, 3),
+            bag_item(12, "spear", 1),
+            enchanted_bag_item(13, "spear", 1, 1),
+            bag_item(14, "healing_potion", 3),
+        ],
+        vec![bag_item(100, "torch", 1)],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 20_000);
+
+    game_state
+        .buy_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![
+                TradeLineItem {
+                    item_def_id: "spear".to_string(),
+                    qty: 2,
+                },
+                TradeLineItem {
+                    item_def_id: "healing_potion".to_string(),
+                    qty: 2,
+                },
+            ],
+        )
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    let buyer_bag = &inventories[&pid("seller")].bag;
+    assert_eq!(
+        buyer_bag
+            .iter()
+            .filter(|i| i.item_def_id == "spear")
+            .count(),
+        2
+    );
+    assert!(buyer_bag
+        .iter()
+        .any(|i| i.item_def_id == "healing_potion" && i.quantity == 2));
+    let ids: Vec<_> = buyer_bag.iter().map(|i| i.instance_id).collect();
+    assert_eq!(
+        ids.iter().collect::<std::collections::HashSet<_>>().len(),
+        ids.len(),
+        "every bought unit gets its own id, clear of the bag's existing ones"
+    );
+    assert!(ids.contains(&100), "the pre-existing torch keeps its id");
+}
+
+/// Two lines for the same def are checked against stock as one total.
+#[tokio::test]
+async fn buy_items_batch_totals_repeated_lines_against_resident_stock() {
+    let game_state = make_test_game_state("batch_buy_resident_repeated_lines");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![
+            enchanted_bag_item(11, "spear", 1, 3),
+            bag_item(12, "spear", 1),
+            enchanted_bag_item(13, "spear", 1, 1),
+        ],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 20_000);
+    let mut seller_rx = game_state.register_direct_channel(&pid("seller")).await;
+
+    game_state
+        .buy_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![
+                TradeLineItem {
+                    item_def_id: "spear".to_string(),
+                    qty: 2,
+                },
+                TradeLineItem {
+                    item_def_id: "spear".to_string(),
+                    qty: 2,
+                },
+            ],
+        )
+        .await;
+
+    match seller_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("out of that item"), "got: {message}")
+        }
+        other => panic!("Expected TradeError, got {:?}", other),
+    }
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 20_000);
+    let inventories = game_state.inventories.read().await;
+    assert!(inventories[&pid("seller")].bag.is_empty());
+    assert_eq!(inventories[&pid("npc_karl")].bag.len(), 3);
+}
+
 /// The resident's receipt draws from a range reserved before the locks, so
 /// every unit must still land on its own id. (No wishlist item is stackable,
 /// so the merge branch is unreachable from data alone.)

--- a/server/src/game_state/tests/trading_tests/mod.rs
+++ b/server/src/game_state/tests/trading_tests/mod.rs
@@ -74,3 +74,17 @@ async fn setup_resident_trade(
         },
     );
 }
+
+fn enchanted_bag_item(
+    instance_id: u64,
+    item_def_id: &str,
+    quantity: u32,
+    enchant: i32,
+) -> ItemInstance {
+    ItemInstance {
+        instance_id,
+        item_def_id: item_def_id.to_string(),
+        quantity,
+        enchant,
+    }
+}

--- a/server/src/game_state/tests/trading_tests/resident_tests.rs
+++ b/server/src/game_state/tests/trading_tests/resident_tests.rs
@@ -122,6 +122,59 @@ async fn resident_sells_stock_but_keeps_wishlist_items() {
 }
 
 #[tokio::test]
+async fn resident_sale_preserves_enchantment() {
+    let game_state = make_test_game_state("resident_enchanted_stock");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![enchanted_bag_item(11, "spear", 1, 3)],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 10_000);
+
+    game_state
+        .buy_item(&pid("seller"), &pid("npc_karl"), "spear")
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    assert_eq!(inventories[&pid("seller")].bag[0].enchant, 3);
+    assert!(inventories[&pid("npc_karl")].bag.is_empty());
+}
+
+#[tokio::test]
+async fn resident_sells_lowest_enchantment_first() {
+    let game_state = make_test_game_state("resident_mixed_enchanted_stock");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![
+            enchanted_bag_item(11, "spear", 1, 3),
+            bag_item(12, "spear", 1),
+        ],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 10_000);
+
+    game_state
+        .buy_item(&pid("seller"), &pid("npc_karl"), "spear")
+        .await;
+
+    let inventories = game_state.inventories.read().await;
+    assert_eq!(inventories[&pid("seller")].bag[0].enchant, 0);
+    assert_eq!(inventories[&pid("npc_karl")].bag[0].enchant, 3);
+}
+
+#[tokio::test]
 async fn resident_shop_state_reports_wishlist_and_stock() {
     let game_state = make_test_game_state("resident_shop_state");
     setup_resident_trade(

--- a/server/src/game_state/tests/trading_tests/resident_tests.rs
+++ b/server/src/game_state/tests/trading_tests/resident_tests.rs
@@ -175,6 +175,38 @@ async fn resident_sells_lowest_enchantment_first() {
 }
 
 #[tokio::test]
+async fn resident_sale_takes_one_unit_out_of_a_stack() {
+    let game_state = make_test_game_state("resident_partial_stack");
+    setup_resident_trade(
+        &game_state,
+        0,
+        vec![bag_item(11, "healing_potion", 5)],
+        vec![],
+    )
+    .await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 10_000);
+
+    game_state
+        .buy_item(&pid("seller"), &pid("npc_karl"), "healing_potion")
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 9_400);
+    assert_eq!(game_state.get_player_gold(&pid("npc_karl")).await, 600);
+    let inventories = game_state.inventories.read().await;
+    let buyer_bag = &inventories[&pid("seller")].bag;
+    assert_eq!(buyer_bag.len(), 1);
+    assert_eq!(buyer_bag[0].item_def_id, "healing_potion");
+    assert_eq!(buyer_bag[0].quantity, 1);
+    let npc_bag = &inventories[&pid("npc_karl")].bag;
+    assert_eq!(npc_bag.len(), 1, "the rest of the stack stays in stock");
+    assert_eq!(npc_bag[0].quantity, 4);
+}
+
+#[tokio::test]
 async fn resident_shop_state_reports_wishlist_and_stock() {
     let game_state = make_test_game_state("resident_shop_state");
     setup_resident_trade(

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -515,7 +515,7 @@ impl super::GameState {
             }
 
             // Residents have finite stock: take the unit out of their bag.
-            let npc_snapshot = if is_resident {
+            let (npc_snapshot, purchased_enchant) = if is_resident {
                 let Some(npc_inv) = inventories.get_mut(npc_player_id) else {
                     drop(inventories);
                     drop(gold_map);
@@ -530,10 +530,14 @@ impl super::GameState {
                         )
                         .await;
                 };
+                // Stock requests are def-only, so sell the lowest enchant first.
                 let Some(idx) = npc_inv
                     .bag
                     .iter()
-                    .position(|i| i.item_def_id == item_def_id)
+                    .enumerate()
+                    .filter(|(_, item)| item.item_def_id == item_def_id)
+                    .min_by_key(|(_, item)| item.enchant)
+                    .map(|(idx, _)| idx)
                 else {
                     drop(inventories);
                     drop(gold_map);
@@ -548,20 +552,21 @@ impl super::GameState {
                         )
                         .await;
                 };
+                let purchased_enchant = npc_inv.bag[idx].enchant;
                 if npc_inv.bag[idx].quantity > 1 {
                     npc_inv.bag[idx].quantity -= 1;
                 } else {
                     npc_inv.bag.remove(idx);
                 }
-                Some(npc_inv.clone())
+                (Some(npc_inv.clone()), purchased_enchant)
             } else {
-                None
+                (None, 0)
             };
 
             let inv = inventories.get_mut(player_id).expect("checked above");
             stack_into_bag(
                 &mut inv.bag,
-                BagInsert::one(stackable, item_def_id, 0, instance_id),
+                BagInsert::one(stackable, item_def_id, purchased_enchant, instance_id),
             );
             let snapshot = inv.clone();
 
@@ -647,6 +652,12 @@ impl super::GameState {
             base_price: i64,
             deal_taken: Option<DealEntry>,
             price: i64,
+        }
+
+        struct ResidentPurchase {
+            item_def_id: String,
+            quantity: u32,
+            enchant: i32,
         }
 
         let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
@@ -775,40 +786,70 @@ impl super::GameState {
         }
 
         // Every line is now guaranteed to apply cleanly — mutate.
-        if is_resident {
+        let resident_purchases = if is_resident {
             let npc_inv = inventories.get_mut(npc_player_id).expect("checked above");
-            for (item_def_id, mut remaining) in requested {
+            let mut purchases = Vec::new();
+            for plan in &plans {
+                let mut remaining = plan.qty;
                 while remaining > 0 {
                     let idx = npc_inv
                         .bag
                         .iter()
-                        .position(|i| i.item_def_id == item_def_id)
+                        .enumerate()
+                        .filter(|(_, item)| item.item_def_id == plan.item_def_id)
+                        .min_by_key(|(_, item)| item.enchant)
+                        .map(|(idx, _)| idx)
                         .expect("availability checked above");
                     let take = remaining.min(npc_inv.bag[idx].quantity);
+                    let enchant = npc_inv.bag[idx].enchant;
                     if npc_inv.bag[idx].quantity > take {
                         npc_inv.bag[idx].quantity -= take;
                     } else {
                         npc_inv.bag.remove(idx);
                     }
+                    purchases.push(ResidentPurchase {
+                        item_def_id: plan.item_def_id.clone(),
+                        quantity: take,
+                        enchant,
+                    });
                     remaining -= take;
                 }
             }
-        }
+            purchases
+        } else {
+            Vec::new()
+        };
 
         {
             let inv = inventories.get_mut(player_id).expect("checked above");
-            for plan in &plans {
-                let stackable = self.item_defs.stackable(&plan.item_def_id);
-                next_id += stack_into_bag(
-                    &mut inv.bag,
-                    BagInsert {
-                        stackable,
-                        item_def_id: &plan.item_def_id,
-                        enchant: 0,
-                        first_instance_id: next_id,
-                        quantity: plan.qty,
-                    },
-                );
+            if is_resident {
+                for purchase in &resident_purchases {
+                    let stackable = self.item_defs.stackable(&purchase.item_def_id);
+                    next_id += stack_into_bag(
+                        &mut inv.bag,
+                        BagInsert {
+                            stackable,
+                            item_def_id: &purchase.item_def_id,
+                            enchant: purchase.enchant,
+                            first_instance_id: next_id,
+                            quantity: purchase.quantity,
+                        },
+                    );
+                }
+            } else {
+                for plan in &plans {
+                    let stackable = self.item_defs.stackable(&plan.item_def_id);
+                    next_id += stack_into_bag(
+                        &mut inv.bag,
+                        BagInsert {
+                            stackable,
+                            item_def_id: &plan.item_def_id,
+                            enchant: 0,
+                            first_instance_id: next_id,
+                            quantity: plan.qty,
+                        },
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Buying from a resident NPC minted the item into the buyer's bag with `enchant: 0`, so an enchanted weapon in a resident's stock lost its enchantment the moment anyone bought it. Selling, dropping and picking up all preserve enchantment — only the resident buy path wiped it. Both the single (`buy_item`) and batch (`buy_items`) paths now carry the actual enchant of the unit taken out of the NPC's bag.

Stock requests are def-only, so when a resident holds several copies of one def at different enchant levels, the lowest enchant sells first: the buyer pays the base price either way, and the valuable copies are the last to leave the stock.

## Testing

- 341 server tests pass (7 new): enchant preservation on both paths, lowest-first ordering, partial-stack buys (no item duplication or whole-stock deletion), buy-side instance-id uniqueness across fan-out inserts, and repeated same-def lines in one batch.
- The added tests were mutation-checked: each one fails under a concrete code mutation that previously survived the entire suite.
- Live check on a local server: reproduced the loss on the pre-fix build (a +3 spear dropped near a resident and picked up into its bag came back as +0 when bought), then verified on this branch that an enchanted spear survives the same round trip.

## Notes

Resident stock rows aggregate by item def, so the shop window doesn't show which enchant level a purchase will yield, and pricing ignores enchantment everywhere; per-enchant rows (and whether to price them) are left as a follow-up. Separately, the trade window's stock list is a snapshot from open time and keeps showing sold-out lines until reopened — a refresh push was prototyped but needs a small protocol addition to do cleanly, so it is deferred to its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
