### PR TITLE
Hide surface objects while the player is in a dungeon

### DIFF
--- a/client/src/lib/components/GameScene.svelte
+++ b/client/src/lib/components/GameScene.svelte
@@ -369,6 +369,8 @@
     if (riverRocksGroup) riverRocksGroup.visible = !underground
     const shoreSprayGroup = shoreSprayRef?.getGroup?.()
     if (shoreSprayGroup) shoreSprayGroup.visible = !underground
+    const objectGroup = objectOverlayRef?.getGroup()
+    if (objectGroup) objectGroup.visible = !underground
     if (underground) {
       // The housing layer's per-frame detection is skipped underground;
       // clear its state so stale floor offsets can't leak into physics.
@@ -376,6 +378,12 @@
       playerFloorOffset.set(0)
     }
   })
+
+  // Hiding the overlay is not enough: THREE's raycaster does not skip invisible
+  // objects, so surface signs and bridges stay pickable unless dropped here.
+  const pickableObjectMeshes = $derived(
+    objectOverlayRef && !$isUnderground ? [objectOverlayRef.getGroup()] : []
+  )
 
   $effect(() => {
     if (!directionalLight) return
@@ -1199,7 +1207,7 @@
       ...(housingLayerRef?.getDoorMeshes() ?? []),
       ...(dungeonLayerRef?.getDoorMeshes() ?? []),
     ]}
-    objectMeshes={objectOverlayRef ? [objectOverlayRef.getGroup()] : []}
+    objectMeshes={pickableObjectMeshes}
     propMeshes={dungeonLayerRef?.getPropMeshes() ?? []}
     groundItemMeshes={groundItemsLayerRef?.getGroup()
       ? [groundItemsLayerRef.getGroup()!]

--- a/client/src/lib/components/game-scene/underground-visibility.test.ts
+++ b/client/src/lib/components/game-scene/underground-visibility.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The overworld is hidden in dungeons by one `$effect` in GameScene.svelte.
+ * A layer left out of it keeps rendering underground — that is how the shop
+ * sign stayed visible from inside a dungeon. These tests fail when a layer
+ * exposing getGroup() is neither gated nor explicitly exempted.
+ */
+
+const GAME_SCENE = join(__dirname, '..', 'GameScene.svelte')
+const LAYER_DIRS = [__dirname, join(__dirname, '..', 'map-editor')]
+
+/**
+ * Layers whose group must be hidden while underground, mapped to the variable
+ * the effect assigns `.visible` on. Asserting the assignment, not just that the
+ * group is reached — `objectGroup.visible = true` must not pass.
+ */
+const SURFACE_LAYERS: Record<string, string> = {
+  GameSceneTerrainLayer: 'terrainGroup',
+  GameSceneWaterFieldLayer: 'waterGroup',
+  GameSceneGrassLayer: 'grassGroup',
+  GameSceneTreeLayer: 'treeGroup',
+  GameSceneHousingLayer: 'housingGroup',
+  GameSceneWindParticles: 'windGroup',
+  GameSceneRiverRocksLayer: 'riverRocksGroup',
+  GameSceneShoreSprayLayer: 'shoreSprayGroup',
+  ObjectOverlay: 'objectGroup',
+}
+
+/** Layers deliberately outside the gate, with the reason they are exempt. */
+const EXEMPT_LAYERS: Record<string, string> = {
+  GameSceneDungeonLayer: 'renders the dungeon itself',
+  GameSceneGroundItemsLayer: 'filters by dungeon depth on its own',
+}
+
+function componentsExposingGetGroup(): string[] {
+  const found: string[] = []
+  for (const dir of LAYER_DIRS) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.svelte')) continue
+      const src = readFileSync(join(dir, file), 'utf8')
+      if (src.includes('export function getGroup')) {
+        found.push(file.replace(/\.svelte$/, ''))
+      }
+    }
+  }
+  return found
+}
+
+/** The body of the `$effect` that hides the overworld underground. */
+function undergroundEffectBody(src: string): string {
+  const start = src.indexOf('// Underground render mode')
+  expect(start, 'underground render-mode effect not found').toBeGreaterThan(-1)
+  const end = src.indexOf('\n  })', start)
+  expect(end, 'underground effect has no closing brace').toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+describe('underground overworld gate', () => {
+  const src = readFileSync(GAME_SCENE, 'utf8')
+
+  it('hides every surface layer while underground', () => {
+    const body = undergroundEffectBody(src)
+    for (const [component, groupVar] of Object.entries(SURFACE_LAYERS)) {
+      expect(
+        new RegExp(`\\b${groupVar}\\.visible = !underground\\b`).test(body),
+        `${component} is not hidden underground`
+      ).toBe(true)
+    }
+  })
+
+  it('leaves no visibility assignment in the effect ungated', () => {
+    const body = undergroundEffectBody(src)
+    const assignments = body.match(/\w+\.visible = [^\n]+/g) ?? []
+    expect(assignments.length).toBe(Object.keys(SURFACE_LAYERS).length)
+    for (const assignment of assignments) {
+      expect(assignment, 'ungated visibility assignment').toContain(
+        '= !underground'
+      )
+    }
+  })
+
+  it('drops the object overlay from pick targets underground', () => {
+    // THREE's raycaster ignores .visible, so hiding the group is not enough:
+    // surface signs stay hoverable and clickable unless removed from the set.
+    const pickSet = src.match(/pickableObjectMeshes = \$derived\([^)]*\)/s)
+    expect(pickSet, 'pickableObjectMeshes not found').not.toBeNull()
+    expect(pickSet![0]).toContain('!$isUnderground')
+    expect(src).toContain('objectMeshes={pickableObjectMeshes}')
+  })
+
+  it('classifies every layer that exposes getGroup', () => {
+    const classified = new Set([
+      ...Object.keys(SURFACE_LAYERS),
+      ...Object.keys(EXEMPT_LAYERS),
+    ])
+    const unclassified = componentsExposingGetGroup().filter(
+      (c) => !classified.has(c)
+    )
+    expect(
+      unclassified,
+      'new layer: add it to SURFACE_LAYERS or EXEMPT_LAYERS'
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Standing on a dungeon floor, the arch sign of Rica's General Store hangs in the dark
above the room — along with the shop building, bridges and furniture placed on the
surface. The overworld is supposed to disappear underground, and for terrain, water,
grass, trees, housing, wind particles, river rocks and shore spray it does. The object
overlay was simply never added to that gate.

- **Hide the overlay underground.** `GameScene.svelte` already has one `$effect` that
  flips `.visible` on every overworld group when `$isUnderground`; the object overlay
  group now joins it.
- **Drop it from pick targets too.** THREE's raycaster does not skip invisible objects,
  so an invisible sign is still hoverable and clickable. Without this, hovering anywhere
  in a dungeon could raise a signpost bubble floating over the dungeon floor with nothing
  beneath it, and a click could resolve `move_to_ground` against a surface bridge deck the
  player cannot see. `objectMeshes` now leaves the pick set underground, the same way
  `groundMeshes` already swaps to the dungeon group.

## Why the sign is the visible symptom

Everything on the surface kept rendering, but a dungeon has no daylight, so the shop
building and its wooden arch stayed black against black. The sign's *text* is the
exception: it is a baked canvas texture on a `MeshBasicNodeMaterial` (`shop-sign.ts`),
which ignores lighting and therefore renders at full brightness wherever it is. That is
why the lettering alone appeared to float in the dark.

## Regression test

The bug came from an omission — a layer that was never added to the gate — so the test
targets that path rather than the single line that was missing.
`underground-visibility.test.ts` reads `GameScene.svelte` and asserts:

1. every surface layer assigns `<group>.visible = !underground` inside the gate (the
   assignment, not merely that the group is reached);
2. no `.visible` assignment inside the gate is ungated, and the count matches the layer
   list;
3. every component exposing `getGroup()` under `game-scene/` and `map-editor/` is
   classified as either a surface layer or an explicitly-reasoned exemption, so a newly
   added layer forces a decision instead of silently rendering underground;
4. the object overlay leaves the pick set underground.

## Verification

- Reproduced live against a local server: descended into `old_crypt` beside the shop and
  captured the sign from depth 1.
- Same player position, with and without the change: sign present before, gone after.
- Resurfacing restores every object; surface click-to-move and object picking still work.
- `format:check`, `eslint`, `svelte-check` + `tsc` clean; client suite 416 tests pass.
- Mutating the fix to `visible = true` fails two of the new assertions.

| Before — the shop sign seen from a dungeon floor | After — same position, nothing above |
|:---:|:---:|
| <img width="1902" height="1273" alt="image" src="https://github.com/user-attachments/assets/c3cd2b1d-ce66-4aec-b32b-5e9988b9ab5d" /> | <img width="1919" height="1225" alt="image" src="https://github.com/user-attachments/assets/d59f485e-b4db-4937-9436-df89b396c28a" /> |
