### PR TITLE
Reject integer overflow in batched request quantities

### DIFF
--- a/server/src/game_state/inventory.rs
+++ b/server/src/game_state/inventory.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::auth::{AuthService, ItemRow};
 use crate::item_defs::UseEffect;
 use crate::types::{PlayerId, ServerMessage};
@@ -1147,6 +1145,17 @@ impl super::GameState {
         if items.is_empty() {
             return;
         }
+        let items: Vec<BagLineItem> = items.into_iter().filter(|i| i.qty > 0).collect();
+        if items.is_empty() {
+            return;
+        }
+        let Some(quantities) =
+            super::checked_batch_quantities(items.iter().map(|item| (item.instance_id, item.qty)))
+        else {
+            self.send_system_message(player_id, "Invalid batch quantity")
+                .await;
+            return;
+        };
         let (player_position, rotation, floor_level) = {
             let players = self.players.read().await;
             match players.get(player_id) {
@@ -1162,7 +1171,6 @@ impl super::GameState {
             enchant: i32,
         }
 
-        let mut reserved: HashMap<u64, u32> = HashMap::new();
         let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
 
         let snapshot = {
@@ -1172,22 +1180,22 @@ impl super::GameState {
             };
 
             for req in &items {
-                if req.qty == 0 {
-                    continue;
-                }
                 let Some(item) = inv.bag.iter().find(|i| i.instance_id == req.instance_id) else {
                     drop(inventories);
                     self.send_system_message(player_id, "Item not found").await;
                     return;
                 };
-                let already = *reserved.get(&req.instance_id).unwrap_or(&0);
-                if already + req.qty > item.quantity {
+                let requested_qty = quantities
+                    .by_key
+                    .get(&req.instance_id)
+                    .copied()
+                    .expect("every retained request was included in batch aggregation");
+                if requested_qty > item.quantity {
                     drop(inventories);
                     self.send_system_message(player_id, "Not enough of that item")
                         .await;
                     return;
                 }
-                reserved.insert(req.instance_id, already + req.qty);
                 plans.push(Plan {
                     instance_id: req.instance_id,
                     qty: req.qty,
@@ -1195,11 +1203,6 @@ impl super::GameState {
                     enchant: item.enchant,
                 });
             }
-            if plans.is_empty() {
-                drop(inventories);
-                return;
-            }
-
             // Every line is now guaranteed to apply cleanly — mutate.
             for plan in &plans {
                 let idx = inv
@@ -1219,8 +1222,7 @@ impl super::GameState {
         self.mark_inventory_dirty(player_id).await;
         self.send_inventory_snapshot(player_id, snapshot).await;
 
-        let total_units: u32 = plans.iter().map(|p| p.qty).sum();
-        let mut next_ground_id = self.reserve_instance_ids(total_units as u64).await;
+        let mut next_ground_id = self.reserve_instance_ids(quantities.total).await;
         for plan in &plans {
             for _ in 0..plan.qty {
                 let preferred = drop_landing_position(player_position, rotation);

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -24,6 +24,7 @@ use onlinerpg_shared::serialize_server_msg;
 use onlinerpg_shared::NoSpawnZone;
 use onlinerpg_shared::Position;
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
@@ -134,6 +135,31 @@ pub(crate) const OUT_OF_COMBAT_MS: u64 = 10_000;
 /// prop. It never enters a bag — picking it up credits a few copper straight
 /// to the player's wallet (see `pickup_item`).
 pub(crate) const COIN_PILE_ITEM_ID: &str = "coin_pile";
+
+struct CheckedBatchQuantities<K> {
+    by_key: HashMap<K, u32>,
+    total: u64,
+}
+
+/// Accumulate client batch lines once before mutation. Per-key totals stay
+/// `u32` because item quantities use that type; the whole request stays `u64`
+/// to match the existing instance-id reservation range.
+fn checked_batch_quantities<K: Eq + Hash>(
+    lines: impl IntoIterator<Item = (K, u32)>,
+) -> Option<CheckedBatchQuantities<K>> {
+    let mut by_key: HashMap<K, u32> = HashMap::new();
+    let mut total = 0u64;
+    for (key, qty) in lines {
+        total = total.checked_add(u64::from(qty))?;
+        let quantity = by_key
+            .get(&key)
+            .copied()
+            .unwrap_or_default()
+            .checked_add(qty)?;
+        by_key.insert(key, quantity);
+    }
+    Some(CheckedBatchQuantities { by_key, total })
+}
 
 #[derive(Default)]
 struct IdState {

--- a/server/src/game_state/tests/trading_tests/batch_tests.rs
+++ b/server/src/game_state/tests/trading_tests/batch_tests.rs
@@ -1,6 +1,56 @@
 use super::*;
 use onlinerpg_shared::messages::{BagLineItem, TradeLineItem};
 
+#[test]
+fn checked_batch_quantity_accumulation_overflow_boundaries() {
+    let quantities = checked_batch_quantities([("first", u32::MAX), ("second", 1)]).unwrap();
+    assert_eq!(quantities.total, u64::from(u32::MAX) + 1);
+    assert_eq!(quantities.by_key["first"], u32::MAX);
+    assert_eq!(quantities.by_key["second"], 1);
+    assert!(checked_batch_quantities([("same", u32::MAX), ("same", 1)]).is_none());
+}
+
+#[tokio::test]
+async fn zero_quantity_trade_batches_still_validate_the_trader() {
+    let game_state = make_test_game_state("zero_quantity_trade_validation");
+    game_state.add_player(make_player("buyer", 1.0, 0.0)).await;
+    let mut buyer_rx = game_state.register_direct_channel(&pid("buyer")).await;
+
+    game_state
+        .buy_items(
+            &pid("buyer"),
+            &pid("missing_trader"),
+            vec![TradeLineItem {
+                item_def_id: "spear".to_string(),
+                qty: 0,
+            }],
+        )
+        .await;
+    match buyer_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("Trader not found"));
+        }
+        other => panic!("Expected TradeError, got {other:?}"),
+    }
+
+    game_state
+        .sell_items(
+            &pid("buyer"),
+            &pid("missing_trader"),
+            vec![BagLineItem {
+                instance_id: 1,
+                qty: 0,
+            }],
+        )
+        .await;
+    match buyer_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("Trader not found"));
+        }
+        other => panic!("Expected TradeError, got {other:?}"),
+    }
+}
+
 // --- Batched sell/buy/drop (bag-cleanup UX: quantity popups + one
 // all-or-nothing round trip instead of N single-unit calls) ---
 
@@ -92,6 +142,57 @@ async fn sell_items_batch_is_all_or_nothing_when_a_line_is_invalid() {
     match seller_rx.try_recv() {
         Ok(ServerMessage::TradeError { .. }) => {}
         other => panic!("Expected TradeError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn sell_items_batch_rejects_quantity_accumulation_overflow() {
+    let game_state = make_test_game_state("batch_sell_quantity_overflow");
+    game_state
+        .add_player(make_npc("npc_rica", "Rica", 0.0, 0.0))
+        .await;
+    game_state.add_player(make_player("seller", 1.0, 0.0)).await;
+    game_state
+        .register_player_character(&pid("seller"), 1, 0, attrs_with_cha(10), 0, None)
+        .await;
+    game_state.inventories.write().await.insert(
+        pid("seller"),
+        PlayerInventory {
+            bag: vec![bag_item(7, "healing_potion", 5)],
+            ..Default::default()
+        },
+    );
+    let mut seller_rx = game_state.register_direct_channel(&pid("seller")).await;
+    let next_item_id = game_state.reserve_instance_ids(0).await;
+
+    game_state
+        .sell_items(
+            &pid("seller"),
+            &pid("npc_rica"),
+            vec![
+                BagLineItem {
+                    instance_id: 7,
+                    qty: 1,
+                },
+                BagLineItem {
+                    instance_id: 7,
+                    qty: u32::MAX,
+                },
+            ],
+        )
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 0);
+    assert_eq!(
+        game_state.inventories.read().await[&pid("seller")].bag[0].quantity,
+        5
+    );
+    assert_eq!(game_state.reserve_instance_ids(0).await, next_item_id);
+    match seller_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("Invalid batch quantity"));
+        }
+        other => panic!("Expected TradeError, got {other:?}"),
     }
 }
 
@@ -386,6 +487,49 @@ async fn buy_items_batch_totals_repeated_lines_against_resident_stock() {
     let inventories = game_state.inventories.read().await;
     assert!(inventories[&pid("seller")].bag.is_empty());
     assert_eq!(inventories[&pid("npc_karl")].bag.len(), 3);
+}
+
+#[tokio::test]
+async fn buy_items_batch_rejects_quantity_accumulation_overflow() {
+    let game_state = make_test_game_state("batch_buy_quantity_overflow");
+    setup_resident_trade(&game_state, 0, vec![bag_item(11, "spear", 1)], vec![]).await;
+    game_state
+        .player_gold
+        .write()
+        .await
+        .insert(pid("seller"), 20_000);
+    let mut seller_rx = game_state.register_direct_channel(&pid("seller")).await;
+    let next_item_id = game_state.reserve_instance_ids(0).await;
+
+    game_state
+        .buy_items(
+            &pid("seller"),
+            &pid("npc_karl"),
+            vec![
+                TradeLineItem {
+                    item_def_id: "spear".to_string(),
+                    qty: 1,
+                },
+                TradeLineItem {
+                    item_def_id: "spear".to_string(),
+                    qty: u32::MAX,
+                },
+            ],
+        )
+        .await;
+
+    assert_eq!(game_state.get_player_gold(&pid("seller")).await, 20_000);
+    let inventories = game_state.inventories.read().await;
+    assert!(inventories[&pid("seller")].bag.is_empty());
+    assert_eq!(inventories[&pid("npc_karl")].bag.len(), 1);
+    drop(inventories);
+    assert_eq!(game_state.reserve_instance_ids(0).await, next_item_id);
+    match seller_rx.try_recv() {
+        Ok(ServerMessage::TradeError { message }) => {
+            assert!(message.contains("Invalid batch quantity"));
+        }
+        other => panic!("Expected TradeError, got {other:?}"),
+    }
 }
 
 /// The resident's receipt draws from a range reserved before the locks, so
@@ -762,5 +906,49 @@ async fn drop_items_batch_is_all_or_nothing_when_quantity_exceeds_the_stack() {
     match owner_rx.try_recv() {
         Ok(ServerMessage::SystemMessage { .. }) => {}
         other => panic!("Expected SystemMessage, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn drop_items_batch_rejects_quantity_accumulation_overflow() {
+    let game_state = make_test_game_state("batch_drop_quantity_overflow");
+    game_state.add_player(make_player("owner", 1.0, 0.0)).await;
+    game_state.inventories.write().await.insert(
+        pid("owner"),
+        PlayerInventory {
+            bag: vec![bag_item(30, "healing_potion", 2)],
+            ..Default::default()
+        },
+    );
+    let mut owner_rx = game_state.register_direct_channel(&pid("owner")).await;
+    let next_item_id = game_state.reserve_instance_ids(0).await;
+
+    game_state
+        .drop_items(
+            &pid("owner"),
+            vec![
+                BagLineItem {
+                    instance_id: 30,
+                    qty: 1,
+                },
+                BagLineItem {
+                    instance_id: 30,
+                    qty: u32::MAX,
+                },
+            ],
+        )
+        .await;
+
+    assert_eq!(
+        game_state.inventories.read().await[&pid("owner")].bag[0].quantity,
+        2
+    );
+    assert!(game_state.ground_items.read().await.is_empty());
+    assert_eq!(game_state.reserve_instance_ids(0).await, next_item_id);
+    match owner_rx.try_recv() {
+        Ok(ServerMessage::SystemMessage { message }) => {
+            assert!(message.contains("Invalid batch quantity"));
+        }
+        other => panic!("Expected SystemMessage, got {other:?}"),
     }
 }

--- a/server/src/game_state/trading.rs
+++ b/server/src/game_state/trading.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::merchant_defs::{merchant_defs, MerchantDefinition};
 use crate::npc_defs::{npc_defs, NpcDefinition};
 use crate::types::{PlayerId, ServerMessage};
@@ -692,6 +690,19 @@ impl super::GameState {
             Ok(def) => def,
             Err(reason) => return self.send_trade_error(player_id, reason).await,
         };
+        let items: Vec<TradeLineItem> = items.into_iter().filter(|i| i.qty > 0).collect();
+        if items.is_empty() {
+            return;
+        }
+        let Some(quantities) = super::checked_batch_quantities(
+            items
+                .iter()
+                .map(|item| (item.item_def_id.as_str(), item.qty)),
+        ) else {
+            return self
+                .send_trade_error(player_id, "Invalid batch quantity")
+                .await;
+        };
         let npc_name = def.npc_name().to_string();
         let is_resident = matches!(def, TraderDef::Resident(_));
 
@@ -711,9 +722,6 @@ impl super::GameState {
 
         let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
         for req in &items {
-            if req.qty == 0 {
-                continue;
-            }
             match &def {
                 TraderDef::Merchant(m) => {
                     if !m.sells(&req.item_def_id) {
@@ -753,15 +761,9 @@ impl super::GameState {
                 price: 0,
             });
         }
-        if plans.is_empty() {
-            return;
-        }
-
         // One id per unit, reserved before the locks rather than one counter
         // acquisition per unit under them. An aborted batch skips the range.
-        let mut next_id = self
-            .reserve_instance_ids(plans.iter().map(|p| p.qty as u64).sum())
-            .await;
+        let mut next_id = self.reserve_instance_ids(quantities.total).await;
         let max_weight = self.max_carry_weight(player_id).await;
 
         let mut gold_map = self.player_gold.write().await;
@@ -781,11 +783,7 @@ impl super::GameState {
                     .send_trade_error(player_id, "They have nothing to sell")
                     .await;
             };
-            let mut requested: HashMap<&str, u32> = HashMap::new();
-            for plan in &plans {
-                *requested.entry(plan.item_def_id.as_str()).or_default() += plan.qty;
-            }
-            for (item_def_id, qty) in requested {
+            for (item_def_id, qty) in quantities.by_key {
                 let available: u32 = npc_inv
                     .bag
                     .iter()
@@ -1251,6 +1249,20 @@ impl super::GameState {
             Ok(def) => def,
             Err(reason) => return self.send_trade_error(player_id, reason).await,
         };
+        // Drop no-op lines before aggregation and mutation. Keeping trader
+        // validation first preserves the existing error response for an
+        // all-zero request sent to an invalid or unreachable trader.
+        let items: Vec<BagLineItem> = items.into_iter().filter(|i| i.qty > 0).collect();
+        if items.is_empty() {
+            return;
+        }
+        let Some(quantities) =
+            super::checked_batch_quantities(items.iter().map(|item| (item.instance_id, item.qty)))
+        else {
+            return self
+                .send_trade_error(player_id, "Invalid batch quantity")
+                .await;
+        };
         let npc_name = def.npc_name().to_string();
         let is_resident = matches!(def, TraderDef::Resident(_));
         let rate = match &def {
@@ -1268,18 +1280,9 @@ impl super::GameState {
             payout: i64,
         }
 
-        // Drop no-op lines before the locks: the plan loop below runs under
-        // both write locks, so a client's padding must not reach it.
-        let items: Vec<BagLineItem> = items.into_iter().filter(|i| i.qty > 0).collect();
-        if items.is_empty() {
-            return;
-        }
-
         // One id per unit, reserved before the locks: a resident's received
         // units draw from it, a merchant's buyback entries do.
-        let mut next_unit_id = self
-            .reserve_instance_ids(items.iter().map(|i| i.qty as u64).sum())
-            .await;
+        let mut next_unit_id = self.reserve_instance_ids(quantities.total).await;
         // Only a resident carries what it buys.
         let npc_max_weight = if is_resident {
             Some(self.max_carry_weight(npc_player_id).await)
@@ -1296,7 +1299,6 @@ impl super::GameState {
             return self.send_trade_error(player_id, "Player not found").await;
         }
 
-        let mut reserved: HashMap<u64, u32> = HashMap::new();
         let mut plans: Vec<Plan> = Vec::with_capacity(items.len());
         for req in &items {
             let Some(item) = inventories
@@ -1309,16 +1311,18 @@ impl super::GameState {
                     .send_trade_error(player_id, "Item not found in bag")
                     .await;
             };
-            let already_reserved = *reserved.get(&req.instance_id).unwrap_or(&0);
-            if already_reserved + req.qty > item.quantity {
+            let requested_qty = quantities
+                .by_key
+                .get(&req.instance_id)
+                .copied()
+                .expect("every retained request was included in batch aggregation");
+            if requested_qty > item.quantity {
                 drop(inventories);
                 drop(gold_map);
                 return self
                     .send_trade_error(player_id, "Not enough of that item")
                     .await;
             }
-            reserved.insert(req.instance_id, already_reserved + req.qty);
-
             let item_def_id = item.item_def_id.clone();
             let enchant = item.enchant;
             let Some(base_price) = self.item_defs.get(&item_def_id).and_then(|d| d.base_price)


### PR DESCRIPTION
## Overview

Batched buy, sell, and drop requests used unchecked `u32` addition for repeated per-item quantities before ownership or stock checks. Repeating one key with quantities `1` and `u32::MAX` wrapped that key's validated quantity to zero in release builds; the drop path also recomputed the whole request as `u32` and wrapped its instance-id reservation to zero.

This change validates per-key `u32` totals and the existing `u64` whole-request range before instance-id reservation or mutation locks, then reuses those checked values throughout each operation.

## Steps to reproduce

1. Give a player a small stack, or give a resident trader one unit of a stock item.
2. Submit one batched buy, sell, or drop request that repeats the same item key with quantities `1` and `u32::MAX`.
3. Follow the prior request path to the unchecked `u32` accumulation used by the ownership or stock guard.
4. In a release build, observe that the per-key sum wraps to zero and the request continues with the original line quantities; for drop, the whole-request sum also reserves zero instance IDs.

## Observed behavior

The ownership or stock comparison used a wrapped total while later planning, payout, and item-transfer paths still consumed the individual request lines. The drop path then generated ground-item IDs from an unreserved range, allowing later reservations to reuse those IDs in addition to driving an impractically large amount of work.

## Expected behavior

- Every per-key quantity must be exactly representable as `u32`, while the whole-request total retains the existing `u64` instance-id reservation range.
- An overflowing batch is rejected before gold, inventory, ground-item, or instance-id state changes.
- Repeated valid lines continue to use their combined quantity for stock and ownership checks.
- An all-zero batch remains a state no-op for a valid trader, while an invalid or unreachable trader still returns the existing validation error.

## Root cause

All three request paths used unchecked `u32` addition for repeated per-key ownership or stock totals, and drop separately recomputed the whole request as `u32`. Validation values were therefore allowed to wrap and were recomputed separately from later processing, breaking the invariant that validation, ID reservation, and mutation describe the same quantities.

## Changes

- Add a shared accumulator that checks per-key `u32` quantities and retains a checked `u64` whole-request total.
- Run quantity aggregation after zero-line filtering and before instance-id reservation or mutation locks, while preserving trader validation order.
- Reuse the checked totals for resident stock, bag ownership, and instance-id reservation.
- Add direct accumulator boundaries, buy/sell/drop overflow regressions, instance-id cursor assertions, and an all-zero trader-validation regression.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server checked_batch_quantity_accumulation_overflow_boundaries --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server buy_items_batch_rejects_quantity_accumulation_overflow --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server sell_items_batch_rejects_quantity_accumulation_overflow --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server drop_items_batch_rejects_quantity_accumulation_overflow --locked --quiet -- --nocapture` — 1 passed
- `cargo test -p onlinerpg-server zero_quantity_trade_batches_still_validate_the_trader --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 862 passed
- `git diff --check HEAD^!` — passed

The focused checks verify the `u64` whole-request range and per-key overflow boundary; unchanged gold and both inventories for buy, unchanged gold and seller bag for sell, unchanged bag and ground items for drop, an unchanged instance-id cursor in all three rejections, and preserved trader errors for all-zero requests. The regression tests run with debug overflow checks and would fail the prior code by panic; the release wrapping behavior is established by the unchecked source operations and the absence of a release-profile override.

## Scope and limitations

This PR does not introduce a smaller gameplay or operational cap for quantities that fit the existing per-key `u32` and whole-request `u64` ranges. Request size, rate limits, and per-unit loop policy remain separate decisions, and the wire protocol is unchanged.
