### PR TITLE
Define skill and durability design

### DIFF
--- a/doc/DURABILITY.md
+++ b/doc/DURABILITY.md
@@ -1,0 +1,223 @@
+# Durability and Repair Design
+
+> Status: **Proposed**. This document defines the intended item-condition
+> contract. Implementation should be reviewed separately after the design is
+> accepted.
+
+Durability is per-item-instance state. Definitions describe an item's maximum
+condition and repair compatibility; each owned, equipped, dropped, or traded
+instance carries its own remaining condition.
+
+## Goals
+
+- Make wear deterministic, server-authoritative, and easy to explain.
+- Preserve valuable equipment instead of destroying it implicitly at zero.
+- Create repair-product and economy hooks without prematurely adding crafting
+  professions.
+- Keep condition intact through every inventory and trade path.
+- Show enough information for players and agents to make maintenance choices.
+- Provide a narrow first slice that can later expand to weapons, shields, and
+  other armor pieces through separate review.
+
+## Non-goals
+
+The first slice does not include weapon wear, Shield wear, extremity-armor wear,
+death wear, environmental wear, repair quality, permanent maximum-durability
+loss, random breakage, item destruction, repair skill XP, crafting recipes, or
+gradual combat penalties between full and zero condition.
+
+## First-slice scope
+
+Only the five mapped primary chest body-armors are durable initially:
+
+| Armor              | Construction | Maximum condition | Repair family | Basic kit capacity |
+| ------------------ | ------------ | ----------------: | ------------- | -----------------: |
+| Padded Battle Robe | Padded       |                40 | Cloth         |                +20 |
+| Leather Armor      | Leather      |                60 | Leather       |                +30 |
+| Chain Mail         | Mail         |                90 | Metal         |                +45 |
+| Breastplate        | Plate        |               120 | Metal         |                +45 |
+| Brigandine Coat    | Hybrid       |               100 | Hybrid        |                +50 |
+
+The values are initial balance targets. Construction identifies armor
+proficiency and repair compatibility, but it does not derive maximum condition,
+protection, or kit capacity implicitly.
+
+## Data model
+
+Durable item definitions declare:
+
+- `maxDurability`: a positive maximum condition;
+- `repairFamily`: one explicit family compatible with repair products.
+
+Finished repair-product definitions declare:
+
+- the same `repairFamily` vocabulary;
+- `repairAmount`: a positive amount restored by one product.
+
+Each durable `ItemInstance` declares:
+
+- `durability`: remaining condition from 0 through the definition maximum.
+
+Durable equipment must be non-stackable. If stack handling is applied
+generically, entries may merge only when item definition, enchantment, and
+condition are identical.
+
+Startup validation must reject a durable item without a compatible repair
+family, a repair product without a positive capacity, an unsupported family,
+or durability metadata on an incompatible item kind.
+
+## Instance lifecycle
+
+New durable instances start at the current definition maximum. The same raw
+condition must survive:
+
+- bag and equipped movement;
+- equip and unequip;
+- drop and pickup;
+- resident-trader transfer;
+- merchant sale and buyback;
+- disconnect, reconnect, and database round trip.
+
+Legacy database rows may have no stored condition. On login, a missing value is
+hydrated to the current definition maximum; the next save makes it explicit.
+If a later data change lowers a maximum, an older larger value clamps to the
+new maximum on load.
+
+Condition is never client-authored. The server sends raw values, and clients
+derive presentation from the same shared rules.
+
+## Wear event
+
+An accepted, landed monster hit wears the same functional primary chest
+captured in the authoritative defense snapshot by exactly 1 condition.
+
+The hit uses the pre-wear snapshot for Guard, protection, and armor-skill
+eligibility. If that hit reduces condition from 1 to 0, the armor becomes
+Broken for subsequent events; the accepted hit is not recalculated midway.
+
+The following events cause no wear:
+
+- a monster miss;
+- a rejected, stale, duplicate, out-of-range, cross-floor, or invalid attack;
+- a client prediction without an accepted server result;
+- a different item equipped after the server captured the resolved snapshot;
+- player attacks, PvP, death, weather, or ordinary movement in the first slice.
+
+## Broken behavior
+
+At 0 condition, armor remains equipped and keeps its equipment weight. It is
+not deleted. Until repaired, it contributes:
+
+- no item Guard;
+- no slash, pierce, or blunt protection;
+- no primary-armor skill activation or XP eligibility.
+
+Broken state must be visible in item tooltips, character defense summaries, and
+agent state. Ordinary clothing remains non-combat regardless of condition.
+
+## Condition labels
+
+Labels are presentation bands over the raw integer value:
+
+| Label    | Boundary              |
+| -------- | --------------------- |
+| Pristine | Above 75%             |
+| Worn     | Above 50% through 75% |
+| Damaged  | Above 25% through 50% |
+| Critical | Above 0% through 25%  |
+| Broken   | Exactly 0             |
+
+The bands do not change combat performance. Every positive condition value is
+fully functional in the first slice; only Broken disables the item. This avoids
+hidden protection cliffs and keeps the initial balance observable.
+
+## Repair action
+
+A repair request targets the equipped primary chest and one owned finished
+repair product. It is valid only when:
+
+- the character is connected, alive, and not in combat;
+- the chest is durable and below maximum condition;
+- the repair product exists in the character's bag;
+- the product and armor repair families match;
+- the request can atomically consume exactly one product and update the same
+  item instance.
+
+A successful repair applies:
+
+```text
+new condition = min(current condition + repairAmount, maxDurability)
+```
+
+The product is consumed only when condition increases. A mismatched family,
+full-condition item, defeated character, in-combat character, missing item,
+duplicate request, or otherwise rejected action keeps both the product and
+condition unchanged.
+
+Using a finished kit awards no skill XP. Cloth, Leather, Metal, and Hybrid are
+repair families, not automatically trained Tailoring, Leatherworking,
+Smithing, or Repair skills.
+
+## Economy and resale
+
+Condition modifies NPC resale after the ordinary sell-rate and haggling
+calculation. The condition percentage is:
+
+```text
+25 + floor(75 × current condition / maximum condition)
+```
+
+The final payout is the ordinary offer multiplied by that percentage, rounded
+down, with the existing minimum positive payout preserved. Full-condition gear
+keeps 100% of the ordinary offer. Broken gear keeps a 25% salvage floor.
+
+The smooth raw-condition formula is independent of presentation labels, so
+crossing Pristine, Worn, Damaged, or Critical does not create a price cliff.
+
+A merchant buyback entry stores the exact final payout, enchantment, and
+condition of the sold unit. Repurchasing costs that exact payout and restores
+the same condition, making the undo gold-neutral. Resident-trader transfers
+also preserve condition. Batched sell and buyback paths must follow the same
+rules as single-item actions.
+
+Selling, buying back, and repairing grant no armor, appraisal, trading, repair,
+or profession XP.
+
+## Protocol and persistence
+
+The wire model carries optional raw condition on item instances and trade
+entries so legacy data can be represented during migration. Once hydrated, a
+durable item should normally have an explicit value.
+
+Any protocol change must update the handshake version and reject incompatible
+clients. Browser and agent clients display raw current/maximum condition and the
+shared label; they do not send trusted condition values.
+
+Persistence tests must cover bag, equipped, ground, resident trade, merchant
+buyback, reconnect, legacy-null hydration, and over-maximum clamping.
+
+## Acceptance criteria
+
+The first slice is acceptable when tests demonstrate that:
+
+1. Only accepted landed monster hits wear the resolved functional chest.
+2. The hit that reaches zero resolves with the pre-wear defense snapshot, and
+   later hits receive no defense or armor-skill activation from that chest.
+3. Condition survives every inventory, persistence, ground, and trade path.
+4. Each repair family accepts only its matching product and applies its authored
+   bounded capacity atomically.
+5. Rejected repair requests consume nothing.
+6. Browser and agent labels match shared boundary rules.
+7. Single and batched resale use the same smooth condition value.
+8. Buyback restores the exact condition and exact adjusted payout.
+
+## Future expansion
+
+Weapons, shields, additional armor layers, profession-made repair products,
+repair quality, field-repair restrictions, material costs, and environmental
+wear should reuse the same instance-state and repair-family model. Each new wear
+source or durable equipment category needs its own gameplay and balance review.
+
+The skill interaction boundary is defined in
+[SKILL_SYSTEM.md](SKILL_SYSTEM.md): wear and finished-product use are not skill
+training events by themselves.

--- a/doc/SKILL_SYSTEM.md
+++ b/doc/SKILL_SYSTEM.md
@@ -1,0 +1,283 @@
+# Skill System Design
+
+> Status: **Proposed**. This document defines the intended gameplay contract.
+> Implementation and balance changes should be reviewed separately after the
+> design is accepted.
+
+OpenMMO uses a small, use-based progression model: characters improve skills by
+completing legitimate actions that the server accepts and resolves. Ultima
+Online is inspiration for that broad idea, not a rules specification. OpenMMO
+keeps its own combat, character-level, persistence, protocol, and client model.
+
+## Goals
+
+- Reward real gameplay instead of client-declared training events.
+- Keep skill definitions explicit and data-authored.
+- Use one progression, persistence, and messaging model across skill families.
+- Keep bonuses small enough that equipment and character attributes remain
+  meaningful.
+- Make browser, agent, and server behavior describe the same rules.
+- Add one bounded vertical slice at a time so balance can be measured before
+  another family expands.
+
+## Non-goals
+
+The initial system does not add a total skill-point cap, skill locks, decay,
+trainers, skill books, random gain chance, difficulty-based gain, diminishing
+returns, PvP training, target-dummy training, class restrictions, active combat
+abilities, or skill-based critical hits. Those require separate designs.
+
+Equipment condition, repair, and resale are defined in
+[DURABILITY.md](DURABILITY.md). Using a finished product does not automatically
+train the profession that might eventually make that product.
+
+## Shared progression model
+
+All trained skills use one stable wire identifier and one sparse progress map.
+Skill levels run from 0 through 30. Reaching level `n` costs `100 × n²` XP for
+that level, and the cumulative threshold is the sum of those per-level costs.
+XP clamps at the level-30 threshold.
+
+A missing map entry means level 0 with 0 XP. The first valid award creates the
+entry, even when the award is not enough to reach level 1. This avoids creating
+rows for skills a character has never used.
+
+The proposed shared skill set is:
+
+| Domain     | Skill identifiers                                                            |
+| ---------- | ---------------------------------------------------------------------------- |
+| Gathering  | `fishing`                                                                    |
+| Weapons    | `one_handed_sword`, `dagger`, `spear`                                        |
+| Defense    | `shield`                                                                     |
+| Treatment  | `healing`                                                                    |
+| Body armor | `padded_armor`, `leather_armor`, `mail_armor`, `plate_armor`, `hybrid_armor` |
+
+Adding another identifier is a protocol and gameplay decision. Unknown item
+metadata must fail validation rather than silently creating a new skill.
+
+## Server authority
+
+The server owns every input that determines a skill award:
+
+- the acting character and authoritative equipment;
+- target existence, life state, floor, range, and ownership;
+- cooldown or action-window acceptance;
+- hit, miss, damage, healing, and kill outcomes;
+- the mapped skill, current progress, bonus, and XP amount.
+
+The client may request an action, but it never supplies the trained skill,
+result, level, bonus, or XP. Rejected, stale, duplicated, out-of-range,
+cross-floor, or otherwise invalid requests award nothing.
+
+XP is attached to a resolved gameplay event, not to an animation packet,
+inventory click, product consumption, or client prediction.
+
+## Explicit item mappings
+
+Skills are assigned by item metadata, never inferred from names, icons, model
+paths, material strings, or damage dice.
+
+| Metadata                           | Purpose                                                                                |
+| ---------------------------------- | -------------------------------------------------------------------------------------- |
+| `weaponSkill`                      | Main-hand weapon accuracy family                                                       |
+| `defenseSkill`                     | Shield or primary body-armor proficiency                                               |
+| `useSkill`                         | Skill used by an authoritative item action, such as Bandage treatment                  |
+| `armorConstruction`                | Padded, Leather, Mail, Plate, or Hybrid body-armor identity                            |
+| `equipmentKind` / `equipmentLayer` | Distinguish body armor, shields, clothing, accessories, held items, and primary layers |
+
+Startup validation must reject mappings whose slot, equipment kind, layer,
+construction, dice, Guard, or protection profile is incompatible with the
+declared skill.
+
+## Shared bonus bands
+
+Weapon accuracy, Shield Guard, primary-armor Guard, and Bandage treatment use
+the same small four-band progression:
+
+| Skill level | Bonus |
+| ----------- | ----: |
+| 0–4         |    +0 |
+| 5–14        |    +1 |
+| 15–24       |    +2 |
+| 25–30       |    +3 |
+
+The meaning of the bonus depends on the skill family. A weapon skill adds to
+the attack roll, Shield and armor skills add to Guard, and Healing adds HP to a
+valid Bandage treatment. No initial skill adds directly to weapon damage.
+
+## Weapon skills
+
+### Mappings and combat profiles
+
+| Skill            | Initial mapped items                                   | Reach | Authoritative attack window |
+| ---------------- | ------------------------------------------------------ | ----: | --------------------------: |
+| One-Handed Sword | Iron Sword, Worn Iron Sword, Goblin Sword, Small Sword |   2 m |                     1.533 s |
+| Dagger           | Dagger                                                 |   2 m |                     1.533 s |
+| Spear            | Spear                                                  |   3 m |                     2.467 s |
+
+The server captures the equipped main-hand definition before resolution. The
+browser and agent use the same authored profile for chase range and presentation,
+but only the server accepts the action window.
+
+The attack formula is:
+
+```text
+character-level attack bonus
++ Strength modifier
++ weapon enchantment
++ mapped weapon-skill bonus
+```
+
+Damage remains the weapon dice plus Strength modifier and enchantment. Weapon
+skill does not change damage in the initial design.
+
+### Weapon XP
+
+Accepted server-resolved attacks award:
+
+| Outcome      | Total XP |
+| ------------ | -------: |
+| Miss         |        5 |
+| Hit          |       10 |
+| Killing blow |       20 |
+
+Equivalently, the award is `5 + (hit ? 5 : 0) + (killing blow ? 10 : 0)`.
+Only the authoritative transition from positive HP to zero earns the killing
+blow portion. Switching targets cannot bypass the per-attacker action window.
+
+## Shield
+
+Only explicitly mapped off-hand shields with positive item Guard activate the
+Shield skill. Torches, weapons, accessories, and other armor do not.
+
+Effective Guard is:
+
+```text
+DEX-derived base Guard
++ Guard from equipped items
++ active Shield skill bonus
++ active primary-armor skill bonus
+```
+
+Item Guard and trained Guard are separate terms and each is applied once.
+Removing the mapped shield removes only its item contribution and Shield skill
+bonus.
+
+An accepted monster attack against a living defender trains Shield as follows:
+
+| Outcome        |  XP |
+| -------------- | --: |
+| Monster misses |  10 |
+| Monster hits   |   5 |
+
+A successful avoidance teaches more, but a failed defense still teaches. The
+initial slice adds no block animation, active parry request, damage reflection,
+or Shield-specific mitigation packet.
+
+## Healing
+
+Healing means applying treatment. It does not mean consuming any item that
+restores HP.
+
+Only Bandages map to `healing` through `useSkill`. A valid initial action is
+self-treatment by a connected, living, injured character who owns the mapped
+Bandage instance. The server consumes one Bandage atomically before applying
+the authoritative roll.
+
+A Bandage restores `2d4 + Healing bonus` HP, capped at maximum HP. XP equals
+the HP actually restored after the cap. Treating a one-point injury therefore
+awards 1 XP. Full-health, defeated, missing-item, unusable-item, and duplicated
+requests award nothing and must not consume a Bandage.
+
+Healing Potions, fish, and other finished products may restore HP through their
+own item effects, but drinking or eating them awards no Healing XP and receives
+no Healing bonus. A Healing Potion remains a `6d4` product. Future Alchemy may
+govern manufacturing without turning potion drinking into treatment training.
+
+Party treatment, resurrection, magical healing, treatment channels, crafting,
+and profession restrictions are outside the initial Healing slice.
+
+## Body-armor proficiencies
+
+Body armor uses construction-specific skills rather than Light/Heavy buckets.
+The initial mappings are:
+
+| Construction | Skill           | Initial primary chest |
+| ------------ | --------------- | --------------------- |
+| Padded       | `padded_armor`  | Padded Battle Robe    |
+| Leather      | `leather_armor` | Leather Armor         |
+| Mail         | `mail_armor`    | Chain Mail            |
+| Plate        | `plate_armor`   | Breastplate           |
+| Hybrid       | `hybrid_armor`  | Brigandine Coat       |
+
+The explicitly mapped, functional primary chest anchors the active armor skill.
+Helmets, gloves, gauntlets, pants, greaves, boots, ordinary clothing, and other
+layers do not activate a second armor skill. Mixed equipment therefore cannot
+create several armor-skill awards from one hit.
+
+An armored robe or coat may qualify when its metadata explicitly says it is
+primary body armor with a mapped construction. Garment form or a word in the
+item name is never sufficient. An ordinary Traveler's Robe remains clothing.
+
+Each active mapped armor skill uses the shared +0/+1/+2/+3 Guard bands. Item
+Guard, authored slash/pierce/blunt protection, and trained Guard are separate
+values. Construction identifies proficiency and repair compatibility; it does
+not implicitly derive mitigation numbers.
+
+An accepted, landed monster hit awards 5 XP to the one active armor skill. A
+miss awards 0 because the blow did not reach the armor. Rejected attacks,
+replayed cooldown requests, unmapped gear, ordinary clothing, and Broken armor
+award nothing. If a bonus threshold is crossed, clients receive one final
+authoritative Guard value containing all simultaneously active item, Shield,
+and primary-armor terms.
+
+`bodyCoverage` may describe head, torso, arms, hands, legs, and feet, but it is
+not a skill trigger. Hit-location rolls, weighted regional mitigation,
+multi-layer occupancy, casting penalties, and construction-specific movement
+rules require separate designs.
+
+## Equipment burden is not a skill
+
+Equipped weight may use Strength-based capacity to select an unburdened, light,
+medium, or heavy movement band. Bag contents, armor skill level, and a future
+Athletics skill do not modify that band in the initial design. Movement burden
+does not train a skill.
+
+## Durability is not a skill action
+
+Broken primary armor cannot activate or train its armor proficiency until it is
+repaired. Wear, repair-kit use, selling, and buyback grant no armor, repair,
+appraisal, trading, tailoring, or smithing XP. Future crafting skills may
+produce maintenance supplies, but consuming a finished kit remains equipment
+maintenance. See [DURABILITY.md](DURABILITY.md).
+
+## Persistence and protocol
+
+All skills share one sparse character-skill table, generic dirty tracking,
+batch save, logout and shutdown flush, and login load. A new skill does not add
+a character column or a family-specific save path.
+
+Generic private messages carry full skill snapshots and XP deltas. A protocol
+version must change whenever a new wire identifier or message shape would make
+an older client unsafe. The handshake must reject incompatible clients rather
+than allowing partial interpretation.
+
+Persistence should preserve unknown rows so a temporarily older server does
+not erase progress it cannot interpret.
+
+## Browser and agent parity
+
+Both clients consume the same generic snapshots and deltas. They may display
+trained entries, level progress, the relevant bonus, mapped item metadata, and
+the exact authoritative Guard value.
+
+The agent stores routine skill and Guard updates as state-only information so
+every XP event does not wake the language model. Neither client computes a
+trusted outcome or chooses which skill receives XP.
+
+## Balance and change control
+
+The XP awards, bands, ranges, and action windows above are initial values. Any
+balance change should use aggregate, non-identifying telemetry and receive a
+separate review. Expanding a family, changing what trains it, or adding a new
+bonus is a new vertical slice—not an automatic consequence of adding an item.


### PR DESCRIPTION
## Purpose

Settle the gameplay contracts for skills and item condition before reviewing or merging the implementation in #97.

This PR contains design documentation only. It adds no Rust, TypeScript, data, protocol, persistence, or balance implementation.

## Documents

- `doc/SKILL_SYSTEM.md` defines the proposed use-based progression model, server authority, explicit item mappings, shared bonus bands, weapon XP, Shield training, Bandage-based Healing, construction-specific body-armor proficiencies, persistence, protocol boundaries, and client parity.
- `doc/DURABILITY.md` defines per-instance condition, the initial primary-chest scope, landed-hit wear, pre-wear defense resolution, Broken behavior, condition labels, repair families and capacities, atomic repair rules, persistence, trade preservation, resale value, and acceptance criteria.

## Review focus

- Whether valid misses, hits, killing blows, Shield outcomes, landed armor hits, and actual HP restored are the correct XP events and amounts.
- Whether +0/+1/+2/+3 is the right initial bonus ladder for accuracy, Guard, and Bandage treatment.
- Whether Padded, Leather, Mail, Plate, and Hybrid should remain explicit construction skills anchored only to a mapped functional primary chest.
- Whether Healing should mean Bandage treatment while potions and food remain finished products that grant no Healing XP.
- Whether one condition per accepted landed monster hit, full performance above zero, and disabled defense at Broken are the right first durability slice.
- Whether Cloth +20, Leather +30, Metal +45, and Hybrid +50 repair products are suitable initial capacities.
- Whether smooth resale value from a 25% Broken salvage floor to 100% at full condition, with exact condition-preserving buyback, is the right economy behavior.
- Whether the listed non-goals and future expansion boundaries keep the first implementation sufficiently narrow.

## Relationship to implementation

Implementation PR #97 should remain draft while this design is reviewed. After the design is accepted, the implementation branch will be updated to match the approved documents and rebased against the then-current `master` before implementation review resumes.

## Validation

- The commit changes exactly `doc/SKILL_SYSTEM.md` and `doc/DURABILITY.md`.
- Markdown Prettier check passed.
- `git diff --check` passed.
