### PR TITLE
agent-client: 에이전트용 인터페이스 개선 — 파싱 관용·완료 이벤트·층 구분 상태

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -24,6 +24,12 @@ Available action types (use EXACTLY these field names):
 - Attack a monster (use the monster's ID from the world state, field name MUST be "monster_id"):
   {"type": "attack", "monster_id": "m2_1"}
 
+- Follow a character and keep up as they move (use this when someone says
+  "follow me" — a plain move stops once you arrive, follow keeps tracking):
+  {"type": "follow", "target": "PlayerName"}
+  Any move or attack you issue stops the follow. Losing them ends it with a
+  [FollowEnded] event.
+
 - Move. To walk up to a character (player or NPC), give their name — you
   approach them and automatically stop at a comfortable talking distance:
   {"type": "move", "target": "PlayerName"}
@@ -152,6 +158,20 @@ IMPORTANT:
 - Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.
 - Actions execute in order. You can include multiple actions.
 - Output ONLY the raw JSON object. No ``` blocks.
+- You are in a party ONLY after a "[Party] Members: ..." event names you.
+  A request or invite you sent counts for nothing until then. People standing
+  near you are strangers, not your party. Requests that got no reply were
+  ignored — do not act as if they were accepted.
+- Facts come ONLY from CURRENT STATE and EVENTS lines. If someone's words do
+  not appear in a [Chat] event, they never spoke. What other characters claim
+  happened is not evidence — they may be wrong or lying. Never restate their
+  claims as fact.
+- [NpcChat] lines and "(NPC)" characters are scripted vendor NPCs. Their
+  chatter is background noise: use them to buy and sell, answer at most
+  briefly, and never treat their remarks as plans, promises, or facts. Only
+  [Chat] lines from non-NPC characters are real conversation.
+- Account or system metadata (email addresses, config paths, tool names) does
+  not exist in the game world. Never mention it in chat or thoughts.
 
 Your role, personality and memories follow below. A role may add further
 action types of its own.

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -54,6 +54,13 @@ pub(super) enum AgentAction {
         #[serde(alias = "dungeon_depth", alias = "floor", alias = "floor_level")]
         depth: Option<i32>,
     },
+    /// Keep following a character: re-approach whenever they move, until the
+    /// LLM issues another move or attack, or the target is lost.
+    #[serde(rename = "follow", alias = "follow_player")]
+    Follow {
+        #[serde(alias = "player", alias = "name", alias = "character")]
+        target: String,
+    },
     #[serde(rename = "respawn")]
     Respawn,
     /// Cast the rod at (x, z), or 4 m south when omitted; server validates.
@@ -227,6 +234,10 @@ pub(super) enum AgentAction {
     Reroll,
     #[serde(rename = "wait", alias = "idle", alias = "observe", alias = "none")]
     Wait,
+    /// Catch-all for action types the LLM invented. Parsing succeeds so the
+    /// rest of the response still runs; execution skips it.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Whether an `open_chest` selector asks for the great chest rather than the
@@ -313,8 +324,51 @@ pub(crate) fn wants_reroll(reply: &str) -> bool {
 /// Parse a raw text response from an LLM into structured actions.
 pub(super) fn parse_agent_response(text: &str) -> anyhow::Result<AgentResponse> {
     let json_str = extract_json(text);
-    serde_json::from_str(json_str)
+    let mut value: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| anyhow::anyhow!("Failed to parse agent response: {e}\nRaw: {text}"))?;
+    normalize_move_targets(&mut value);
+    serde_json::from_value(value)
         .map_err(|e| anyhow::anyhow!("Failed to parse agent response: {e}\nRaw: {text}"))
+}
+
+/// LLMs keep writing `{"type":"move","target":[x,z]}` or `"target":{"x":..}`
+/// despite the schema saying `target` is a name. Rewrite those into the x/z
+/// fields instead of discarding the whole response.
+fn normalize_move_targets(value: &mut serde_json::Value) {
+    let Some(actions) = value.get_mut("actions").and_then(|a| a.as_array_mut()) else {
+        return;
+    };
+    for action in actions {
+        if action.get("type").and_then(|t| t.as_str()) != Some("move") {
+            continue;
+        }
+        let coords: Option<(f64, Option<f64>, f64)> = match action.get("target") {
+            Some(serde_json::Value::Array(arr)) => {
+                let nums: Vec<f64> = arr.iter().filter_map(|n| n.as_f64()).collect();
+                match nums.len() {
+                    2 => Some((nums[0], None, nums[1])),
+                    3 => Some((nums[0], Some(nums[1]), nums[2])),
+                    _ => None,
+                }
+            }
+            Some(serde_json::Value::Object(obj)) => {
+                match (obj.get("x").and_then(|n| n.as_f64()), obj.get("z").and_then(|n| n.as_f64())) {
+                    (Some(x), Some(z)) => Some((x, obj.get("y").and_then(|n| n.as_f64()), z)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        if let Some((x, y, z)) = coords {
+            let obj = action.as_object_mut().unwrap();
+            obj.remove("target");
+            obj.entry("x").or_insert_with(|| x.into());
+            if let Some(y) = y {
+                obj.entry("y").or_insert_with(|| y.into());
+            }
+            obj.entry("z").or_insert_with(|| z.into());
+        }
+    }
 }
 
 /// Extract JSON object from text that might contain markdown code blocks.
@@ -374,6 +428,10 @@ pub(super) fn action_to_command(
     player_pos: Option<&onlinerpg_shared::Position>,
 ) -> Option<ClientMessage> {
     match action {
+        AgentAction::Unknown => None,
+        // Handled in `execute::handle_response` (needs name resolution and a
+        // background chase task).
+        AgentAction::Follow { .. } => None,
         AgentAction::Say { message } => Some(ClientMessage::ChatMessage {
             message: message.clone(),
         }),
@@ -518,6 +576,74 @@ mod tests {
         assert_eq!(target, None);
         assert_eq!(x, Some(10.0));
         assert_eq!(z, Some(-5.0));
+    }
+
+    #[test]
+    fn move_target_coordinate_array_becomes_xz() {
+        let action =
+            parse_single_action(r#"{"actions": [{"type": "move", "target": [-1460, 4730]}]}"#);
+        let AgentAction::Move { target, x, z, .. } = action else {
+            panic!("expected Move");
+        };
+        assert_eq!(target, None);
+        assert_eq!(x, Some(-1460.0));
+        assert_eq!(z, Some(4730.0));
+    }
+
+    #[test]
+    fn move_target_xyz_array_becomes_xyz() {
+        let action = parse_single_action(
+            r#"{"actions": [{"type": "move", "target": [-1460, 1.1, 4730]}]}"#,
+        );
+        let AgentAction::Move { target, x, y, z, .. } = action else {
+            panic!("expected Move");
+        };
+        assert_eq!(target, None);
+        assert_eq!(x, Some(-1460.0));
+        assert_eq!(y, Some(1.1));
+        assert_eq!(z, Some(4730.0));
+    }
+
+    #[test]
+    fn move_target_coordinate_object_becomes_xz() {
+        let action = parse_single_action(
+            r#"{"actions": [{"type": "move", "target": {"x": 10.0, "z": -5.0}}]}"#,
+        );
+        let AgentAction::Move { target, x, z, .. } = action else {
+            panic!("expected Move");
+        };
+        assert_eq!(target, None);
+        assert_eq!(x, Some(10.0));
+        assert_eq!(z, Some(-5.0));
+    }
+
+    #[test]
+    fn move_ignores_extra_reason_field() {
+        let action = parse_single_action(
+            r#"{"actions": [{"type": "move", "x": -1485.0, "z": 4720.0,
+                "reason": "남서쪽 슬라임 탐색"}]}"#,
+        );
+        let AgentAction::Move { x, z, .. } = action else {
+            panic!("expected Move");
+        };
+        assert_eq!(x, Some(-1485.0));
+        assert_eq!(z, Some(4720.0));
+    }
+
+    #[test]
+    fn unknown_action_type_does_not_discard_response() {
+        let resp = parse_agent_response(
+            r#"{"actions": [{"type": "look", "reason": "scan"}, {"type": "say", "message": "hi"}],
+                "memory_update": "kept"}"#,
+        )
+        .unwrap();
+        assert_eq!(resp.actions.len(), 2);
+        assert!(matches!(resp.actions[0], AgentAction::Unknown));
+        let AgentAction::Say { ref message } = resp.actions[1] else {
+            panic!("expected Say to survive");
+        };
+        assert_eq!(message, "hi");
+        assert_eq!(resp.memory_update.as_deref(), Some("kept"));
     }
 
     #[test]

--- a/agent-client/src/driver/combat.rs
+++ b/agent-client/src/driver/combat.rs
@@ -104,8 +104,26 @@ pub(super) async fn tick_combat(
     // Chase until in range (handles monster movement during chase)
     match chase_monster(state, &monster_id).await {
         ChaseResult::InRange => {}
-        ChaseResult::Lost(_) | ChaseResult::Error => {
-            info!("Combat ended: monster {monster_id} lost or error during chase");
+        ChaseResult::Lost(reason) => {
+            info!("Combat ended: monster {monster_id} lost during chase ({reason:?})");
+            let mut s = state.lock().await;
+            let note = match reason {
+                // Gone from the world state right after we were trading
+                // blows — almost always our kill.
+                LostReason::TargetGone => format!(
+                    "[CombatEnded] {monster_id} is gone — dead or despawned. Pick up any \
+                     loot and decide your next move."
+                ),
+                other => format!(
+                    "[CombatEnded] You broke off from {monster_id} — {}.",
+                    other.clause()
+                ),
+            };
+            s.push_agent_event(note);
+            return None;
+        }
+        ChaseResult::Error => {
+            info!("Combat ended: error during chase of {monster_id}");
             return None;
         }
     }

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -166,6 +166,71 @@ pub(super) async fn handle_response(
             continue;
         }
 
+        // A new movement intent replaces a running follow.
+        if matches!(
+            action,
+            AgentAction::Move { .. } | AgentAction::Attack { .. } | AgentAction::Follow { .. }
+        ) {
+            let mut s = state.lock().await;
+            if let Some(name) = s.cancel_follow() {
+                info!("Follow of {name} cancelled by a new movement action");
+            }
+        }
+
+        // Keep following a character until something else takes over.
+        if let AgentAction::Follow { target } = action {
+            let name = target.trim();
+            let target_id = {
+                let mut s = state.lock().await;
+                match s.resolve_nearby_player(name) {
+                    Some((id, _)) => id,
+                    None => {
+                        warn!("follow: no nearby character named '{name}'");
+                        s.push_agent_event(format!(
+                            "[MoveFailed] No character named '{name}' is nearby to follow."
+                        ));
+                        continue;
+                    }
+                }
+            };
+            let name = name.to_string();
+            let task_state = Arc::clone(state);
+            let task_name = name.clone();
+            let handle = tokio::spawn(async move {
+                loop {
+                    match approach_player(&task_state, &target_id).await {
+                        ChaseResult::InRange => {
+                            tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+                        }
+                        ChaseResult::Lost(loss) => {
+                            let mut s = task_state.lock().await;
+                            s.follow_task = None;
+                            s.push_agent_event(format!(
+                                "[FollowEnded] You are no longer following {task_name} — {}.",
+                                loss.clause()
+                            ));
+                            break;
+                        }
+                        ChaseResult::Error => {
+                            let mut s = task_state.lock().await;
+                            s.follow_task = None;
+                            s.push_agent_event(format!(
+                                "[FollowEnded] Something went wrong while following {task_name}."
+                            ));
+                            break;
+                        }
+                    }
+                }
+            });
+            let mut s = state.lock().await;
+            s.follow_task = Some((name.clone(), handle));
+            s.push_agent_event(format!(
+                "[Following] You are now following {name}. Any move or attack you \
+                 issue stops the follow."
+            ));
+            continue;
+        }
+
         // For attack actions, chase the monster and attack
         if let AgentAction::Attack { monster_id } = action {
             info!("Agent attacking monster {monster_id}, chasing...");
@@ -838,6 +903,11 @@ pub(super) async fn handle_response(
                 match execute_move(state, gx, gz, floor).await {
                     MoveResult::Arrived => {
                         info!("Agent arrived at ({gx:.1}, {gz:.1})");
+                        let mut s = state.lock().await;
+                        s.push_agent_event(format!(
+                            "[Arrived] You reached ({gx:.1}, {gz:.1}). Look around and \
+                             decide your next move."
+                        ));
                     }
                     MoveResult::Blocked => {
                         warn!("Path blocked to ({gx:.1}, {gz:.1})");

--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -155,10 +155,12 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
             if !player_within_event_range(state, player_id) {
                 return None;
             }
-            Some(format!(
-                "[Chat] {}: {message}",
-                player_name(state, player_id)
-            ))
+            let is_npc = state
+                .nearby_players
+                .get(player_id)
+                .is_some_and(|p| p.is_official_npc);
+            let tag = if is_npc { "[NpcChat]" } else { "[Chat]" };
+            Some(format!("{tag} {}: {message}", player_name(state, player_id)))
         }
         ServerMessage::WhisperMessage { from, message, .. } => {
             // Skip the echo of our own outgoing whisper.

--- a/agent-client/src/state.rs
+++ b/agent-client/src/state.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use crate::dungeon::Dungeon;
 use crate::monster_ai::MonsterAiManager;
 use onlinerpg_shared::dungeon::{
-    dungeon_cache_key, floor_cells, floor_level_for_passability, passability_floor_for_level,
-    path_max_nodes, set_floor_cells,
+    cell_center, dungeon_cache_key, floor_cells, floor_level_for_passability,
+    passability_floor_for_level, path_max_nodes, set_floor_cells, world_to_cell,
 };
 use onlinerpg_shared::furniture::{self, FurniturePlacement};
 use onlinerpg_shared::housing::{HouseData, WallDirection};
@@ -438,6 +438,9 @@ pub struct SharedState {
     no_spawn_zones: Vec<NoSpawnZone>,
     /// Spectator panel handle; feeds it chat/combat/system lines
     watch: Option<Arc<crate::watch::NpcWatch>>,
+    /// Running follow loop: (target name, task handle). Any move or attack
+    /// the LLM issues aborts it; losing the target ends it with an event.
+    pub follow_task: Option<(String, tokio::task::JoinHandle<()>)>,
 }
 
 impl SharedState {
@@ -491,7 +494,16 @@ impl SharedState {
             pending_commands: Vec::new(),
             no_spawn_zones: Vec::new(),
             watch,
+            follow_task: None,
         }
+    }
+
+    /// Abort a running follow loop, if any. Returns the name that was
+    /// being followed.
+    pub fn cancel_follow(&mut self) -> Option<String> {
+        let (name, handle) = self.follow_task.take()?;
+        handle.abort();
+        Some(name)
     }
 
     /// Returns true if any non-NPC (human) player is in `nearby_players`.
@@ -1735,6 +1747,50 @@ impl SharedState {
                 ));
             }
             line.push_str(&self.format_room_props(p));
+            // Floor map in world coordinates: without it the LLM aims moves
+            // into solid rock and collects [MoveFailed] walls.
+            if let Some(d) = dungeon.as_ref() {
+                if let Some(layout) = d.layouts().get(depth as usize - 1) {
+                    let me = world_to_cell(&d.entrance, p.position.x, p.position.z);
+                    let rooms = layout
+                        .rooms
+                        .iter()
+                        .enumerate()
+                        .map(|(i, room)| {
+                            let c = cell_center(&d.entrance, depth, room.center());
+                            format!(
+                                "room {} center ({:.0}, {:.0}) {}x{}m{}",
+                                i + 1,
+                                c.x,
+                                c.z,
+                                room.w,
+                                room.d,
+                                if room.contains(me.0, me.1) {
+                                    " (you are here)"
+                                } else {
+                                    ""
+                                }
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" · ");
+                    line.push_str(&format!("\nRooms on this floor: {rooms}"));
+                    let up = cell_center(
+                        &d.entrance,
+                        depth,
+                        (layout.up_shaft.x, layout.up_shaft.z),
+                    );
+                    line.push_str(&format!("\nStairs up at ({:.0}, {:.0})", up.x, up.z));
+                    if let Some(down) = &layout.down_shaft {
+                        let dn = cell_center(&d.entrance, depth, (down.x, down.z));
+                        line.push_str(&format!("; stairs down at ({:.0}, {:.0})", dn.x, dn.z));
+                    }
+                    line.push_str(
+                        "\nEverything outside rooms and corridors is solid rock — aim \
+                         moves at room centers or stairs.",
+                    );
+                }
+            }
             return Some(line);
         }
         let dungeon = self
@@ -1903,12 +1959,15 @@ impl SharedState {
         None
     }
 
-    /// Push a synthetic agent event visible to the LLM.
+    /// Push a synthetic agent event visible to the LLM. Synthetic events are
+    /// feedback on the agent's own actions (arrival, a failed move, a kill),
+    /// so they wake the LLM driver instead of waiting out the idle interval.
     pub fn push_agent_event(&mut self, event: String) {
         if let Some(watch) = &self.watch {
             watch.push("agent", event.clone());
         }
         self.agent_events.push(event);
+        self.urgent_notify.notify_one();
     }
 
     /// Resolve a player name (or raw id) among nearby players, as used by
@@ -2121,13 +2180,19 @@ impl SharedState {
             if self.self_player_id.as_ref() == Some(&p.id) {
                 continue;
             }
+            // A character on another floor is a dot straight above or below —
+            // not someone standing next to us.
+            if p.floor_level != self.self_floor_level {
+                continue;
+            }
             if let Some(sp) = sp {
                 if p.position.dist_xz_sq(&sp.position) > sight_sq {
                     continue;
                 }
             }
+            let npc_tag = if p.is_official_npc { " (NPC)" } else { "" };
             lines.push(format!(
-                "Player: {} Lv.{} HP {}/{} at ({:.1}, {:.1}, {:.1})",
+                "Player: {}{npc_tag} Lv.{} HP {}/{} at ({:.1}, {:.1}, {:.1})",
                 p.name, p.level, p.health, p.max_health, p.position.x, p.position.y, p.position.z
             ));
             if p.is_official_npc {
@@ -2137,8 +2202,12 @@ impl SharedState {
             }
         }
 
-        // Exclude monsters beyond LLM sight radius
+        // Exclude monsters beyond LLM sight radius or on another floor —
+        // cross-floor monsters read as phantom respawns to the LLM.
         for m in self.nearby_monsters.values() {
+            if m.floor_level != self.self_floor_level {
+                continue;
+            }
             if let Some(sp) = sp {
                 if m.position.dist_xz_sq(&sp.position) > sight_sq {
                     continue;


### PR DESCRIPTION
claude 백엔드로 원격 에이전트를 하루 돌리며 잡은 문제들입니다. 전부 백엔드 무관합니다.

## 파싱 관용 2건

1. **`move`의 `target`에 좌표가 오면 x/z로 정규화** — claude(sonnet·opus 모두)가 시스템 프롬프트에 경고를 넣어도 `"target": [-1460, 4730]` 형식을 반복 생성합니다. 기존 별칭 수용(`targetId`/`target_id`/`id`)과 같은 방식으로, 배열·`{"x","z"}` 객체를 x/z 필드로 옮겨 받습니다.
2. **정의에 없는 액션 type은 그 액션만 무시** — 지금은 `{"type":"look"}` 하나가 응답 전체를 버려서, 같이 온 say·memory_update까지 사라지고 모델은 실패를 통보받지 못해 반복합니다. `#[serde(other)] Unknown` 변형으로 해당 액션만 건너뜁니다.

## 완료 이벤트 3건

행동이 끝나도 이벤트가 없어서, LLM이 다음 정기 프롬프트까지 서 있는 패턴이 반복됐습니다.

3. 좌표 이동 완료 시 `[Arrived]` — 사람 접근 move에는 있는데 좌표 move에는 없었습니다.
4. 추격하던 몬스터가 사라지면(처치 포함) `[CombatEnded]` — 사유(clause)를 붙입니다.
5. **`push_agent_event()`가 LLM 드라이버를 깨웁니다** — 합성 이벤트는 전부 에이전트 자기 행동의 결과라서, idle 간격을 기다릴 이유가 없습니다. `[MoveFailed]`·`[TradeFailed]` 등 기존 이벤트도 같이 즉시 반영됩니다.

## 새 액션 1건

6. **`follow`** — 대상이 움직이면 계속 재접근합니다(이름 move는 도착하면 끝). 다른 move/attack을 내리면 해제되고, 대상을 놓치면 `[FollowEnded]`로 통보합니다. "따라와"라는 요청을 이행할 수단이 없어서 넣었습니다.

## 상태 충실도 3건

7. **다른 층 개체를 CURRENT STATE에서 제외** — 플레이어·몬스터 목록이 XZ 거리로만 걸러져서, 던전에서 위아래 층 몬스터가 유령 리스폰처럼 보였습니다. `floor_level` 비교로 같은 층만 남깁니다.
8. **지하에서 층 레이아웃 제공** — 방 중심 좌표·크기·계단 위치를 월드 좌표로 상태창에 싣습니다. 없으면 LLM이 바위 속 좌표를 찍고 `[MoveFailed]`만 쌓입니다.
9. **공식 NPC 채팅 구분** — `[NpcChat]` 태그와 이름 뒤 `(NPC)` 표식을 붙이고, 시스템 프롬프트에 "NPC 대사는 배경, 대화로 격상하지 말 것"을 추가했습니다. 상인 NPC의 반복 호객을 에이전트가 실제 대화로 받아 서사를 쌓는 문제가 있었습니다.

## 검증

- 파서 테스트 6개 추가 (좌표 배열 2·좌표 객체 1·잉여 필드 1·미정의 액션 1 등), `cargo test -p agent-client` 124개 통과
- clippy 경고 없음
- 실운용 검증: claude 백엔드 에이전트가 이 패치 상태로 Old Crypt 1~5층을 무피해 클리어했습니다 (Lv.1→7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

