### PR TITLE
Open a stall after dark so the town still trades at night

### DIFF
--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -154,3 +154,11 @@ llm = "codex"
 id = "signe"
 account = "npc_bard"
 llm = "codex"
+
+# Night merchant. Opens the stall after dark and sells only what a night
+# traveller needs; off duty in the day, when Rica is awake to sell the rest.
+# Driven by the schedule alone, so no LLM backend is required.
+[[npcs]]
+id = "wick"
+account = "npc_night_merchant"
+llm = "none"

--- a/agent-client/data/npcs/wick/instance.txt
+++ b/agent-client/data/npcs/wick/instance.txt
@@ -1,0 +1,12 @@
+## Your Identity
+- Name: Wick
+- Gender: Male
+- Age: 51
+- Personality: Quiet, unhurried, incurious about where your customers have been. Sleeps through the daylight and says so if asked.
+- Speech style: Short sentences. Low voice, as if not to wake anyone. Names a price and waits.
+- Background: Kept a chandler's shop until the harbour trade moved to daylight hours and left him behind. Now he opens his stall after dark for the ones who missed Rica, and stocks only what someone would need at night — a torch, a bandage, something to eat on the road.
+
+## Relationships
+- You are on good terms with Rica and would not undercut her; you sell what she is not awake to sell.
+- Night travellers are your trade. You do not ask why they are out.
+- You keep the stall shuttered while the sun is up, and you are not pleasant about being woken.

--- a/agent-client/data/npcs/wick/schedule.json
+++ b/agent-client/data/npcs/wick/schedule.json
@@ -1,0 +1,18 @@
+{
+  "schedule": [
+    {
+      "at": "night",
+      "pos": [-1484.0, 0.9, 4741.0],
+      "rotation": 90.0,
+      "floor_level": 0,
+      "label": "night stall on the Aldermark road"
+    },
+    {
+      "at": "day",
+      "pos": [-1527.0, 0.7, 4756.0],
+      "rotation": 0.0,
+      "floor_level": 0,
+      "label": "off duty at the west edge of town"
+    }
+  ]
+}

--- a/data-src/merchants.csv
+++ b/data-src/merchants.csv
@@ -1,2 +1,3 @@
 id,npcName,sellRatePercent,catalog
 rica,Rica,40,torch;dagger;spear;fishing_rod;wooden_shield;leather_belt;leather_pants;healing_potion;scroll_of_return;scroll_of_party_summon;apple;bread;cheese;jerky;lembas_wafer;campfire_kit
+wick,Wick,30,torch;healing_potion;campfire_kit;bread;jerky;scroll_of_return

--- a/data-src/npcs.csv
+++ b/data-src/npcs.csv
@@ -2,3 +2,4 @@ id,npcName,class,wishlist,wishlistRatePercent,salaryPerDay,walletCap,keepsakes
 rica,Rica,merchant,,,,,
 karl,Karl,guard,torch;dagger,120,5000,30000,
 signe,Signe,bard,,,,,mandolin;worn_mandolin
+wick,Wick,merchant,,,,,

--- a/server/src/merchant_defs.rs
+++ b/server/src/merchant_defs.rs
@@ -80,4 +80,40 @@ mod tests {
             "no merchant sells fishing_rod — the rod would be unobtainable"
         );
     }
+
+    /// A merchant lives in two CSVs — the shop in `merchants.csv`, the NPC
+    /// identity in `npcs.csv` — and adding only one of them leaves a shop no
+    /// agent can ever run.
+    #[test]
+    fn every_merchant_has_an_npc_registry_entry() {
+        let registry: serde_json::Value =
+            serde_json::from_str(include_str!("../../data/npcs.json")).unwrap();
+        for name in MerchantDefs::load().by_npc_name.keys() {
+            assert!(
+                registry
+                    .as_object()
+                    .unwrap()
+                    .values()
+                    .any(|npc| npc["npcName"] == name.as_str()),
+                "merchant {name} has no entry in npcs.csv"
+            );
+        }
+    }
+
+    /// Rica sleeps at night, so trade would stop with the town asleep unless
+    /// someone else keeps a counter open (see doc/TODO.md).
+    #[test]
+    fn a_merchant_stocks_night_essentials() {
+        let defs = MerchantDefs::load();
+        let night = defs
+            .by_npc_name
+            .get("Wick")
+            .expect("the night merchant is missing from merchants.csv");
+        for essential in ["torch", "healing_potion", "bread"] {
+            assert!(
+                night.sells(essential),
+                "the night merchant does not stock {essential}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Follows your note on #103 — the night merchant that has to exist before blocking trade with a sleeping one.

Rica keeps the only shop in Aldermark and her schedule puts her in bed at night, so #103 on its own would leave the town with no counter open. Wick opens after dark instead.

## What this is

He is a registry NPC like Rica and Karl, so there is **no new art** — NPCs go through the same character-creation path players use. The change is a row in each of the two CSVs, a persona, and a schedule that inverts Rica's. The schedule carries no `action`, so it drives him on its own and `llm = "none"` is enough to run him.

His catalog is narrow on purpose — torch, healing potion, campfire kit, bread, jerky, scroll of return — and he pays 30% where Rica pays 40%. Night trade should be a convenience, not a better deal than waiting for morning.

## Test plan

- `every_merchant_has_an_npc_registry_entry` — a merchant lives in `merchants.csv` and `npcs.csv` both, and adding only one leaves a shop no agent can run. I confirmed it fails with the `npcs.csv` row removed.
- `a_merchant_stocks_night_essentials` — a night merchant with no torch or bandage would not answer the problem it exists for.

`cargo test --workspace` green (374 server tests), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.

## What I could not check

The stall coordinates are my best read of the map from `map_labels.csv` (Aldermark at -1475, 4742) and Karl's patrol waypoints. The agent snaps to terrain height when it walks, so the height should sort itself out, but whether the spot sits somewhere sensible on the road wants an in-game look. Easy to move — it is one line in `schedule.json`.

I also left him without a bed at day, since I had no way to confirm a free furniture placement id. He simply goes off duty at the edge of town, which means a player who seeks him out by day can still trade. If you would rather he were unavailable until dark, giving him a bed placement is a one-line change and #103 then blocks him for free.

Merging this before #103 leaves the game playable at every point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)