### PR TITLE
Restore rustfmt formatting in stall_tests

### DIFF
--- a/server/src/game_state/tests/stall_tests.rs
+++ b/server/src/game_state/tests/stall_tests.rs
@@ -8,7 +8,9 @@ async fn only_a_merchant_lays_a_stall_and_only_one_at_a_time() {
     let game_state = make_test_game_state("stall_lay");
     let auth = make_test_auth("stall_lay");
     let knight_id = pid("knight");
-    game_state.add_player(make_player("knight", 100.0, 50.0)).await;
+    game_state
+        .add_player(make_player("knight", 100.0, 50.0))
+        .await;
     let merchant_id = pid("npc_wick");
     let mut merchant = make_player("npc_wick", 100.0, 50.0);
     merchant.class = CharacterClass::Merchant;


### PR DESCRIPTION
## Summary

`cargo fmt --all --check` fails on master since dfd98814 (the `/lay_stall` commit), so the Rust CI job is red on master and on every open PR based on it — #118's failure is this, for example. One `add_player` call in `server/src/game_state/tests/stall_tests.rs` needed wrapping.

Formatting only, no behavior change.

## Test plan

- `cargo fmt --all --check` passes locally
- `cargo test -p onlinerpg-server stall` — 4 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)