### PR TITLE
Include vertical displacement in owned-monster movement limits

### DIFF
--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -212,7 +212,13 @@ impl super::GameState {
             let budget = (monster.move_budget + run_speed * MONSTER_MOVE_SPEED_SLACK * elapsed_s)
                 .min(MONSTER_MOVE_BUDGET_CAP_METERS);
             monster.last_move_at = now;
-            let dist = monster.position.dist_xz_sq(&new_position).sqrt();
+            let dx = onlinerpg_shared::shortest_world_delta_x(monster.position.x, new_position.x);
+            let dy = new_position.y - monster.position.y;
+            let dz = new_position.z - monster.position.z;
+            // Run speed is ground-projected, so charge horizontal travel once
+            // and cap height changes independently. Euclidean distance would
+            // double-charge ordinary slopes that the terrain snap adds.
+            let dist = (dx * dx + dz * dz).sqrt().max(dy.abs());
             if dist > budget {
                 // Bank the refill so the budget keeps recovering, but don't
                 // spend it: the move stays where it was and isn't fanned out.
@@ -233,8 +239,7 @@ impl super::GameState {
                 let floor = super::passability::authoritative_floor(&cache, &monster.position);
                 // Sweep in unwrapped X so a seam-crossing move stays the short
                 // local segment `dist` measured.
-                let to_x = monster.position.x
-                    + onlinerpg_shared::shortest_world_delta_x(monster.position.x, new_position.x);
+                let to_x = monster.position.x + dx;
                 super::passability::wrapped_block_info(
                     &cache,
                     monster.position.x,

--- a/server/src/game_state/tests/combat_tests.rs
+++ b/server/src/game_state/tests/combat_tests.rs
@@ -490,6 +490,92 @@ async fn client_monster_move_stores_canonical_world_x() {
     }
 }
 
+#[tokio::test]
+async fn client_monster_move_charges_vertical_displacement() {
+    let game_state = make_test_game_state("monster_move_vertical_budget");
+    let owner_id = pid("owner");
+    let observer_id = pid("observer");
+    let start = Position {
+        x: 1.0,
+        y: 0.0,
+        z: 1.0,
+    };
+
+    game_state.add_player(make_player("owner", 1.0, 1.0)).await;
+    game_state
+        .add_player(make_player("observer", 1.0, 1.0))
+        .await;
+    let mut owner_rx = game_state.register_direct_channel(&owner_id).await;
+    let mut observer_rx = game_state.register_direct_channel(&observer_id).await;
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        let mut monster = make_monster("vertical_monster", start, 0);
+        monster.owner_id = Some(owner_id);
+        monster.move_budget = 1.0;
+        monster.last_move_at = GameState::now_ms();
+        monsters.insert(monster.id.clone(), monster);
+    }
+
+    let forged = Position { y: -40.0, ..start };
+    game_state
+        .update_monster_position(
+            &owner_id,
+            "vertical_monster".to_string(),
+            forged,
+            0.0,
+            MonsterState::Run,
+            forged,
+        )
+        .await;
+
+    let after = game_state.monsters.read().await["vertical_monster"].clone();
+    assert_eq!(after.position, start);
+    assert!(after.move_budget >= 1.0, "a rejected move keeps its refill");
+    match owner_rx.try_recv() {
+        Ok(ServerMessage::MonsterMoved { position, .. }) => assert_eq!(position, start),
+        other => panic!("a vertical teleport must correct its owner, got {other:?}"),
+    }
+    assert!(matches!(
+        observer_rx.try_recv(),
+        Err(MpscTryRecvError::Empty)
+    ));
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        let monster = monsters.get_mut("vertical_monster").unwrap();
+        monster.move_budget = 1.0;
+        monster.last_move_at = GameState::now_ms();
+    }
+    let legal = Position {
+        x: 1.25,
+        y: 0.9,
+        z: 1.0,
+    };
+    game_state
+        .update_monster_position(
+            &owner_id,
+            "vertical_monster".to_string(),
+            legal,
+            0.0,
+            MonsterState::Walk,
+            legal,
+        )
+        .await;
+
+    let after = game_state.monsters.read().await["vertical_monster"].clone();
+    assert_eq!(after.position, legal);
+    assert!(
+        after.move_budget < 0.5,
+        "a vertical-dominant move must spend its vertical displacement, got {}",
+        after.move_budget
+    );
+    match observer_rx.try_recv() {
+        Ok(ServerMessage::MonsterMoved { position, .. }) => assert_eq!(position, legal),
+        other => panic!("a bounded vertical move must fan out, got {other:?}"),
+    }
+}
+
 /// A client-owned monster is still untrusted movement. Staying within the
 /// speed bucket must not let its owner walk it through the same solid cell that
 /// blocks server-simulated player movement — while an equally long move that


### PR DESCRIPTION
## Overview

Owned-monster movement charged only horizontal XZ displacement to the server token bucket while storing the client-reported Y coordinate. A controller could therefore move a monster vertically at zero movement cost, select collision data for another height, and leave the authoritative collision floor inconsistent with the position sent to nearby clients.

This change caps horizontal and vertical displacement independently with the existing movement budget, while preserving the ground-projected run speed used on ordinary slopes.

## Steps to reproduce

1. Create a live monster controlled by a connected player and give it a small movement budget.
2. Send a movement update that keeps X and Z unchanged but changes Y by a large amount.
3. On the prior path, observe that `dist_xz_sq` returns zero, the speed check passes, and the collision sweep is skipped.
4. Inspect the stored monster position and the movement update sent to observers.

## Observed behavior

The server stored the requested Y without spending movement budget. The requested height also selected the passability floor used by collision handling even though the monster's logical floor was unchanged, producing a position and collision-floor combination that normal bounded movement could not reach.

## Expected behavior

- The larger of wrap-aware horizontal distance and absolute vertical distance consumes the authoritative movement budget.
- A vertical displacement above the available budget keeps the stored transform unchanged and corrects the owner.
- A rejected movement is not fanned out to observers.
- A bounded 45-degree movement remains accepted without charging its horizontal and terrain-snapped vertical components twice.

## Root cause

`update_monster_position` computed movement cost with `dist_xz_sq` and later assigned the full client position. Because both the speed gate and the zero-distance collision shortcut ignored Y, downstream collision code could not restore the invariant that every accepted height change was covered by an authoritative limit.

## Changes

- Compute wrap-aware horizontal distance and absolute vertical distance, then charge the larger value to cap each dimension without double-charging terrain slopes.
- Keep the existing token-bucket refill and cap, collision sweep, correction message, and observer fanout ordering.
- Add a regression that distinguishes a rejected large height change from an accepted one-meter horizontal and one-meter vertical move.

## Validation

Local validation on the current `master`:

- `cargo test -p onlinerpg-server client_monster_move_charges_vertical_displacement --locked --quiet -- --nocapture` — 1 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test --workspace --locked --quiet` — 858 passed
- `git diff --check HEAD^!` — passed

The focused regression verifies authoritative position, movement-budget accounting, owner correction, observer suppression for rejection, and normal fanout for a bounded 45-degree move.

## Scope and limitations

This PR does not add terrain sampling or path restrictions and does not change monster floor messages, collision geometry, budget size, refill rate, or the wire protocol. Horizontal and vertical displacement share the existing budget but are bounded independently rather than combined as Euclidean travel.
