### PR TITLE
Reject zero LLM concurrency at startup

### DIFF
--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -152,6 +152,13 @@ fn default_max_concurrent() -> usize {
     2
 }
 
+fn check_max_concurrent(max_concurrent: usize) -> anyhow::Result<()> {
+    if max_concurrent == 0 {
+        anyhow::bail!("max_concurrent must be at least 1");
+    }
+    Ok(())
+}
+
 fn default_request_timeout_secs() -> u64 {
     120
 }
@@ -194,6 +201,7 @@ async fn main() -> anyhow::Result<()> {
     let config: Config = toml::from_str(&config_text)
         .map_err(|e| anyhow::anyhow!("Failed to parse {CONFIG_PATH}: {e}"))?;
 
+    check_max_concurrent(config.max_concurrent)?;
     if config.npcs.is_empty() {
         anyhow::bail!("No [[npcs]] configured in {CONFIG_PATH}");
     }
@@ -477,6 +485,25 @@ server = "wss://example.test/ws"
 [auth]
 mode = "google"
 "#;
+
+    #[test]
+    fn max_concurrent_must_leave_at_least_one_scheduler_slot() {
+        let zero = parse(
+            r#"
+server = "ws://127.0.0.1:10006"
+max_concurrent = 0
+"#,
+        );
+        let defaulted = parse("server = \"ws://127.0.0.1:10006\"\n");
+
+        let err = check_max_concurrent(zero.max_concurrent)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("at least 1"), "{err}");
+        assert_eq!(defaulted.max_concurrent, 2);
+        assert!(check_max_concurrent(defaulted.max_concurrent).is_ok());
+        assert!(check_max_concurrent(1).is_ok());
+    }
 
     /// Who pays decides the default: an agent someone runs for themselves
     /// spends their own LLM quota, so it keeps thinking with nobody watching.


### PR DESCRIPTION
## Overview

The agent client accepted `max_concurrent = 0`, started its LLM scheduler, and then left every submitted request queued forever because no dispatch slot could ever become available.

This change rejects zero concurrency during startup before authentication, backend construction, or agent sessions begin.

## Steps to reproduce

1. Set `max_concurrent = 0` in `agent-client/data/config.toml`.
2. Start the agent client with at least one configured NPC.
3. Observe that `LlmScheduler::new` starts normally.
4. Submit an LLM request from an agent session.
5. Observe that the request remains queued because `in_flight < max_concurrent` is false at `0 < 0`.
6. Observe that the caller waits indefinitely and no startup error identifies the configuration.

## Observed behavior

The scheduler dispatch loop runs while `in_flight < max_concurrent`. With a value of zero, that condition is false from the first iteration. Requests remain in the queue and callers wait indefinitely for responses.

The configuration described the value as a maximum but did not define zero as an off mode. Unlike `request_timeout_secs = 0`, there was no explicit zero behavior, warning, or fallback.

## Expected behavior

- `max_concurrent` must be at least `1`.
- The default value remains `2`.
- A zero value produces a clear startup error instead of a running but permanently stalled process.
- Positive concurrency values keep the existing scheduler behavior.

## Root cause

Configuration deserialization accepted every `usize`, while the scheduler loop assumes at least one dispatch slot. Unlike the separately documented zero timeout, zero concurrency had no defined runtime meaning.

## Changes

- Add a small startup validation for `max_concurrent`.
- Return `max_concurrent must be at least 1` when the configured value is zero.
- Run the check immediately after parsing configuration.
- Add a regression for zero, the default, and the lower valid boundary.

## Validation

The regression verifies that:

- explicitly configured zero is rejected;
- the error explains the minimum accepted value;
- an omitted value still defaults to `2`;
- `1` is accepted.

Local validation on the current `master`:

- `cargo test -p agent-client max_concurrent_must_leave_at_least_one_scheduler_slot --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 858 passed
- `git diff --check HEAD^!` — passed

## Scope and limitations

This PR rejects one invalid configuration value only. It does not change scheduler fairness, request timeouts, queue limits, or backend selection.
