### PR TITLE
Refuse trade with a merchant who is asleep

### DIFF
--- a/server/src/game_state/tests/trading_tests/merchant_tests.rs
+++ b/server/src/game_state/tests/trading_tests/merchant_tests.rs
@@ -60,6 +60,79 @@ async fn offer_deal_clamps_modifier_to_cha_band() {
     }
 }
 
+/// Rica's schedule puts her in bed at night; the server only learns of it
+/// through the `InteractObject` that leaves her occupying a bed.
+#[tokio::test]
+async fn a_sleeping_merchant_refuses_to_open_shop() {
+    let game_state = make_test_game_state("sleeping_merchant_shop");
+    let (mut buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 100).await;
+    put_in_bed(&game_state, "npc_rica").await;
+
+    game_state
+        .open_shop(&pid("buyer"), &pid("npc_rica"), true)
+        .await;
+
+    assert!(
+        drain(&mut buyer_rx).iter().any(|m| matches!(
+            m,
+            ServerMessage::TradeError { message } if message.contains("asleep")
+        )),
+        "opening a sleeping merchant's shop must be refused"
+    );
+}
+
+/// The check sits in the shared validation, so a window opened before bedtime
+/// stops transacting too rather than trading with a sleeping merchant.
+#[tokio::test]
+async fn falling_asleep_stops_an_open_shop_from_selling() {
+    let game_state = make_test_game_state("sleeping_merchant_buy");
+    let (mut buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 1000).await;
+    game_state
+        .open_shop(&pid("buyer"), &pid("npc_rica"), true)
+        .await;
+    let _ = drain(&mut buyer_rx);
+
+    put_in_bed(&game_state, "npc_rica").await;
+    game_state
+        .buy_item(&pid("buyer"), &pid("npc_rica"), "wooden_shield")
+        .await;
+
+    assert!(
+        drain(&mut buyer_rx).iter().any(|m| matches!(
+            m,
+            ServerMessage::TradeError { message } if message.contains("asleep")
+        )),
+        "buying from a sleeping merchant must be refused"
+    );
+    assert_eq!(
+        game_state.get_player_gold(&pid("buyer")).await,
+        1000,
+        "and must not charge the buyer"
+    );
+}
+
+/// Only a bed means asleep — an NPC resting on a chair is still open for
+/// business.
+#[tokio::test]
+async fn a_merchant_on_a_chair_still_trades() {
+    let game_state = make_test_game_state("chair_merchant");
+    let (mut buyer_rx, _npc_rx) = setup_haggle(&game_state, 10, 100).await;
+    game_state
+        .set_player_interaction(&pid("npc_rica"), Some("chair".to_string()), Some(7))
+        .await;
+
+    game_state
+        .open_shop(&pid("buyer"), &pid("npc_rica"), true)
+        .await;
+
+    assert!(
+        drain(&mut buyer_rx)
+            .iter()
+            .any(|m| matches!(m, ServerMessage::ShopState { .. })),
+        "a seated merchant must still open the shop"
+    );
+}
+
 #[tokio::test]
 async fn cross_floor_offer_deal_is_rejected_without_consuming_ledger() {
     let game_state = make_test_game_state("cross_floor_offer");

--- a/server/src/game_state/tests/trading_tests/mod.rs
+++ b/server/src/game_state/tests/trading_tests/mod.rs
@@ -24,6 +24,13 @@ async fn set_floor(game_state: &GameState, name: &str, floor: i8) {
         .floor_level = floor;
 }
 
+/// Occupy a bed, which is all the server sees of a scheduled NPC going to sleep.
+async fn put_in_bed(game_state: &GameState, name: &str) {
+    game_state
+        .set_player_interaction(&pid(name), Some("bed".to_string()), Some(3))
+        .await;
+}
+
 /// Spawn a merchant NPC and a buyer with the given CHA/gold next to each
 /// other, returning the buyer's direct-message receiver and the NPC's.
 async fn setup_haggle(game_state: &GameState, cha: u8, gold: i64) -> (DirectRx, DirectRx) {

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -16,6 +16,11 @@ use super::StoredBuyback;
 /// Maximum distance between player and trader for any shop interaction.
 const MAX_TRADE_DISTANCE: f32 = 6.0;
 
+/// Interaction object an NPC occupies while asleep. Schedules send NPCs to bed
+/// at night (`agent-client/data/npcs/*/schedule.json`), and the resulting
+/// `InteractObject` is what the server sees of it.
+const BED_OBJECT_TYPE: &str = "bed";
+
 /// Most recent sold units kept per (player, merchant) for buyback; older
 /// entries are dropped oldest-first.
 const BUYBACK_CAP: usize = 10;
@@ -182,6 +187,12 @@ impl super::GameState {
             return Err("That character is not a trader");
         }
         let def = trader_def_by_name(&npc.name).ok_or("This NPC does not trade")?;
+
+        // Every trade path validates here, so this closes the shop window and
+        // any transaction already inside one.
+        if npc.object_type.as_deref() == Some(BED_OBJECT_TYPE) {
+            return Err("The trader is asleep");
+        }
 
         let dist_sq = reachable_dist_sq(
             player.position,


### PR DESCRIPTION
From `doc/TODO.md`:

> - Rica 잠잘 때 거래 막고, 야간 상점 npc 추가

This is the first half — the night-shop NPC is a separate piece of content.

Rica's schedule sends her to bed at night, but it lives in `agent-client/data/npcs/rica/schedule.json`, so the server has no idea she is asleep. It does, however, see the `InteractObject` her driver sends on arrival, which leaves her occupying a bed — that is enough to know.

The check goes in `validate_trader`. Every trade path already routes through it (`open_shop`, `buy_item`, `buy_items`, `sell_item`, `sell_items`, `buyback_item`, `buyback_items`), so one line closes the shop window and also stops a window opened before bedtime from transacting afterwards. I kept it to beds specifically: an NPC resting on a chair is still open for business.

## Test plan

- `a_sleeping_merchant_refuses_to_open_shop` — the window is refused
- `falling_asleep_stops_an_open_shop_from_selling` — a window opened while awake stops transacting, and the buyer is not charged
- `a_merchant_on_a_chair_still_trades` — a different interaction does not block

I checked the first two fail without the change before keeping it. `cargo test --workspace` is green (361 server tests), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)