### PR TITLE
Break unspaced chat text at the bubble width without splitting emoji

### DIFF
--- a/client/src/lib/components/TextLabel.svelte
+++ b/client/src/lib/components/TextLabel.svelte
@@ -3,6 +3,7 @@
   import * as THREE from 'three'
   import { MeshBasicNodeMaterial } from 'three/webgpu'
   import { onDestroy } from 'svelte'
+  import { wrapLines } from '../utils/textWrap'
 
   interface Props {
     text: string
@@ -83,46 +84,16 @@
     maxWidthPx: number | undefined,
     breakWord: boolean
   ): string[] {
-    const paragraphs = inputText.split('\n')
     if (!maxWidthPx || whiteSpace === 'nowrap') {
+      const paragraphs = inputText.split('\n')
       return paragraphs.length ? paragraphs : ['']
     }
-
-    const allLines: string[] = []
-    for (const para of paragraphs) {
-      if (!para) {
-        allLines.push('')
-        continue
-      }
-      if (breakWord) {
-        let cur = ''
-        for (const ch of para) {
-          const test = cur + ch
-          if (ctx.measureText(test).width > maxWidthPx && cur.length > 0) {
-            allLines.push(cur)
-            cur = ch
-          } else {
-            cur = test
-          }
-        }
-        if (cur) allLines.push(cur)
-      } else {
-        const words = para.split(/\s+/)
-        let cur = ''
-        for (const w of words) {
-          if (!w) continue
-          const test = cur ? cur + ' ' + w : w
-          if (ctx.measureText(test).width > maxWidthPx && cur.length > 0) {
-            allLines.push(cur)
-            cur = w
-          } else {
-            cur = test
-          }
-        }
-        if (cur) allLines.push(cur)
-      }
-    }
-    return allLines.length ? allLines : ['']
+    return wrapLines(
+      inputText,
+      maxWidthPx,
+      breakWord,
+      (s) => ctx.measureText(s).width
+    )
   }
 
   function renderCanvas() {

--- a/client/src/lib/utils/textWrap.test.ts
+++ b/client/src/lib/utils/textWrap.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { wrapLines } from './textWrap'
+
+const measure = (s: string) => s.length * 10
+
+describe('wrapLines', () => {
+  it('wraps spaced text at word boundaries without splitting words', () => {
+    expect(wrapLines('the quick brown fox', 100, false, measure)).toEqual([
+      'the quick',
+      'brown fox',
+    ])
+  })
+
+  it('breaks a single unspaced run wider than the line', () => {
+    const lines = wrapLines('ㅁ'.repeat(25), 100, false, measure)
+    expect(lines).toEqual(['ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ', 'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ', 'ㅁㅁㅁㅁㅁ'])
+    for (const line of lines) expect(measure(line)).toBeLessThanOrEqual(100)
+  })
+
+  it('continues the line after an oversized word is broken', () => {
+    expect(wrapLines('ab ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ cd', 100, false, measure)).toEqual([
+      'ab',
+      'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ',
+      'ㅁㅁ cd',
+    ])
+  })
+
+  it('keeps explicit newlines and empty lines', () => {
+    expect(wrapLines('a\n\nb', 100, false, measure)).toEqual(['a', '', 'b'])
+  })
+
+  it('breaks every character run in break-word mode', () => {
+    expect(wrapLines('abcdefghijkl', 50, true, measure)).toEqual([
+      'abcde',
+      'fghij',
+      'kl',
+    ])
+  })
+
+  it('returns a single empty line for empty input', () => {
+    expect(wrapLines('', 100, false, measure)).toEqual([''])
+  })
+
+  it('never breaks inside a ZWJ emoji cluster', () => {
+    const family = '👨‍👩‍👧‍👦'
+    const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    const glyphs = (s: string) => [...seg.segment(s)].length
+    const measureGlyphs = (s: string) => glyphs(s) * 10
+
+    const lines = wrapLines(family.repeat(5), 20, false, measureGlyphs)
+    expect(lines).toEqual([
+      family + family,
+      family + family,
+      family,
+    ])
+  })
+})

--- a/client/src/lib/utils/textWrap.test.ts
+++ b/client/src/lib/utils/textWrap.test.ts
@@ -13,16 +13,18 @@ describe('wrapLines', () => {
 
   it('breaks a single unspaced run wider than the line', () => {
     const lines = wrapLines('ㅁ'.repeat(25), 100, false, measure)
-    expect(lines).toEqual(['ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ', 'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ', 'ㅁㅁㅁㅁㅁ'])
+    expect(lines).toEqual([
+      'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ',
+      'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ',
+      'ㅁㅁㅁㅁㅁ',
+    ])
     for (const line of lines) expect(measure(line)).toBeLessThanOrEqual(100)
   })
 
   it('continues the line after an oversized word is broken', () => {
-    expect(wrapLines('ab ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ cd', 100, false, measure)).toEqual([
-      'ab',
-      'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ',
-      'ㅁㅁ cd',
-    ])
+    expect(
+      wrapLines('ab ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ cd', 100, false, measure)
+    ).toEqual(['ab', 'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ', 'ㅁㅁ cd'])
   })
 
   it('keeps explicit newlines and empty lines', () => {
@@ -48,10 +50,6 @@ describe('wrapLines', () => {
     const measureGlyphs = (s: string) => glyphs(s) * 10
 
     const lines = wrapLines(family.repeat(5), 20, false, measureGlyphs)
-    expect(lines).toEqual([
-      family + family,
-      family + family,
-      family,
-    ])
+    expect(lines).toEqual([family + family, family + family, family])
   })
 })

--- a/client/src/lib/utils/textWrap.ts
+++ b/client/src/lib/utils/textWrap.ts
@@ -1,0 +1,72 @@
+export type MeasureFn = (text: string) => number
+
+const graphemes = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
+/** Break `word` into max-width chunks; pushes full chunks, returns the tail.
+ *  Splits between grapheme clusters, never inside one — a mid-cluster break
+ *  would turn ZWJ emoji like 👨‍👩‍👧‍👦 into different visible emoji. */
+function breakChars(
+  word: string,
+  maxWidthPx: number,
+  measure: MeasureFn,
+  out: string[]
+): string {
+  let cur = ''
+  for (const { segment } of graphemes.segment(word)) {
+    const test = cur + segment
+    if (measure(test) > maxWidthPx && cur.length > 0) {
+      out.push(cur)
+      cur = segment
+    } else {
+      cur = test
+    }
+  }
+  return cur
+}
+
+function wrapWords(
+  para: string,
+  maxWidthPx: number,
+  measure: MeasureFn,
+  out: string[]
+) {
+  let cur = ''
+  for (const w of para.split(/\s+/)) {
+    if (!w) continue
+    const test = cur ? cur + ' ' + w : w
+    if (measure(test) <= maxWidthPx) {
+      cur = test
+      continue
+    }
+    if (cur) {
+      out.push(cur)
+      cur = ''
+    }
+    // A word wider than the line on its own gets broken mid-word,
+    // so unspaced runs (e.g. Korean without spaces) still wrap.
+    cur = measure(w) > maxWidthPx ? breakChars(w, maxWidthPx, measure, out) : w
+  }
+  if (cur) out.push(cur)
+}
+
+export function wrapLines(
+  text: string,
+  maxWidthPx: number,
+  breakWord: boolean,
+  measure: MeasureFn
+): string[] {
+  const lines: string[] = []
+  for (const para of text.split('\n')) {
+    if (!para) {
+      lines.push('')
+      continue
+    }
+    if (breakWord) {
+      const tail = breakChars(para, maxWidthPx, measure, lines)
+      if (tail) lines.push(tail)
+    } else {
+      wrapWords(para, maxWidthPx, measure, lines)
+    }
+  }
+  return lines.length ? lines : ['']
+}


### PR DESCRIPTION
## Why

Chat text with no spaces — very common in Korean chat, e.g. `ㅁㅁㅁㅁㅁㅁㅁ…` — never wrapped: the bubble background stopped at its max width but the text kept going in a single line, spilling far outside the bubble on both sides.

## Cause

`TextLabel`'s word-wrap mode (`overflowWrap="normal"`) broke lines only between words and never split a word wider than `maxWidth`. An unspaced run is one giant "word", so it was laid out as a single overflowing line while the bubble shape stayed clamped to `MAX_BUBBLE_WIDTH`.

## Fix

- Extracted the wrapping logic into a pure `textWrap` module (`wrapLines`), unit-testable with an injected measure function.
- Word wrap still breaks between words first, but a word wider than the line is now broken mid-word, so the bubble stops growing at its max width and expands vertically instead.
- Mid-word breaks are segmented with `Intl.Segmenter` (grapheme granularity), so a break can never land inside a ZWJ emoji sequence — splitting `👨‍👩‍👧‍👦` between code points would render as different emoji than the sender typed.

Callers without `maxWidth` (nametags, stats) and the `whiteSpace="nowrap"` path are unchanged.

## Screenshots

Before — the text escapes the bubble on both sides:

<img width="861" height="588" alt="image" src="https://github.com/user-attachments/assets/e961440b-301a-4a09-baa3-6572ff70f335" />

After — same message wraps inside the bubble, which grows vertically:

<img width="473" height="476" alt="image" src="https://github.com/user-attachments/assets/bd8a6786-af8b-450c-8f9b-d6a6a1b68d70" />

## Tests

- 7 new unit tests for `wrapLines`: word-boundary wrapping, unspaced-run breaking, continuing the line after a broken word, explicit newlines, break-word mode, empty input, and a regression test that a ZWJ emoji cluster is never split.
- Full client suite passes (408 tests), `eslint` and `svelte-check` clean.
- Verified live in-game: a 40-character unspaced message now wraps to two lines inside the bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
