### PR TITLE
Reject client-reported monster deaths

### DIFF
--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -189,6 +189,12 @@ impl super::GameState {
                 self.send_direct_message(mover_id, correction).await;
                 return;
             }
+            if state == MonsterState::Dead {
+                let correction = Self::move_correction(monster_id, monster);
+                drop(monsters);
+                self.send_direct_message(mover_id, correction).await;
+                return;
+            }
             // Store canonical X like player moves do; the budget and sweep
             // below are already periodic. See the regression test for what a
             // non-canonical stored X costs.

--- a/server/src/game_state/tests/combat_tests.rs
+++ b/server/src/game_state/tests/combat_tests.rs
@@ -252,6 +252,71 @@ async fn non_finite_monster_move_is_rejected() {
 }
 
 #[tokio::test]
+async fn monster_move_cannot_report_dead_state() {
+    let game_state = make_test_game_state("monster_move_dead_state");
+    let owner_id = pid("owner");
+    let observer_id = pid("observer");
+    let authoritative_position = pos(1.0);
+
+    game_state.add_player(make_player("owner", 1.0, 0.0)).await;
+    game_state
+        .add_player(make_player("observer", 1.0, 0.0))
+        .await;
+    let mut owner_rx = game_state.register_direct_channel(&owner_id).await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        let mut monster = make_monster("owned_monster", authoritative_position, 0);
+        monster.owner_id = Some(owner_id);
+        monster.move_budget = 7.0;
+        monster.last_move_at = 42;
+        monsters.insert(monster.id.clone(), monster);
+    }
+
+    game_state
+        .update_monster_position(
+            &owner_id,
+            "owned_monster".to_string(),
+            authoritative_position,
+            0.5,
+            MonsterState::Dead,
+            authoritative_position,
+        )
+        .await;
+
+    let monster = game_state.monsters.read().await["owned_monster"].clone();
+    assert_eq!(monster.position, authoritative_position);
+    assert_eq!(monster.rotation, 0.0);
+    assert_eq!(monster.state, MonsterState::Idle);
+    assert_eq!(monster.move_budget, 7.0);
+    assert_eq!(monster.last_move_at, 42);
+
+    match owner_rx.try_recv() {
+        Ok(ServerMessage::MonsterMoved {
+            monster_id,
+            position,
+            rotation,
+            state,
+            target_position,
+            ..
+        }) => {
+            assert_eq!(monster_id, "owned_monster");
+            assert_eq!(position, authoritative_position);
+            assert_eq!(rotation, 0.0);
+            assert_eq!(state, MonsterState::Idle);
+            assert_eq!(target_position, authoritative_position);
+        }
+        other => panic!("a client-reported death must correct the owner, got {other:?}"),
+    }
+    assert!(matches!(owner_rx.try_recv(), Err(MpscTryRecvError::Empty)));
+    assert!(matches!(
+        observer_rx.try_recv(),
+        Err(MpscTryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
 async fn non_finite_spawn_request_is_rejected() {
     let game_state = make_test_game_state("spawn_request_non_finite");
     let player_id = pid("spawner");


### PR DESCRIPTION
## Overview

Owned-monster movement messages could report `MonsterState::Dead`. The server accepted that state as an ordinary movement update even though monster death is an authoritative combat transition with separate removal and dungeon bookkeeping.

This change rejects client-reported death before movement accounting or state mutation and sends the owner the existing authoritative movement correction.

## Steps to reproduce

1. Spawn or insert a live monster owned by a connected player.
2. Send a zero-distance monster movement update with `state = Dead`.
3. On the prior behavior, observe that ownership, finite-position, speed, and collision checks all succeed.
4. Inspect the stored monster and alive-monster accounting.

## Observed behavior

The stored monster state changed to `Dead` without a server combat result. The entry stopped counting toward live ambient-monster limits, but the combat removal path and dungeon death bookkeeping did not run. A client could therefore create a state that the normal death lifecycle cannot produce.

## Expected behavior

- Movement messages may update movement states, but cannot declare a monster dead.
- Rejection does not consume movement budget or alter position, rotation, state, or timestamp; it discards the requested target position and returns the authoritative position as the correction target.
- The owner receives the authoritative state as a correction.
- Nearby observers do not receive the rejected update.

## Root cause

`update_monster_position` validated ownership and movement authority but treated every finite `MonsterState` value as movement data. It did not preserve the invariant that only the server combat path may transition a live monster to `Dead`.

## Changes

- Reject `Dead` immediately after the existing finite-input checks.
- Reuse the existing correction message to restore the owner's local state.
- Add a regression that verifies stored state, movement budget, timestamp, correction, and observer fanout.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server monster_move_cannot_report_dead_state --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 858 passed
- `git diff --check HEAD^!` — passed

## Scope and limitations

This PR only rejects the death state at the owned-monster movement boundary. It does not change damage calculation, authoritative death handling, monster removal timing, spawn caps, or the wire protocol.
