### PR TITLE
Despawn abandoned monsters and raise the spawn cap for 5,000 users

### DIFF
--- a/data-src/world.json
+++ b/data-src/world.json
@@ -5,7 +5,7 @@
     "z": 4741.6,
     "rotation": 158.8
   },
-  "maxMonstersTotal": 1000,
+  "maxMonstersTotal": 135000,
   "ambientSpawns": [
     {
       "monsterType": "scp939",

--- a/server/src/game_state/combat.rs
+++ b/server/src/game_state/combat.rs
@@ -355,10 +355,12 @@ impl super::GameState {
                     monster_id, monster.health, monster.max_health
                 );
 
-                if monster.health == 0 {
-                    monster.state = MonsterState::Dead;
-                    is_dead = true;
-                }
+                is_dead = monster.health == 0;
+            }
+            if is_dead {
+                // Through the registry so the kill frees its spawn slot now,
+                // not when the corpse is swept 30s later.
+                monsters.mark_dead(&monster_id);
             }
 
             if is_dead {

--- a/server/src/game_state/dungeon.rs
+++ b/server/src/game_state/dungeon.rs
@@ -1116,9 +1116,13 @@ impl GameState {
                     let mut monsters = self.monsters.write().await;
                     let mut out = Vec::new();
                     for id in &alive_ids {
-                        if let Some(m) = monsters.get_mut(id) {
-                            if m.owner_id.as_ref() == Some(player_id) {
-                                m.owner_id = Some(new_owner);
+                        if monsters
+                            .get(id)
+                            .map(|m| m.owner_id.as_ref() == Some(player_id))
+                            == Some(true)
+                        {
+                            monsters.reassign_owner(id, new_owner);
+                            if let Some(m) = monsters.get(id) {
                                 out.push(m.clone());
                             }
                         }

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -179,12 +179,15 @@ pub struct GameState {
     movement_intents: Arc<RwLock<HashMap<PlayerId, player::MoveQueue>>>,
     last_player_attacks: Arc<RwLock<HashMap<PlayerId, u64>>>,
     player_spatial_cells: Arc<RwLock<HashMap<SpatialCell, HashSet<PlayerId>>>>,
-    monsters: Arc<RwLock<HashMap<String, crate::types::Monster>>>,
+    monsters: Arc<RwLock<monster::MonsterRegistry>>,
     /// player_id → (resolved track title, performance start). Source of the
     /// `elapsed_secs` sent to players entering earshot mid-performance;
     /// cleared with the `MUSIC_EMOTE` interaction.
     music_performances: Arc<RwLock<HashMap<PlayerId, (String, Instant)>>>,
     ambient_spawn_allowances: Arc<RwLock<HashMap<(PlayerId, String), u64>>>,
+    /// monster id → when it was first found with no player inside its AOI.
+    /// Drives the abandoned-monster despawn in `tick_abandoned_monsters`.
+    abandoned_monsters: Arc<RwLock<HashMap<String, u64>>>,
     broadcast_tx: GameStateSender,
     server_notice: Arc<RwLock<Option<String>>>,
     game_clock: Arc<std::sync::RwLock<GameClock>>,
@@ -437,9 +440,10 @@ impl GameState {
             movement_intents: Arc::new(RwLock::new(HashMap::new())),
             last_player_attacks: Arc::new(RwLock::new(HashMap::new())),
             player_spatial_cells: Arc::new(RwLock::new(HashMap::new())),
-            monsters: Arc::new(RwLock::new(HashMap::new())),
+            monsters: Arc::new(RwLock::new(monster::MonsterRegistry::default())),
             music_performances: Arc::new(RwLock::new(HashMap::new())),
             ambient_spawn_allowances: Arc::new(RwLock::new(HashMap::new())),
+            abandoned_monsters: Arc::new(RwLock::new(HashMap::new())),
             broadcast_tx,
             server_notice: Arc::new(RwLock::new(None)),
             game_clock: Arc::new(std::sync::RwLock::new(GameClock {

--- a/server/src/game_state/monster.rs
+++ b/server/src/game_state/monster.rs
@@ -20,6 +20,160 @@ const MONSTER_MOVE_BUDGET_CAP_METERS: f32 = 12.0;
 /// type stays tightly bounded rather than inheriting a fast monster's leeway.
 const DEFAULT_MONSTER_RUN_SPEED: f32 = 3.5;
 const AMBIENT_SPAWN_ALLOWANCE_TTL_MS: u64 = 30_000;
+/// How long a surface monster may sit with no player inside its AOI before it
+/// despawns. Long enough that stepping out of range and back doesn't churn.
+const ABANDONED_MONSTER_GRACE_MS: u64 = 60_000;
+
+/// Player positions bucketed by spatial cell for one abandonment sweep.
+type PlayerCells = std::collections::HashMap<super::SpatialCell, Vec<(Position, i8)>>;
+
+/// The monster map plus incrementally maintained population counts.
+///
+/// Every spawn checks the global and per-player caps. At 5,000 users that is
+/// tens of thousands of checks per 10s tick, so the caps cannot be answered by
+/// scanning the map. Counts track *alive* monsters only: a corpse lingers 30s
+/// (combat.rs) and must not hold a spawn slot.
+///
+/// `get_mut` hands out a plain `&mut Monster` for position and health edits.
+/// Changing a monster's `state` to Dead or its `owner_id` through it would
+/// desync the counts — route those through `mark_dead` / `reassign_owner`.
+#[derive(Default)]
+pub(crate) struct MonsterRegistry {
+    monsters: std::collections::HashMap<String, crate::types::Monster>,
+    alive_total: usize,
+    alive_by_owner_type: std::collections::HashMap<(PlayerId, String), u32>,
+}
+
+impl MonsterRegistry {
+    fn credit(&mut self, monster: &crate::types::Monster) {
+        if monster.state == MonsterState::Dead {
+            return;
+        }
+        self.alive_total += 1;
+        if let Some(owner) = monster.owner_id {
+            *self
+                .alive_by_owner_type
+                .entry((owner, monster.monster_type.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+
+    fn debit(&mut self, monster: &crate::types::Monster) {
+        if monster.state == MonsterState::Dead {
+            return;
+        }
+        self.alive_total = self.alive_total.saturating_sub(1);
+        if let Some(owner) = monster.owner_id {
+            let key = (owner, monster.monster_type.clone());
+            if let Entry::Occupied(mut entry) = self.alive_by_owner_type.entry(key) {
+                *entry.get_mut() -= 1;
+                if *entry.get() == 0 {
+                    entry.remove();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        id: String,
+        monster: crate::types::Monster,
+    ) -> Option<crate::types::Monster> {
+        self.credit(&monster);
+        let replaced = self.monsters.insert(id, monster);
+        if let Some(old) = &replaced {
+            self.debit(old);
+        }
+        replaced
+    }
+
+    pub(crate) fn remove(&mut self, id: &str) -> Option<crate::types::Monster> {
+        let removed = self.monsters.remove(id);
+        if let Some(monster) = &removed {
+            self.debit(monster);
+        }
+        removed
+    }
+
+    pub(crate) fn get(&self, id: &str) -> Option<&crate::types::Monster> {
+        self.monsters.get(id)
+    }
+
+    pub(crate) fn get_mut(&mut self, id: &str) -> Option<&mut crate::types::Monster> {
+        self.monsters.get_mut(id)
+    }
+
+    pub(crate) fn values(
+        &self,
+    ) -> std::collections::hash_map::Values<'_, String, crate::types::Monster> {
+        self.monsters.values()
+    }
+
+    pub(crate) fn iter(
+        &self,
+    ) -> std::collections::hash_map::Iter<'_, String, crate::types::Monster> {
+        self.monsters.iter()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.monsters.len()
+    }
+
+    /// Alive monsters server-wide, for the global cap.
+    pub(crate) fn alive_total(&self) -> usize {
+        self.alive_total
+    }
+
+    /// Alive monsters of one type owned by one player, for the per-player cap.
+    pub(crate) fn alive_for(&self, owner: &PlayerId, monster_type: &str) -> u32 {
+        self.alive_by_owner_type
+            .get(&(*owner, monster_type.to_string()))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Kill a monster, freeing its spawn slot while the corpse lingers.
+    pub(crate) fn mark_dead(&mut self, id: &str) {
+        let Some(monster) = self.monsters.get(id) else {
+            return;
+        };
+        if monster.state == MonsterState::Dead {
+            return;
+        }
+        let snapshot = monster.clone();
+        self.debit(&snapshot);
+        if let Some(monster) = self.monsters.get_mut(id) {
+            monster.state = MonsterState::Dead;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn alive_by_owner_type_len(&self) -> usize {
+        self.alive_by_owner_type.len()
+    }
+
+    pub(crate) fn reassign_owner(&mut self, id: &str, new_owner: PlayerId) {
+        let Some(monster) = self.monsters.get(id) else {
+            return;
+        };
+        let snapshot = monster.clone();
+        self.debit(&snapshot);
+        if let Some(monster) = self.monsters.get_mut(id) {
+            monster.owner_id = Some(new_owner);
+        }
+        let updated = self.monsters[id].clone();
+        self.credit(&updated);
+    }
+}
+
+impl<Q: AsRef<str>> std::ops::Index<Q> for MonsterRegistry {
+    type Output = crate::types::Monster;
+
+    fn index(&self, id: Q) -> &Self::Output {
+        &self.monsters[id.as_ref()]
+    }
+}
 
 impl super::GameState {
     fn find_ambient_rule(
@@ -53,21 +207,15 @@ impl super::GameState {
             Self::find_ambient_rule(&monster_type).map(|r| r.max_per_player as usize)
         };
 
-        // Read lock: single-pass check of both global and per-player limits
+        // O(1) against the registry's maintained counts: this runs on every
+        // spawn, tens of thousands of times per tick at target population.
         {
             let monsters = self.monsters.read().await;
-            let mut alive_count = 0usize;
-            let mut owned_alive = 0usize;
-            for m in monsters.values() {
-                if m.state != MonsterState::Dead {
-                    alive_count += 1;
-                    if let Some(ref owner) = owner_id {
-                        if m.owner_id.as_ref() == Some(owner) && m.monster_type == monster_type {
-                            owned_alive += 1;
-                        }
-                    }
-                }
-            }
+            let alive_count = monsters.alive_total();
+            let owned_alive = owner_id
+                .as_ref()
+                .map(|owner| monsters.alive_for(owner, &monster_type) as usize)
+                .unwrap_or(0);
             if alive_count >= max_total {
                 warn!("Monster spawn rejected: limit reached ({})", alive_count);
                 return None;
@@ -128,10 +276,7 @@ impl super::GameState {
 
         let mut monsters = self.monsters.write().await;
         monsters.insert(id.clone(), monster.clone());
-        let alive = monsters
-            .values()
-            .filter(|m| m.state != MonsterState::Dead)
-            .count();
+        let alive = monsters.alive_total();
         debug!(
             "Spawned monster {} [owner #{}, spawn #{}] (Alive: {})",
             id, owner_number, spawn_count, alive
@@ -181,6 +326,11 @@ impl super::GameState {
                 return;
             };
             if !monster.is_controllable_by(mover_id) {
+                return;
+            }
+            // A corpse has already been debited from the population counts;
+            // letting a client move it would also resurrect its `state`.
+            if monster.state == MonsterState::Dead {
                 return;
             }
             if !new_position.is_finite() || !rotation.is_finite() || !target_position.is_finite() {
@@ -408,20 +558,21 @@ impl super::GameState {
             return;
         }
 
-        // Single lock: count alive monsters per (owner, type) and total
+        // Single lock, no scan: the registry keeps both counts current, so
+        // this reads only the (player, type) pairs this tick actually asks
+        // about instead of walking every monster on the server.
         let (owner_type_counts, total_alive) = {
             let monsters = self.monsters.read().await;
             let mut counts = std::collections::HashMap::new();
-            let mut alive = 0usize;
-            for m in monsters.values() {
-                if m.state != MonsterState::Dead {
-                    alive += 1;
-                    if let Some(ref owner) = m.owner_id {
-                        *counts.entry((*owner, m.monster_type.clone())).or_insert(0) += 1;
+            for rule in ambient_spawns {
+                for player_id in &player_ids {
+                    let owned = monsters.alive_for(player_id, &rule.monster_type);
+                    if owned > 0 {
+                        counts.insert((*player_id, rule.monster_type.clone()), owned);
                     }
                 }
             }
-            (counts, alive)
+            (counts, monsters.alive_total())
         };
 
         // Unconsumed allowances reserve slots against the global cap.
@@ -464,6 +615,126 @@ impl super::GameState {
                 ServerMessage::SpawnMonsterRequest { monster_type },
             )
             .await;
+        }
+    }
+
+    /// Same predicate as `player_ids_within_position(.., EVENT_DELIVERY_RADIUS)`
+    /// but against a per-tick snapshot, so a sweep over every monster locks the
+    /// roster once instead of twice per monster.
+    fn any_player_in_aoi(cells: &PlayerCells, position: &Position, floor_level: i8) -> bool {
+        let radius_sq = super::EVENT_DELIVERY_RADIUS * super::EVENT_DELIVERY_RADIUS;
+        // Mirror player_ids_within_position's seam handling: query translated
+        // copies so cells from the opposite world edge participate too.
+        [
+            -onlinerpg_shared::WORLD_WIDTH_X,
+            0.0,
+            onlinerpg_shared::WORLD_WIDTH_X,
+        ]
+        .iter()
+        .any(|shift_x| {
+            let shifted = Position {
+                x: position.x + shift_x,
+                ..*position
+            };
+            let center = super::SpatialCell::from_position(&shifted);
+            (center.x - 1..=center.x + 1).any(|x| {
+                (center.z - 1..=center.z + 1).any(|z| {
+                    cells
+                        .get(&super::SpatialCell { x, z })
+                        .is_some_and(|nearby| {
+                            nearby.iter().any(|(pos, floor)| {
+                                *floor == floor_level && position.dist_xz_sq(pos) <= radius_sq
+                            })
+                        })
+                })
+            })
+        })
+    }
+
+    /// Despawn surface monsters no player has been near for the grace period.
+    ///
+    /// An ambient monster the owner walked away from is invisible to everyone
+    /// (nobody is inside its AOI) yet still counts against both the owner's
+    /// `max_per_player` and the global `max_monsters_total`. Roaming clients —
+    /// agent bots especially — abandon monsters faster than they kill them, so
+    /// without this the caps fill with unreachable monsters and ambient
+    /// spawning stops server-wide. Dungeon monsters are excluded: their floor
+    /// lifecycle already despawns them.
+    pub async fn tick_abandoned_monsters(&self) {
+        self.tick_abandoned_monsters_at(Self::now_ms()).await
+    }
+
+    /// Clock-injected body, so soak tests can compress hours into a loop.
+    pub(crate) async fn tick_abandoned_monsters_at(&self, now: u64) {
+        let player_cells: PlayerCells = {
+            let players = self.players.read().await;
+            let mut cells = PlayerCells::new();
+            for player in players.values() {
+                cells
+                    .entry(super::SpatialCell::from_position(&player.position))
+                    .or_default()
+                    .push((player.position, player.floor_level));
+            }
+            cells
+        };
+
+        let unattended: Vec<String> = {
+            let monsters = self.monsters.read().await;
+            monsters
+                .values()
+                .filter(|m| {
+                    m.floor_level >= 0
+                        && !Self::any_player_in_aoi(&player_cells, &m.position, m.floor_level)
+                })
+                .map(|m| m.id.clone())
+                .collect()
+        };
+
+        let expired: Vec<String> = {
+            let mut tracker = self.abandoned_monsters.write().await;
+            let unattended_set: HashSet<&String> = unattended.iter().collect();
+            // Anything seen again (or already gone) stops accruing.
+            tracker.retain(|id, _| unattended_set.contains(id));
+            unattended
+                .iter()
+                .filter(|id| {
+                    now.saturating_sub(*tracker.entry((*id).clone()).or_insert(now))
+                        >= ABANDONED_MONSTER_GRACE_MS
+                })
+                .cloned()
+                .collect()
+        };
+        if expired.is_empty() {
+            return;
+        }
+
+        let removed: Vec<crate::types::Monster> = {
+            let mut monsters = self.monsters.write().await;
+            expired
+                .iter()
+                .filter_map(|id| monsters.remove(id))
+                .collect()
+        };
+        {
+            let mut tracker = self.abandoned_monsters.write().await;
+            for id in &expired {
+                tracker.remove(id);
+            }
+        }
+
+        // Nobody is inside the AOI by definition, so only the owner needs
+        // telling — its client still holds the monster and runs its AI.
+        for monster in removed {
+            debug!("Despawned abandoned monster {}", monster.id);
+            if let Some(owner_id) = monster.owner_id {
+                self.send_direct_message(
+                    &owner_id,
+                    ServerMessage::MonsterRemoved {
+                        monster_id: monster.id,
+                    },
+                )
+                .await;
+            }
         }
     }
 

--- a/server/src/game_state/tests/mod.rs
+++ b/server/src/game_state/tests/mod.rs
@@ -27,6 +27,8 @@ mod persistence_tests;
 mod pickup_tests;
 mod player_tests;
 mod skills_tests;
+mod spawn_scale_tests;
+mod spawn_soak_tests;
 mod stall_tests;
 mod trading_tests;
 

--- a/server/src/game_state/tests/spawn_scale_tests.rs
+++ b/server/src/game_state/tests/spawn_scale_tests.rs
@@ -1,0 +1,203 @@
+//! Scale measurements for the ambient spawn path, sized against the 5,000
+//! concurrent-user target. Run with --nocapture to read the timings.
+use super::*;
+use std::time::Instant;
+
+const USERS: usize = 5_000;
+
+/// Fill the monster map directly — spawn_monster itself is what we measure.
+async fn preload_monsters(game_state: &GameState, count: usize, owners: &[PlayerId]) {
+    let mut monsters = game_state.monsters.write().await;
+    for i in 0..count {
+        let owner = owners[i % owners.len()];
+        let position = Position {
+            x: (i % 2000) as f32 * 3.0,
+            y: 0.0,
+            z: (i / 2000) as f32 * 3.0,
+        };
+        let mut monster = make_monster(&format!("pre{i}"), position, 0);
+        monster.owner_id = Some(owner);
+        monster.monster_type = "goblin".to_string();
+        monsters.insert(monster.id.clone(), monster);
+    }
+}
+
+async fn add_bots(game_state: &GameState, count: usize) -> Vec<PlayerId> {
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let name = format!("scale_bot{i}");
+        let id = pid(&name);
+        let player = make_player(&name, (i % 100) as f32 * 60.0, (i / 100) as f32 * 60.0);
+        game_state.add_player(player).await;
+        ids.push(id);
+    }
+    ids
+}
+
+#[tokio::test]
+#[ignore = "measurement, not an assertion; run explicitly with --nocapture"]
+async fn spawn_path_cost_at_scale() {
+    // Kept just under the global cap so the measured spawns actually run the
+    // full insert path instead of returning early on the limit.
+    for &population in &[1_000usize, 10_000, 50_000, 134_000] {
+        let game_state = make_test_game_state(&format!("scale_{population}"));
+        let owners = add_bots(&game_state, USERS).await;
+        preload_monsters(&game_state, population, &owners).await;
+
+        let spawner = owners[0];
+        let start = Instant::now();
+        const SPAWNS: usize = 50;
+        for i in 0..SPAWNS {
+            game_state
+                .spawn_monster(
+                    "goblin".to_string(),
+                    Position {
+                        x: 5.0 + i as f32,
+                        y: 0.0,
+                        z: 5.0,
+                    },
+                    0.0,
+                    Some(spawner),
+                    // Dungeon floor: skips the per-player cap, so all 50
+                    // spawns succeed and we time the real work.
+                    -1,
+                    None,
+                    false,
+                )
+                .await
+                .expect("spawn succeeds below the global cap");
+        }
+        let per_spawn = start.elapsed() / SPAWNS as u32;
+
+        let start = Instant::now();
+        game_state.tick_monster_spawns().await;
+        let spawn_tick = start.elapsed();
+
+        let start = Instant::now();
+        game_state.tick_abandoned_monsters().await;
+        let abandon_tick = start.elapsed();
+
+        // The per-move fanout is the steady-state cost: every alive monster
+        // reports movement roughly once a second.
+        let movers: Vec<(PlayerId, String, Position)> = {
+            let monsters = game_state.monsters.read().await;
+            monsters
+                .values()
+                .filter(|m| m.owner_id.is_some())
+                .take(200)
+                .map(|m| (m.owner_id.unwrap(), m.id.clone(), m.position))
+                .collect()
+        };
+        let start = Instant::now();
+        for (owner, id, position) in &movers {
+            let target = Position {
+                x: position.x + 0.5,
+                ..*position
+            };
+            game_state
+                .update_monster_position(owner, id.clone(), target, 0.0, MonsterState::Idle, target)
+                .await;
+        }
+        let per_move = start.elapsed() / movers.len() as u32;
+
+        println!(
+            "{population:>7} monsters / {USERS} users: spawn_monster {per_spawn:>10.2?}  \
+             tick_monster_spawns {spawn_tick:>10.2?}  tick_abandoned {abandon_tick:>10.2?}  \
+             move {per_move:>10.2?}"
+        );
+    }
+}
+
+/// The registry's counts are the spawn caps. If they drift from the map the
+/// server silently over- or under-spawns, so pin them against a full scan
+/// after every kind of mutation.
+#[tokio::test]
+async fn registry_counts_track_the_map_through_every_mutation() {
+    let game_state = make_test_game_state("registry_counts");
+    let owners = add_bots(&game_state, 3).await;
+
+    let mut spawned = Vec::new();
+    for (i, owner) in owners.iter().enumerate() {
+        for t in ["goblin", "orc"] {
+            let monster = game_state
+                .spawn_monster(
+                    t.to_string(),
+                    Position {
+                        x: i as f32 * 10.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    0.0,
+                    Some(*owner),
+                    0,
+                    None,
+                    false,
+                )
+                .await
+                .expect("spawn succeeds under the caps");
+            spawned.push(monster.id);
+        }
+    }
+
+    let audit = |label: &'static str| {
+        let game_state = game_state.clone();
+        async move {
+            let monsters = game_state.monsters.read().await;
+            let expected_total = monsters
+                .values()
+                .filter(|m| m.state != MonsterState::Dead)
+                .count();
+            assert_eq!(
+                monsters.alive_total(),
+                expected_total,
+                "{label}: alive_total drifted from the map"
+            );
+            let mut expected_pairs = std::collections::HashMap::new();
+            for m in monsters.values() {
+                if m.state != MonsterState::Dead {
+                    if let Some(owner) = m.owner_id {
+                        *expected_pairs
+                            .entry((owner, m.monster_type.clone()))
+                            .or_insert(0u32) += 1;
+                    }
+                }
+            }
+            for ((owner, monster_type), count) in &expected_pairs {
+                assert_eq!(
+                    monsters.alive_for(owner, monster_type),
+                    *count,
+                    "{label}: per-owner count drifted for {monster_type}"
+                );
+            }
+            assert_eq!(
+                monsters.alive_by_owner_type_len(),
+                expected_pairs.len(),
+                "{label}: stale zero-count entries left behind"
+            );
+        }
+    };
+
+    audit("after spawns").await;
+
+    game_state.monsters.write().await.mark_dead(&spawned[0]);
+    audit("after mark_dead").await;
+    // Idempotent: a second kill must not double-debit.
+    game_state.monsters.write().await.mark_dead(&spawned[0]);
+    audit("after repeat mark_dead").await;
+
+    game_state.monsters.write().await.remove(&spawned[0]);
+    audit("after removing the corpse").await;
+
+    game_state.monsters.write().await.remove(&spawned[1]);
+    audit("after removing a live monster").await;
+
+    game_state
+        .monsters
+        .write()
+        .await
+        .reassign_owner(&spawned[2], owners[2]);
+    audit("after reassign_owner").await;
+
+    game_state.remove_monsters_by_owner(&owners[2]).await;
+    audit("after owner disconnect").await;
+}

--- a/server/src/game_state/tests/spawn_soak_tests.rs
+++ b/server/src/game_state/tests/spawn_soak_tests.rs
@@ -1,0 +1,301 @@
+//! Soak harness: does ambient spawning still work after hours of roaming
+//! agent-client bots? Compresses the 10s spawn tick (main.rs:445) into a loop.
+use super::*;
+
+const TICK_SECONDS: u64 = 10;
+const TWO_HOURS_TICKS: u64 = 2 * 3600 / TICK_SECONDS;
+/// How far a roaming bot travels between two spawn ticks (~3m/s for 10s).
+const ROAM_PER_TICK: f32 = 30.0;
+/// The bot chases and kills whatever it can see (NPC_SIGHT_RADIUS). Spawns
+/// land at 22m, so a bot that stays put does clear its own spawns.
+const KILL_RADIUS: f32 = onlinerpg_shared::NPC_SIGHT_RADIUS;
+
+fn lcg(seed: &mut u64) -> f32 {
+    *seed = seed
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    ((*seed >> 33) as f32) / (u32::MAX as f32 / 2.0)
+}
+
+/// Moves through the real API so `player_spatial_cells` stays in sync —
+/// writing the roster directly leaves the proximity index stale.
+async fn set_player_xz(game_state: &GameState, player_id: &PlayerId, x: f32, z: f32) {
+    let position = Position {
+        x: onlinerpg_shared::wrap_world_x(x),
+        y: 0.0,
+        z,
+    };
+    game_state
+        .teleport_player(player_id, position, 0.0, 0)
+        .await;
+}
+
+/// Mirrors connection.rs:1211 + agent-client's find_valid_spawn_position:
+/// answer every SpawnMonsterRequest with a point 22m from the bot.
+async fn answer_spawn_requests(
+    game_state: &GameState,
+    player_id: &PlayerId,
+    rx: &mut DirectRx,
+    seed: &mut u64,
+) -> usize {
+    let requested: Vec<String> = drain(rx)
+        .into_iter()
+        .filter_map(|msg| match msg {
+            ServerMessage::SpawnMonsterRequest { monster_type } => Some(monster_type),
+            _ => None,
+        })
+        .collect();
+
+    let center = game_state.get_all_players().await[player_id].position;
+    let mut spawned = 0;
+    for monster_type in requested {
+        let angle = lcg(seed) * std::f32::consts::TAU;
+        let position = Position {
+            x: onlinerpg_shared::wrap_world_x(center.x + angle.cos() * 22.0),
+            y: 0.0,
+            z: center.z + angle.sin() * 22.0,
+        };
+        let Some(position) = game_state
+            .validate_spawn_request(player_id, &monster_type, &position, 0.0)
+            .await
+        else {
+            continue;
+        };
+        if !game_state
+            .take_spawn_allowance(player_id, &monster_type)
+            .await
+        {
+            continue;
+        }
+        if game_state
+            .spawn_monster(
+                monster_type,
+                position,
+                0.0,
+                Some(*player_id),
+                0,
+                None,
+                false,
+            )
+            .await
+            .is_some()
+        {
+            spawned += 1;
+        }
+    }
+    spawned
+}
+
+/// The bot kills what is in reach; corpse cleanup (combat.rs:535) then removes
+/// it. Monsters it has walked away from are left behind, exactly as in play.
+async fn kill_monsters_in_reach(game_state: &GameState, player_id: &PlayerId) -> usize {
+    let center = game_state.get_all_players().await[player_id].position;
+    let mut monsters = game_state.monsters.write().await;
+    let doomed: Vec<String> = monsters
+        .values()
+        .filter(|m| {
+            m.owner_id.as_ref() == Some(player_id)
+                && m.position.dist_xz_sq(&center) <= KILL_RADIUS * KILL_RADIUS
+        })
+        .map(|m| m.id.clone())
+        .collect();
+    for id in &doomed {
+        monsters.remove(id);
+    }
+    doomed.len()
+}
+
+#[tokio::test]
+async fn ambient_spawns_survive_two_hours_of_roaming_bots() {
+    let game_state = make_test_game_state("spawn_soak");
+    let player_id = pid("roaming_bot");
+    game_state
+        .add_player(make_player("roaming_bot", 0.0, 0.0))
+        .await;
+    let mut rx = game_state.register_direct_channel(&player_id).await;
+
+    let mut seed = 0x5EED_1234u64;
+    let mut heading = 0.0f32;
+    let (mut x, mut z) = (0.0f32, 0.0f32);
+    let mut spawns_by_tick = Vec::new();
+    let mut kills_total = 0usize;
+
+    let sim_base = GameState::now_ms();
+    for tick in 0..TWO_HOURS_TICKS {
+        game_state
+            .tick_abandoned_monsters_at(sim_base + tick * TICK_SECONDS * 1000)
+            .await;
+        heading += (lcg(&mut seed) - 1.0) * 0.4;
+        x += heading.cos() * ROAM_PER_TICK;
+        z += heading.sin() * ROAM_PER_TICK;
+        set_player_xz(&game_state, &player_id, x, z).await;
+
+        // Kill before spawning: a real kill costs a chase plus several swings,
+        // so a monster spawned this tick is only reachable on a later one.
+        kills_total += kill_monsters_in_reach(&game_state, &player_id).await;
+        game_state.tick_monster_spawns().await;
+        spawns_by_tick
+            .push(answer_spawn_requests(&game_state, &player_id, &mut rx, &mut seed).await);
+    }
+
+    let alive = game_state.monsters.read().await.len();
+    let first_hour: usize = spawns_by_tick[..spawns_by_tick.len() / 2].iter().sum();
+    let last_30: usize = spawns_by_tick[spawns_by_tick.len() - 30..].iter().sum();
+    println!(
+        "spawned in hour 1: {first_hour}, in last 5 min: {last_30}, killed: {kills_total}, alive at end: {alive}"
+    );
+
+    assert!(
+        last_30 > 0,
+        "no ambient monster spawned in the last 5 minutes after 2h of roaming \
+         (hour 1 spawned {first_hour}, {alive} monsters still alive)"
+    );
+}
+
+/// H2 at scale: monsters roaming bots left behind must not survive as
+/// permanent cap-holders. Enough of them exhausts max_monsters_total and
+/// starves every other player on the server.
+#[tokio::test]
+async fn abandoned_monsters_do_not_accumulate_across_many_bots() {
+    let game_state = make_test_game_state("spawn_soak_global");
+    let max_total = world_config().max_monsters_total as usize;
+    let per_player: u32 = world_config()
+        .ambient_spawns
+        .iter()
+        .map(|r| r.max_per_player)
+        .sum();
+    // Enough bots that unchecked abandonment would have exhausted the old
+    // 1,000 cap; the current cap is sized for 5,000 users so it won't bind.
+    let bots = 40.min(max_total / per_player as usize + 1);
+
+    let mut bot_state = Vec::new();
+    for i in 0..bots {
+        let name = format!("bot{i}");
+        let id = pid(&name);
+        // Spread the bots far apart so nobody shares another's monsters.
+        let (x, z) = (i as f32 * 500.0, i as f32 * 500.0);
+        game_state.add_player(make_player(&name, x, z)).await;
+        let rx = game_state.register_direct_channel(&id).await;
+        bot_state.push((id, rx, x, z, 0.0f32));
+    }
+
+    let mut seed = 0xB07u64;
+    let sim_base = GameState::now_ms();
+    let sim_at = |tick: u64| sim_base + tick * TICK_SECONDS * 1000;
+    for tick in 0..TWO_HOURS_TICKS {
+        game_state.tick_abandoned_monsters_at(sim_at(tick)).await;
+        for (id, _, x, z, heading) in bot_state.iter_mut() {
+            *heading += (lcg(&mut seed) - 1.0) * 0.4;
+            *x += heading.cos() * ROAM_PER_TICK;
+            *z += heading.sin() * ROAM_PER_TICK;
+            set_player_xz(&game_state, id, *x, *z).await;
+        }
+        game_state.tick_monster_spawns().await;
+        for (id, rx, ..) in bot_state.iter_mut() {
+            answer_spawn_requests(&game_state, id, rx, &mut seed).await;
+        }
+    }
+
+    let peak = game_state.monsters.read().await.len();
+    let peak_unattended = count_unattended(&game_state).await;
+
+    // Bots stop spawning and stand still. Everything they walked away from is
+    // now well past the grace window, so nothing unattended may remain.
+    for tick in TWO_HOURS_TICKS..TWO_HOURS_TICKS + 24 {
+        game_state.tick_abandoned_monsters_at(sim_at(tick)).await;
+    }
+    let alive = game_state.monsters.read().await.len();
+    let unattended = count_unattended(&game_state).await;
+    println!(
+        "{bots} bots: peak {peak} alive ({peak_unattended} unattended, global cap \
+         {max_total}) -> after drain {alive} alive ({unattended} unattended)"
+    );
+
+    assert_eq!(
+        unattended, 0,
+        "{unattended}/{alive} monsters have no player inside their AOI yet still \
+         hold spawn-cap slots"
+    );
+}
+
+/// Monsters no player is near — invisible to everyone, yet cap-consuming.
+async fn count_unattended(game_state: &GameState) -> usize {
+    let monsters = game_state.monsters.read().await;
+    let mut unattended = 0;
+    for monster in monsters.values() {
+        if game_state
+            .player_ids_within_position(
+                &monster.position,
+                monster.floor_level,
+                EVENT_DELIVERY_RADIUS,
+            )
+            .await
+            .is_empty()
+        {
+            unattended += 1;
+        }
+    }
+    unattended
+}
+
+/// Control: same loop, bot never moves. If roaming is the load-bearing
+/// element, this one keeps spawning forever.
+#[tokio::test]
+async fn stationary_bot_keeps_spawning() {
+    let game_state = make_test_game_state("spawn_soak_still");
+    let player_id = pid("still_bot");
+    game_state
+        .add_player(make_player("still_bot", 0.0, 0.0))
+        .await;
+    let mut rx = game_state.register_direct_channel(&player_id).await;
+
+    let mut seed = 0x5EED_1234u64;
+    let mut spawns_by_tick = Vec::new();
+    for _ in 0..TWO_HOURS_TICKS {
+        game_state.tick_monster_spawns().await;
+        spawns_by_tick
+            .push(answer_spawn_requests(&game_state, &player_id, &mut rx, &mut seed).await);
+        kill_monsters_in_reach(&game_state, &player_id).await;
+    }
+    let last_30: usize = spawns_by_tick[spawns_by_tick.len() - 30..].iter().sum();
+    println!("stationary spawns in last 5 min: {last_30}");
+    assert!(last_30 > 0);
+}
+
+/// Minimal repro: no kills, no roaming loop, one monster type. Fill the
+/// per-player cap, walk 1km away, and the server stops asking for spawns.
+#[tokio::test]
+async fn walking_away_from_owned_monsters_stops_spawn_requests() {
+    let game_state = make_test_game_state("spawn_soak_min");
+    let player_id = pid("walker");
+    game_state.add_player(make_player("walker", 0.0, 0.0)).await;
+    let mut rx = game_state.register_direct_channel(&player_id).await;
+
+    let cap = world_config()
+        .ambient_spawns
+        .iter()
+        .find(|r| r.monster_type == "goblin")
+        .unwrap()
+        .max_per_player;
+    let mut seed = 1;
+    for _ in 0..cap {
+        game_state.tick_monster_spawns().await;
+        answer_spawn_requests(&game_state, &player_id, &mut rx, &mut seed).await;
+    }
+
+    set_player_xz(&game_state, &player_id, 1000.0, 1000.0).await;
+    // Walk away and stay away past the despawn grace period.
+    let start = GameState::now_ms();
+    for tick in 0..12u64 {
+        game_state
+            .tick_abandoned_monsters_at(start + tick * TICK_SECONDS * 1000)
+            .await;
+    }
+    game_state.tick_monster_spawns().await;
+
+    assert_eq!(
+        spawn_requests(&mut rx, "goblin"),
+        1,
+        "a bot that walked 1km from its owned monsters gets no new goblin spawn request"
+    );
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -456,6 +456,19 @@ async fn main() -> ExitCode {
         },
     ));
 
+    // Every 10s, free monsters their owner roamed away from. Without this the
+    // spawn caps fill with monsters nobody can see and ambient spawning stops.
+    let game_state_for_abandoned = Arc::clone(&game_state);
+    background.spawn(run_ticks(
+        "abandoned monster despawn",
+        Duration::from_secs(10),
+        drain_shutdown.clone(),
+        move || {
+            let game_state = Arc::clone(&game_state_for_abandoned);
+            async move { game_state.tick_abandoned_monsters().await }
+        },
+    ));
+
     // Dungeon spawn-slot refill tick (respawns on occupied floors)
     let game_state_for_dungeons = Arc::clone(&game_state);
     background.spawn(run_ticks(

--- a/server/src/world_config.rs
+++ b/server/src/world_config.rs
@@ -15,8 +15,12 @@ pub struct WorldConfig {
     pub ambient_spawns: Vec<AmbientSpawnRule>,
 }
 
+/// Sized for the 5,000-user target: a player can hold the sum of every
+/// `maxPerPlayer` (27) at once, so anything below users x 27 starves whoever
+/// logs in last. Raising it is only safe because the spawn caps are O(1)
+/// against `MonsterRegistry`'s maintained counts rather than a map scan.
 fn default_max_monsters_total() -> u32 {
-    1000
+    135_000
 }
 
 fn default_max_distance() -> f32 {


### PR DESCRIPTION
Each player can own at most 27 monsters at once, but when a player walks away the monsters stay where they were — nobody can see them, yet they still hold the slots. Since a roaming client abandons monsters faster than it kills them, these far-away monsters gradually fill all 27 slots, the server stops handing that player new ones, and the area around them goes empty; with enough players online the same population also fills the 1,000 shared server-wide slots, so nobody gets monsters at all.

https://github.com/user-attachments/assets/ac106783-535b-4562-b24c-a060162465c8

The fix sweeps every 10 seconds and despawns any surface monster with no player near it for 60 seconds, returning the slot (dungeon monsters are left alone — their floor lifecycle already handles them). It also replaces the "how many are there" recount, which walked every monster on each spawn, with a running count that adds 1 on spawn and subtracts 1 on death, dropping the check from 422 µs to a flat 1.66 µs — which is what makes it safe to raise the cap from 1,000 to 135,000 (5,000 users × 27).