### PR TITLE
Add a contributor guide covering CI checks and how to pick work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to OpenMMO
+
+Contributions are welcome — this guide collects the practical details that are easy to discover only after CI fails or a PR collides with someone else's.
+
+## Before you start
+
+- [doc/TODO.md](doc/TODO.md) is the maintainer's backlog and the best source of work that is wanted. Verify against the current code that the item is still open — the list moves fast.
+- Check [open pull requests](https://github.com/Julian-adv/OpenMMO/pulls) before starting: several contributors work in parallel, and an item can be claimed between one day and the next.
+- For larger changes (new systems, UI, design decisions), open an issue describing the approach first.
+
+## Development setup
+
+Follow the [Development Setup](README.md#development-setup) section of the README. Two steps live outside git and are required for a working world: fetching binary assets (`bash tools/fetch-assets.sh`, re-run whenever `assets.lock` changes) and baking terrain (`cargo run -p terrain-gen --release -- bake --seed 42`, ~73 GB).
+
+## Checks CI runs
+
+CI ([.github/workflows/ci.yml](.github/workflows/ci.yml)) runs the checks below on every PR; running them locally before pushing saves a round-trip.
+
+Rust, from the repo root:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Client, from `client/`:
+
+```bash
+npm test              # vitest
+npm run check         # svelte-check + tsc
+npm run lint          # eslint
+npm run format:check  # prettier (npm run format to fix)
+```
+
+If you touched Rust code in `shared/`, run `npm run build:wasm` first so the client checks see the current WASM bindings — CI builds it before everything else.
+
+## Pull requests
+
+- Keep branch names short and descriptive (kebab-case).
+- Write commit messages in the imperative mood and explain the intent, matching the existing history.
+- In the PR body, describe what changed and how you tested it; if the work comes from `doc/TODO.md`, quote the item.
+- On your first PR, a bot asks you to sign the [Contributor License Agreement](CLA.md) by leaving a comment — required before merging.
+
+## Binary assets
+
+3D models, music, and sounds are hosted on Hugging Face, not in git. See [doc/ASSETS.md](doc/ASSETS.md) for the dataset PR flow, and record each asset's origin and license in the matching `doc/assets/` file.

--- a/README.ja.md
+++ b/README.ja.md
@@ -251,6 +251,6 @@ sudo systemctl restart openmmo-server
 
 ## コントリビューション
 
-コントリビューションを歓迎します！初めてプルリクエストを開くと、ボットが PR 上のコメントで [Contributor License Agreement](CLA.md) への署名を求めます。コントリビューションをマージするには CLA への署名が必要です。
+コントリビューションを歓迎します！作業の選び方、CI が実行するチェック、PR の慣例については [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。初めてプルリクエストを開くと、ボットが PR 上のコメントで [Contributor License Agreement](CLA.md) への署名を求めます。コントリビューションをマージするには CLA への署名が必要です。
 
 バイナリアセット（3D モデル・音楽・効果音）のコントリビューションは [doc/ASSETS.md](doc/ASSETS.md) を参照してください — git ではなく Hugging Face データセットへの PR で行います。

--- a/README.md
+++ b/README.md
@@ -280,6 +280,6 @@ The movement warnings (rejected move target, waypoint queue full, blocked move) 
 
 ## Contributing
 
-Contributions are welcome! When you open your first pull request, a bot will ask you to sign the [Contributor License Agreement](CLA.md) by leaving a comment on the PR. Signing the CLA is required before your contribution can be merged.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to pick work, the checks CI runs, and PR conventions. When you open your first pull request, a bot will ask you to sign the [Contributor License Agreement](CLA.md) by leaving a comment on the PR. Signing the CLA is required before your contribution can be merged.
 
 To contribute binary assets (3D models, music, sounds), see [doc/ASSETS.md](doc/ASSETS.md) — they go through a Hugging Face dataset PR rather than git.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -251,6 +251,6 @@ sudo systemctl restart openmmo-server
 
 ## 贡献
 
-欢迎贡献！当你首次提交 Pull Request 时，机器人会要求你在 PR 中留言签署[贡献者许可协议](CLA.md)。签署 CLA 后你的贡献才能被合并。
+欢迎贡献！关于如何选择任务、CI 运行的检查项以及 PR 约定，请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。当你首次提交 Pull Request 时，机器人会要求你在 PR 中留言签署[贡献者许可协议](CLA.md)。签署 CLA 后你的贡献才能被合并。
 
 如需贡献二进制资产（3D 模型、音乐、音效），请参阅 [doc/ASSETS.md](doc/ASSETS.md) — 它们通过 Hugging Face 数据集 PR 提交，而不是 git。


### PR DESCRIPTION
## Summary

A new contributor currently learns two things the hard way: which checks CI runs (they live only in `ci.yml` — I found `npm run format:check` via a red X), and that the backlog moves fast enough for duplicate work (my #87 was closed because #84 landed an hour earlier).

This adds a `CONTRIBUTING.md` that collects the practical parts:

- **Before you start** — verify a `doc/TODO.md` item is still open and check open PRs first
- **Checks CI runs** — the exact `cargo` and `npm` commands from `ci.yml`, plus the `build:wasm` prerequisite after `shared/` changes
- **PR conventions** — branch naming, imperative commits, quoting the TODO item, and the CLA bot flow
- **Pointers** — README dev setup (asset fetch + terrain bake) and `doc/ASSETS.md` for binary assets

The Contributing section in all three READMEs (en, zh-CN, ja) now links to it; the CLA and assets paragraphs there are unchanged.

Since a contributing guide is really the maintainer's voice, please treat the conventions I wrote down as a draft — I described what I observed in the existing history, and I'm happy to adjust tone, structure, or drop sections entirely.

## Test plan

- All relative links in `CONTRIBUTING.md` point at files that exist (`CLA.md`, `doc/TODO.md`, `doc/ASSETS.md`, `ci.yml`), and the README anchor `#development-setup` matches the existing heading
- Commands were copied from `ci.yml` and `client/package.json` rather than from memory
- Docs-only change; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)