### PR TITLE
Suppress the native context menu across the game screen

### DIFF
--- a/client/src/lib/managers/inputHandler.test.ts
+++ b/client/src/lib/managers/inputHandler.test.ts
@@ -9,7 +9,11 @@ vi.mock('../wasm/onlinerpg_shared', () => ({
   max_cast_distance_m: () => MAX_CAST_DISTANCE_M,
 }))
 
-import { inputHandler, type RaycastContext } from './inputHandler'
+import {
+  inputHandler,
+  shouldSuppressContextMenu,
+  type RaycastContext,
+} from './inputHandler'
 import { resetFishingStore } from '../stores/fishingStore'
 
 const RECT = { left: 0, top: 0, width: 100, height: 100 }
@@ -175,5 +179,47 @@ describe('processCanvasClick cast-vs-walk', () => {
     )
 
     expect(intent.type).toBe('move_to_ground')
+  })
+})
+
+describe('shouldSuppressContextMenu', () => {
+  it('always suppresses on the game canvas, even while text is selected', () => {
+    expect(
+      shouldSuppressContextMenu({
+        onGameCanvas: true,
+        typingTarget: false,
+        textSelected: true,
+      })
+    ).toBe(true)
+  })
+
+  it('suppresses on plain HUD targets', () => {
+    expect(
+      shouldSuppressContextMenu({
+        onGameCanvas: false,
+        typingTarget: false,
+        textSelected: false,
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the paste menu on text fields', () => {
+    expect(
+      shouldSuppressContextMenu({
+        onGameCanvas: false,
+        typingTarget: true,
+        textSelected: false,
+      })
+    ).toBe(false)
+  })
+
+  it('keeps the copy menu while HUD text is selected', () => {
+    expect(
+      shouldSuppressContextMenu({
+        onGameCanvas: false,
+        typingTarget: false,
+        textSelected: true,
+      })
+    ).toBe(false)
   })
 })

--- a/client/src/lib/managers/inputHandler.ts
+++ b/client/src/lib/managers/inputHandler.ts
@@ -640,18 +640,40 @@ class InputHandler {
     document.addEventListener('keyup', onKeyUp)
     window.addEventListener('blur', onWindowBlur)
 
-    const onContextMenu = (event: MouseEvent) => event.preventDefault()
+    const onContextMenu = (event: MouseEvent) => {
+      const suppress = shouldSuppressContextMenu({
+        onGameCanvas: event.target === canvas,
+        typingTarget: isTypingTarget(event.target),
+        textSelected: window.getSelection()?.isCollapsed === false,
+      })
+      if (suppress) event.preventDefault()
+    }
     canvas.addEventListener('mousedown', onCanvasClick)
-    canvas.addEventListener('contextmenu', onContextMenu)
+    document.addEventListener('contextmenu', onContextMenu, true)
 
     return () => {
       document.removeEventListener('keydown', onKeyDown)
       document.removeEventListener('keyup', onKeyUp)
       window.removeEventListener('blur', onWindowBlur)
       canvas.removeEventListener('mousedown', onCanvasClick)
-      canvas.removeEventListener('contextmenu', onContextMenu)
+      document.removeEventListener('contextmenu', onContextMenu, true)
     }
   }
+}
+
+/** Right-click is a game input, so the native context menu is suppressed
+ *  across the whole game screen (HUD overlays included), not just the canvas.
+ *  Exceptions apply to DOM targets only: text fields keep their paste menu,
+ *  and a text selection (chat log copy) keeps its copy menu. The canvas is
+ *  never exempt — a selection elsewhere on the page survives canvas clicks,
+ *  and must not leak the browser menu into the 3D view. */
+export function shouldSuppressContextMenu(state: {
+  onGameCanvas: boolean
+  typingTarget: boolean
+  textSelected: boolean
+}): boolean {
+  if (state.onGameCanvas) return true
+  return !state.typingTarget && !state.textSelected
 }
 
 export const inputHandler = new InputHandler()


### PR DESCRIPTION
## Summary

Right-clicking an NPC opened the game's context menu with the browser's native menu stacked on top: the game menu mounts at the cursor on mousedown, so on release the `contextmenu` event fired on the menu itself, which nothing suppressed. The same gap covered every HUD overlay (time widget, hunger indicator, panels) — only the canvas prevented the browser default.

The suppression now lives in one document-level capture listener, active only while the game screen is mounted, so the login and character screens keep native menus. Handlers that act on right-click (quickslot clear, world map's macOS ctrl+click) keep working — only the default action is prevented. Two exemptions: text fields keep their paste menu, and an active text selection keeps its copy menu for the chat log. The canvas is never exempt: a selection elsewhere on the page survives canvas clicks, and would otherwise leak the browser menu into the 3D view on every right-click until the selection happens to collapse.

## Testing

- The suppression decision is a pure function pinned by 4 unit tests (canvas always suppresses even mid-selection, typing/selection exemptions, HUD default); 391 client tests pass, svelte-check / eslint / prettier clean.
- Live check on a local server: right-clicking an NPC shows only the game menu; text can still be selected and copied from the chat log.

## Screenshots

| Before — browser menu over the NPC menu | After — game menu only |
|:---:|:---:|
| <img width="1026" height="702" alt="image" src="https://github.com/user-attachments/assets/c62e6d7d-9976-4801-ae6b-5204a437a1b5" /> | <img width="645" height="669" alt="image" src="https://github.com/user-attachments/assets/abfc7c1b-1024-4d6b-8317-3809ec6809f8" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
