### PR TITLE
Enhance agent action control

### DIFF
--- a/agent-client/data/system_prompt.txt
+++ b/agent-client/data/system_prompt.txt
@@ -17,12 +17,38 @@ accumulates across days — the world state shows it as "(favor +N)" next to
 a player's name. It is your private feeling: never mention favor or its
 numbers in chat.
 
+=== NAMING THINGS: "target" ===
+
+Every action that acts on something takes it in "target". Copy the name or
+id exactly as the world state prints it — that is the only place real targets
+come from.
+
+- A character: their name.            "target": "Karl"
+- A monster: its id, never its kind.  "target": "m2_1"
+- An item on the ground: its id.      "target": 6043
+- A dungeon: its name.                "target": "Old Crypt"
+- A prop in a dungeon room: its id.   "target": 3
+
+Monsters are ALWAYS addressed by id. "goblin" names a kind of monster, and
+there may be five of them in front of you; "m2_1" names one. Ids look like
+"m2_1" or "m3_2" and are listed with every monster in the world state.
+
+When an action names two things — buying from a merchant, haggling with a
+player — "target" is the character and the goods keep their own field:
+  {"type": "buy", "item": "healing_potion", "target": "Rica"}
+
+Every action you take answers back with an event. [Arrived] means you got
+there. Anything tagged [...Failed], [Unreachable] or [NoResult] means it did
+not happen, and the line says why — read it and do something different rather
+than reissuing the same thing. If a move fails, the rest of that turn's
+actions are cancelled, because they assumed you had arrived.
+
 {{ACTIONS}}
 
 - Hunger: your satiation (0-1000) drains slowly while you play; the world
   state shows your band. Well-Fed (300-850) grants +10% move/attack speed
   and +15% carry weight; Weak (<100) slows you and stops natural healing —
-  you never die of hunger. Eat food ({"type": "use", "item": "bread"}) to
+  you never die of hunger. Eat food ({"type": "use", "target": "bread"}) to
   stay fed; merchants sell apple/bread/cheese/jerky. Eating a RAW fish
   gives little nutrition and a 70% chance of food poisoning (5 minutes of
   heavy penalties). Instead, use a campfire_kit to light a fire (burns 10
@@ -30,9 +56,10 @@ numbers in chat.
   safe, nutritious meal after a short cast. Moving cancels the grilling.
 
 IMPORTANT:
-- For attack, the field is "monster_id" (NOT "targetId", NOT "target", NOT "id").
-- Monster IDs look like "m2_1", "m3_2" etc. Copy them exactly from the world state.
-- Actions execute in order. You can include multiple actions.
+- Monster ids look like "m2_1", "m3_2" etc. Copy them exactly from the world
+  state. A monster's kind ("goblin", "slime") is never a target.
+- Actions execute in order. You can include multiple actions. A failed move
+  cancels the later ones that needed you to be somewhere; speech still runs.
 - Output ONLY the raw JSON object. No ``` blocks.
 - You are in a party ONLY after a "[Party] Members: ..." event names you.
   A request or invite you sent counts for nothing until then. People standing

--- a/agent-client/data/templates/guard.txt
+++ b/agent-client/data/templates/guard.txt
@@ -59,10 +59,10 @@ You are an AI agent playing an NPC guard in an MMORPG.
 Action types available to you on top of the shared ones:
 
 - Open your trade window on a nearby player's screen (pair it with a "say"):
-  {"type": "open_trade", "player": "PlayerName"}
+  {"type": "open_trade", "target": "PlayerName"}
 
 - Offer to pay a bonus (or less) for one item, one time (pair it with a "say"):
-  {"type": "offer_deal", "player": "PlayerName", "item": "torch", "kind": "sell", "modifier_pct": 15, "reason": "night patrol needs torches"}
+  {"type": "offer_deal", "target": "PlayerName", "item": "torch", "kind": "sell", "modifier_pct": 15, "reason": "night patrol needs torches"}
   "kind" is "sell" (player sells to you; positive = you pay a bonus) or
   "buy" (player buys from your bag; negative = discount). "reason" is
   logged, not shown to the player.

--- a/agent-client/data/templates/merchant.txt
+++ b/agent-client/data/templates/merchant.txt
@@ -45,7 +45,7 @@ You are an AI agent playing an NPC merchant in an MMORPG.
 Action types available to you on top of the shared ones:
 
 - Offer a haggled price to a nearby player (pair it with a "say"):
-  {"type": "offer_deal", "player": "PlayerName", "item": "iron_sword", "kind": "buy", "modifier_pct": -10, "reason": "told a great story about the goblin cave"}
+  {"type": "offer_deal", "target": "PlayerName", "item": "iron_sword", "kind": "buy", "modifier_pct": -10, "reason": "told a great story about the goblin cave"}
   "kind" is "buy" (player buys from you; negative = discount) or "sell"
   (player sells to you; positive = bonus). "reason" is logged, not shown
   to the player.
@@ -60,7 +60,7 @@ Action types available to you on top of the shared ones:
   itself up when you log out, so a stall left behind never lingers.
 
 - Open your shop window on a nearby player's screen (pair it with a "say"):
-  {"type": "open_trade", "player": "PlayerName"}
+  {"type": "open_trade", "target": "PlayerName"}
   Use it when the conversation turns to trading. The player must be standing
   close (a few meters) or the server refuses with a [TradeError]; ask them
   to come closer and try again. Players only — other NPCs cannot use your

--- a/agent-client/data/user_prompts/veteran.txt
+++ b/agent-client/data/user_prompts/veteran.txt
@@ -27,9 +27,9 @@ works — you have hunted these lands before.
 ## What You Know About This World
 - Towns are no-spawn zones: monsters never appear inside them. If you see no
   monsters, you are probably standing in town — walk OUT to find them.
-- attack auto-chases: give the monster_id and you walk to the monster and keep
-  swinging. Never use move to approach a monster; move's "target" only works
-  for players and NPCs.
+- attack auto-chases: give the monster's id and you walk to it and keep
+  swinging. Moving to a monster id works too, for closing the gap without
+  committing to a fight.
 - Combat is d20 vs the target's guard. Higher-guard monsters are hard to hit
   at low level. Rough tiers: Kobold Lv1 (guard 8, 2 XP), Goblin Lv2 (guard 9,
   5 XP), Stalker Lv3 (guard 10, 10 XP, fast), Orc Lv4 (guard 11, 19 XP).

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -7,7 +7,6 @@
 
 use onlinerpg_shared::ClientMessage;
 use serde::Deserialize;
-use tracing::warn;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
@@ -188,7 +187,12 @@ pub(super) enum AgentAction {
     /// Stricter than the web client: worn gear must be taken off first.
     #[serde(rename = "drop", alias = "drop_item", alias = "discard")]
     Drop {
-        #[serde(alias = "item_def_id", alias = "item_id", alias = "name")]
+        #[serde(
+            alias = "item_def_id",
+            alias = "item_id",
+            alias = "name",
+            alias = "target"
+        )]
         item: String,
         /// How many units to drop: a positive count, or "all". Defaults to 1
         /// when omitted.
@@ -273,8 +277,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
     ActionSpec {
         names: &["attack"],
         aliases: &[],
-        doc: r#"- Attack a monster (use the monster's ID from the world state, field name MUST be "monster_id"):
-  {"type": "attack", "monster_id": "m2_1"}"#,
+        doc: r#"- Attack a monster:
+  {"type": "attack", "target": "m2_1"}
+  You walk into range first, then strike."#,
     },
     ActionSpec {
         names: &["follow"],
@@ -289,22 +294,34 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
     ActionSpec {
         names: &["move"],
         aliases: &[],
-        doc: r#"- Move. To walk up to a character (player or NPC), give their name — you
-  approach them and automatically stop at a comfortable talking distance:
+        doc: r#"- Move. To a character or a monster, giving their name or id — you approach
+  and stop at the right distance, talking distance for a person and striking
+  distance for a monster:
   {"type": "move", "target": "PlayerName"}
-  To go to a place, use exact coordinates from world state:
+  {"type": "move", "target": "m2_1"}
+  To an item lying on the ground, so you can pick it up:
+  {"type": "move", "target": 6043}
+  To a place, using exact coordinates from the world state:
   {"type": "move", "x": 10.0, "y": 0.0, "z": -5.0}
-  Or move by direction and distance:
+  Or by direction and distance:
   {"type": "move", "direction": "north", "distance": 10.0}
-  Directions: north, south, east, west, northeast, northwest, southeast, southwest
-  ALWAYS use "target" with a name when moving toward a person — never copy a
-  person's coordinates into a move (you would walk right into them).
-  To go into a dungeon, name the floor you want with "depth" — 1 is the first
-  floor below ground, and you walk to the entrance and down the stairs on your
-  own, opening any doors in the way:
+  Directions are exactly these eight words: north, south, east, west,
+  northeast, northwest, southeast, southwest. Any other word fails and you
+  stay where you are.
+  Never copy a character's coordinates into a move — use their name, or you
+  walk right into them.
+
+- Go into a dungeon. The world state names each entrance and how far away it
+  is. Name the dungeon and the floor you want with "depth" — 1 is the first
+  floor below ground — and you walk to the entrance and down the stairs on
+  your own, opening any doors in the way:
+  {"type": "move", "target": "Old Crypt", "depth": 1}
+  Without a depth you walk to the entrance and stop outside:
+  {"type": "move", "target": "Old Crypt"}
+  Without a name the nearest dungeon is used:
   {"type": "move", "depth": 1}
-  Deeper floors hold stronger monsters, so descend one floor at a time and only
-  while you can still win your fights. To come back up to the surface:
+  Deeper floors hold stronger monsters, so descend one floor at a time and
+  only while you can still win your fights. To come back up to the surface:
   {"type": "move", "depth": 0}"#,
     },
     ActionSpec {
@@ -343,7 +360,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   a scroll, eat food. Name it as it appears in your bag. Using gear you
   already wear takes it off; wearing a torch is how you light your way at
   night:
-  {"type": "use", "item": "worn_torch"}"#,
+  {"type": "use", "target": "worn_torch"}"#,
     },
     ActionSpec {
         names: &["pickup"],
@@ -351,7 +368,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         doc: r#"- Pick up an item lying on the ground into your bag. You walk over to it
   first, like a web player clicking it. Give the id shown in the world
   state ("Item on ground: ... [id 6043]"), or its name:
-  {"type": "pickup", "item": 6043}
+  {"type": "pickup", "target": 6043}
   The world state marks who put an item down ("dropped by Mira"); a
   [GroundItem] event tells you when someone collects such an item, and an
   item that is no longer listed is gone — don't reach for bare ground."#,
@@ -365,7 +382,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   Plain form opens the nearest one:
   {"type": "open_chest"}
   To cross the room to the great chest instead of the small one at your feet:
-  {"type": "open_chest", "chest": "great"}"#,
+  {"type": "open_chest", "target": "great"}"#,
     },
     ActionSpec {
         names: &["sell"],
@@ -377,8 +394,8 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   unit you have. Selling more than you actually own fails outright —
   nothing is sold. Equipped gear must be taken off before selling:
   {"type": "sell", "item": "goblin_sword"}
-  {"type": "sell", "item": "healing_potion", "merchant": "Rica", "qty": 5}
-  {"type": "sell", "item": "healing_potion", "merchant": "Rica", "qty": "all"}"#,
+  {"type": "sell", "item": "healing_potion", "target": "Rica", "qty": 5}
+  {"type": "sell", "item": "healing_potion", "target": "Rica", "qty": "all"}"#,
     },
     ActionSpec {
         names: &["buy"],
@@ -388,7 +405,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   nearby merchant sells is listed under their name in the world state.
   Naming the merchant is optional — without one you buy from the nearest.
   One unit per action — repeat for more:
-  {"type": "buy", "item": "healing_potion", "merchant": "Rica"}"#,
+  {"type": "buy", "item": "healing_potion", "target": "Rica"}"#,
     },
     ActionSpec {
         names: &["drop"],
@@ -398,9 +415,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   Defaults to 1 unit; add "qty" for more, or "qty": "all" to drop every
   unit you have. Dropping more than you actually own fails outright —
   nothing is dropped:
-  {"type": "drop", "item": "goblin_sword"}
-  {"type": "drop", "item": "old_boot", "qty": 2}
-  {"type": "drop", "item": "old_boot", "qty": "all"}"#,
+  {"type": "drop", "target": "goblin_sword"}
+  {"type": "drop", "target": "old_boot", "qty": 2}
+  {"type": "drop", "target": "old_boot", "qty": "all"}"#,
     },
     ActionSpec {
         names: &["buyback"],
@@ -408,7 +425,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         doc: r#"- Buy back one item you sold to that merchant this session, for exactly
   what they paid you (undo a mis-sell). The [Buyback] event after each
   sale lists what they still hold:
-  {"type": "buyback", "item": "iron_sword", "merchant": "Rica"}"#,
+  {"type": "buyback", "item": "iron_sword", "target": "Rica"}"#,
     },
     ActionSpec {
         names: &["offer_deal"],
@@ -417,14 +434,14 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   haggle. "kind" is "buy" (they buy from you, the default) or "sell" (they
   sell to you); "modifier_pct" moves the price by that many percent, so a
   negative number is a discount. The server clamps and validates the offer:
-  {"type": "offer_deal", "player": "darkcocoa", "item": "healing_potion", "kind": "buy", "modifier_pct": -10}"#,
+  {"type": "offer_deal", "target": "darkcocoa", "item": "healing_potion", "kind": "buy", "modifier_pct": -10}"#,
     },
     ActionSpec {
         names: &["open_trade"],
         aliases: &["trade"],
         doc: r#"- (merchants only) Open your trade window on a nearby player's screen —
   how you move from talk to an actual trade:
-  {"type": "open_trade", "player": "darkcocoa"}"#,
+  {"type": "open_trade", "target": "darkcocoa"}"#,
     },
     ActionSpec {
         names: &["break_prop"],
@@ -432,7 +449,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         doc: r#"- Smash a breakable dungeon prop (barrel or crate). You have to be in the
   room it stands in — the world state lists the breakable props there with
   their ids. You walk to it first, and smashing opens its cell for movement:
-  {"type": "break_prop", "prop_id": 3}"#,
+  {"type": "break_prop", "target": 3}"#,
     },
     ActionSpec {
         names: &["party_invite"],
@@ -440,7 +457,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         doc: r#"- Invite a player to your party by name. Works at any distance, like a
   whisper; they get 30 seconds to answer. Your roster shows in the world
   state ("Your party: ..."):
-  {"type": "party_invite", "player": "darkcocoa"}"#,
+  {"type": "party_invite", "target": "darkcocoa"}"#,
     },
     ActionSpec {
         names: &["party_accept", "party_decline"],
@@ -449,7 +466,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   their party; a party hunts and travels together. With several invites
   pending, name the inviter — bare answers the oldest:
   {"type": "party_accept"}
-  {"type": "party_decline", "player": "darkcocoa"}"#,
+  {"type": "party_decline", "target": "darkcocoa"}"#,
     },
     ActionSpec {
         names: &["summon_accept", "summon_decline"],
@@ -459,7 +476,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   moves you there instantly; you cannot accept mid-combat. With several
   pending, name the caster — bare answers the oldest:
   {"type": "summon_accept"}
-  {"type": "summon_decline", "player": "darkcocoa"}"#,
+  {"type": "summon_decline", "target": "darkcocoa"}"#,
     },
     ActionSpec {
         names: &["party_say"],
@@ -483,10 +500,10 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
     },
 ];
 
-/// The "Available action types" section of the system prompt, rendered from
+/// The "=== ACTIONS ===" section of the system prompt, rendered from
 /// `ACTION_SPECS`. Fills the `{{ACTIONS}}` slot in `load_system_prompt`.
 pub(super) fn action_reference() -> String {
-    let mut out = String::from("Available action types (use EXACTLY these field names):\n");
+    let mut out = String::from("=== ACTIONS ===\n");
     for spec in ACTION_SPECS {
         out.push('\n');
         out.push_str(spec.doc.trim_end());
@@ -535,6 +552,68 @@ impl AgentAction {
     /// and respawning keep it where it is, so they stay allowed.
     pub(super) fn blocked_while_holding_position(&self) -> bool {
         self.takes_over_movement() && !matches!(self, Self::Fish { .. } | Self::Respawn)
+    }
+
+    /// Whether the action needs no additional outcome event.
+    pub(super) fn outcome_speaks_for_itself(&self) -> bool {
+        match self {
+            Self::Say { .. } | Self::PartySay { .. } | Self::Wait => true,
+            Self::Move { .. }
+            | Self::Attack { .. }
+            | Self::Follow { .. }
+            | Self::Pickup { .. }
+            | Self::OpenChest { .. }
+            | Self::BreakProp { .. }
+            | Self::Sell { .. }
+            | Self::Buy { .. }
+            | Self::Buyback { .. }
+            | Self::Fish { .. }
+            | Self::StopFishing
+            | Self::Respawn
+            | Self::OfferDeal { .. }
+            | Self::OpenTrade { .. }
+            | Self::PartyInvite { .. }
+            | Self::PartyAccept { .. }
+            | Self::PartyDecline { .. }
+            | Self::SummonAccept { .. }
+            | Self::SummonDecline { .. }
+            | Self::PartyLeave
+            | Self::Use { .. }
+            | Self::Drop { .. }
+            | Self::Reroll => false,
+        }
+    }
+
+    /// The action name used in feedback.
+    pub(super) fn label(&self) -> &'static str {
+        match self {
+            Self::Say { .. } => "say",
+            Self::Attack { .. } => "attack",
+            Self::Move { .. } => "move",
+            Self::Follow { .. } => "follow",
+            Self::Respawn => "respawn",
+            Self::Fish { .. } => "fish",
+            Self::StopFishing => "stop_fishing",
+            Self::OfferDeal { .. } => "offer_deal",
+            Self::OpenTrade { .. } => "open_trade",
+            Self::PartyInvite { .. } => "party_invite",
+            Self::PartyAccept { .. } => "party_accept",
+            Self::PartyDecline { .. } => "party_decline",
+            Self::SummonAccept { .. } => "summon_accept",
+            Self::SummonDecline { .. } => "summon_decline",
+            Self::PartyLeave => "party_leave",
+            Self::PartySay { .. } => "party_say",
+            Self::Use { .. } => "use",
+            Self::Pickup { .. } => "pickup",
+            Self::Sell { .. } => "sell",
+            Self::Buy { .. } => "buy",
+            Self::Drop { .. } => "drop",
+            Self::Buyback { .. } => "buyback",
+            Self::BreakProp { .. } => "break_prop",
+            Self::OpenChest { .. } => "open_chest",
+            Self::Reroll => "reroll",
+            Self::Wait => "wait",
+        }
     }
 }
 
@@ -754,8 +833,24 @@ fn normalize_move_targets(value: &mut serde_json::Value) {
                 obj.entry("y").or_insert_with(|| y.into());
             }
             obj.entry("z").or_insert_with(|| z.into());
+            continue;
+        }
+        // Ids print as numbers, so LLMs write them as numbers (6043.0 after
+        // arithmetic); the resolver reads shapes off the string.
+        if let Some(n) = action.get("target").and_then(as_integer) {
+            action.as_object_mut().unwrap()["target"] = n.to_string().into();
         }
     }
+}
+
+/// A JSON number that names an id, whether the model wrote it whole or as a
+/// float. Anything with a fractional part is a coordinate, not an id.
+fn as_integer(value: &serde_json::Value) -> Option<u64> {
+    if let Some(n) = value.as_u64() {
+        return Some(n);
+    }
+    let f = value.as_f64()?;
+    (f.fract() == 0.0 && f >= 0.0 && f <= u64::MAX as f64).then_some(f as u64)
 }
 
 /// Extract JSON object from text that might contain markdown code blocks.
@@ -797,15 +892,26 @@ pub(super) fn resolve_move_goal(
     direction: &Option<String>,
     distance: &Option<f32>,
     player_pos: Option<&onlinerpg_shared::Position>,
-) -> Option<(f32, f32)> {
+) -> Result<(f32, f32), GoalError> {
     if let (Some(x), Some(z)) = (x, z) {
-        Some((*x, *z))
+        Ok((*x, *z))
     } else if let (Some(dir), Some(dist), Some(pp)) = (direction.as_deref(), distance, player_pos) {
-        let (dx, dz) = direction_to_offset(dir);
-        Some((pp.x + dx * dist, pp.z + dz * dist))
+        let (dx, dz) =
+            direction_to_offset(dir).ok_or_else(|| GoalError::BadDirection(dir.into()))?;
+        Ok((pp.x + dx * dist, pp.z + dz * dist))
     } else {
-        None
+        Err(GoalError::NoGoal)
     }
+}
+
+/// Why a move carried no usable destination.
+#[derive(Debug, PartialEq)]
+pub(super) enum GoalError {
+    /// A direction word that names no direction. Not guessed at — see
+    /// [`direction_to_offset`].
+    BadDirection(String),
+    /// Nothing to go on: no coordinate pair, no direction with a distance.
+    NoGoal,
 }
 
 /// Convert an AgentAction into a ClientMessage for the game server.
@@ -838,7 +944,7 @@ pub(super) fn action_to_command(
             if target.is_some() || depth.is_some() {
                 return None;
             }
-            let (gx, gz) = resolve_move_goal(x, z, direction, distance, player_pos)?;
+            let (gx, gz) = resolve_move_goal(x, z, direction, distance, player_pos).ok()?;
             let rotation = if let Some(pp) = player_pos {
                 (gx - pp.x).atan2(gz - pp.z)
             } else {
@@ -907,8 +1013,10 @@ pub(super) fn action_to_command(
 }
 
 /// Convert a cardinal/ordinal direction string to a (dx, dz) unit offset.
-fn direction_to_offset(dir: &str) -> (f32, f32) {
-    match dir.to_lowercase().as_str() {
+/// `None` for anything else: guessing north sent the agent walking the wrong
+/// way with nothing in the transcript to explain it.
+pub(super) fn direction_to_offset(dir: &str) -> Option<(f32, f32)> {
+    Some(match dir.trim().to_lowercase().as_str() {
         "north" | "n" => (0.0, -1.0),
         "south" | "s" => (0.0, 1.0),
         "east" | "e" => (1.0, 0.0),
@@ -917,11 +1025,8 @@ fn direction_to_offset(dir: &str) -> (f32, f32) {
         "northwest" | "nw" => (-0.707, -0.707),
         "southeast" | "se" => (0.707, 0.707),
         "southwest" | "sw" => (-0.707, 0.707),
-        _ => {
-            warn!("Unknown direction '{dir}', defaulting to north");
-            (0.0, -1.0)
-        }
-    }
+        _ => return None,
+    })
 }
 
 #[cfg(test)]
@@ -1325,6 +1430,7 @@ mod tests {
             r#"{"actions": [{"type": "drop", "item": "torch"}]}"#,
             r#"{"actions": [{"type": "drop_item", "item_def_id": "torch"}]}"#,
             r#"{"actions": [{"type": "discard", "name": "torch"}]}"#,
+            r#"{"actions": [{"type": "drop", "target": "torch"}]}"#,
         ] {
             let AgentAction::Drop { item, .. } = parse_single_action(json) else {
                 panic!("expected Drop for {json}");
@@ -1636,8 +1742,14 @@ mod tests {
                     spec.names.contains(&tag),
                     "example sits under the wrong doc block: {line}"
                 );
-                serde_json::from_value::<AgentAction>(value)
-                    .unwrap_or_else(|e| panic!("doc example no longer parses: {line}\n{e}"));
+                // The whole turn parser, not bare serde: normalising numeric
+                // ids is part of reading a turn.
+                let turn = parse_turn_tolerant(&format!(r#"{{"actions": [{line}]}}"#)).unwrap();
+                assert!(
+                    turn.errors.is_empty(),
+                    "doc example no longer parses: {line}\n{:?}",
+                    turn.errors
+                );
             }
         }
     }
@@ -1652,5 +1764,93 @@ mod tests {
             text.contains("{{ACTIONS}}"),
             "data/system_prompt.txt lost its {{{{ACTIONS}}}} slot"
         );
+    }
+
+    /// Ground item ids print as numbers, so LLMs write them as numbers. They
+    /// reach the resolver as the string it reads shapes off.
+    #[test]
+    fn a_numeric_move_target_survives_as_a_string() {
+        // A model that did arithmetic writes 6043.0, and a number left where a
+        // string belongs loses the whole response, not just this action.
+        for json in [
+            r#"{"actions": [{"type": "move", "target": 6043}]}"#,
+            r#"{"actions": [{"type": "move", "target": 6043.0}]}"#,
+        ] {
+            let AgentAction::Move { target, x, z, .. } = parse_single_action(json) else {
+                panic!("expected Move for {json}");
+            };
+            assert_eq!(target.as_deref(), Some("6043"));
+            assert_eq!((x, z), (None, None));
+        }
+    }
+
+    /// The eight compass words, however the LLM abbreviates or pads them.
+    #[test]
+    fn the_compass_words_resolve() {
+        assert_eq!(direction_to_offset("north"), Some((0.0, -1.0)));
+        assert_eq!(direction_to_offset(" EAST "), Some((1.0, 0.0)));
+        assert_eq!(direction_to_offset("sw"), Some((-0.707, 0.707)));
+    }
+
+    /// Anything else stops the move. Guessing north walked the agent the
+    /// wrong way with nothing in the transcript to explain it.
+    #[test]
+    fn a_word_that_is_not_a_direction_is_not_guessed_at() {
+        for junk in ["forward", "up", "left", "왼쪽", ""] {
+            assert_eq!(direction_to_offset(junk), None, "{junk}");
+        }
+
+        let pos = onlinerpg_shared::Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        assert_eq!(
+            resolve_move_goal(
+                &None,
+                &None,
+                &Some("forward".to_string()),
+                &Some(10.0),
+                Some(&pos)
+            ),
+            Err(GoalError::BadDirection("forward".to_string()))
+        );
+    }
+
+    /// Only speech and waiting report themselves; everything else owes the
+    /// LLM an outcome. A miscategorised action silently loses its feedback.
+    #[test]
+    fn only_speech_and_waiting_report_themselves() {
+        for quiet in [
+            AgentAction::Say {
+                message: "hi".to_string(),
+            },
+            AgentAction::PartySay {
+                message: "hi".to_string(),
+            },
+            AgentAction::Wait,
+        ] {
+            assert!(quiet.outcome_speaks_for_itself(), "{quiet:?}");
+        }
+        for owes in [
+            AgentAction::Move {
+                target: None,
+                x: Some(1.0),
+                y: None,
+                z: Some(2.0),
+                direction: None,
+                distance: None,
+                depth: None,
+            },
+            AgentAction::Attack {
+                monster_id: "m2_1".to_string(),
+            },
+            AgentAction::Use {
+                item: "torch".to_string(),
+            },
+            AgentAction::PartyLeave,
+        ] {
+            assert!(!owes.outcome_speaks_for_itself(), "{owes:?}");
+        }
     }
 }

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -10,18 +10,21 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use crate::dungeon::ChestKind;
-use crate::state::{Carried, CarriedBagCopies, SharedState};
+use crate::state::{Carried, CarriedBagCopies, MoveTarget, MoveTargetError, SharedState};
 use onlinerpg_shared::messages::BagLineItem;
 
 use super::action::{
     action_to_command, asks_for_great_chest, parse_turn_tolerant, resolve_move_goal, AgentAction,
-    PickupRef, Qty,
+    GoalError, PickupRef, Qty,
 };
 use super::combat::{
     approach_player, chase_monster, chest_arrive_range, walk_to_ground_item, walk_to_point,
     ChaseResult, LostReason,
 };
 use super::movement::{execute_move, MoveResult};
+#[cfg(test)]
+use super::outcome::reports_failure;
+use super::outcome::{settle_action, ActionOutcome};
 use super::MEMORY_LINES;
 
 /// Pause between the crouch broadcast and the actual pickup, approximating
@@ -59,6 +62,114 @@ async fn target_moved(
         return false;
     };
     was.dist_xz_sq(&now) > FOLLOW_PROGRESS_M * FOLLOW_PROGRESS_M
+}
+
+/// Feedback for a `move` target string that resolved to nothing. Each case
+/// hands back the ids or names that would have worked, so the LLM can fix the
+/// target next turn instead of reissuing the same string.
+fn move_target_failure(e: &MoveTargetError) -> String {
+    match e {
+        MoveTargetError::SpeciesNotId {
+            species,
+            candidates,
+        } => {
+            let list: Vec<String> = candidates
+                .iter()
+                .take(5)
+                .map(|(id, d)| format!("{id} ({d:.0}m)"))
+                .collect();
+            format!(
+                "[MoveFailed] '{species}' names a kind of monster, not one monster. \
+                 Nearby {species}s: {}. Use the id.",
+                list.join(", ")
+            )
+        }
+        MoveTargetError::MonsterGone { id } => format!(
+            "[MoveFailed] Monster {id} is not in sight — it died, or it wandered off. \
+             Pick an id from the current world state."
+        ),
+        MoveTargetError::Unknown { asked, addressable } => {
+            if addressable.is_empty() {
+                format!("[MoveFailed] Nothing here is called '{asked}'.")
+            } else {
+                format!(
+                    "[MoveFailed] Nothing here is called '{asked}'. You can move to: {}.",
+                    addressable.join(", ")
+                )
+            }
+        }
+    }
+}
+
+/// What a resolved target is, for the message about a depth that does not
+/// belong with it.
+fn describe_target(t: &MoveTarget) -> &'static str {
+    match t {
+        MoveTarget::Character { .. } => "a character",
+        MoveTarget::Monster { .. } => "a monster",
+        MoveTarget::GroundItem { .. } => "an item on the ground",
+        MoveTarget::Prop { .. } => "a prop",
+        MoveTarget::Chest { .. } => "a chest",
+        MoveTarget::Dungeon { .. } => "a dungeon",
+    }
+}
+
+type Approach = (onlinerpg_shared::Position, i8, f32);
+
+async fn prop_approach(state: &Arc<Mutex<SharedState>>, prop_id: u32) -> Option<Approach> {
+    let s = state.lock().await;
+    let prop = s
+        .breakables_in_sight()
+        .into_iter()
+        .find(|b| b.prop_id == prop_id)?;
+    let gap = crate::geom::PlanarDelta::between(&prop.approach, &prop.position).dist;
+    Some((prop.approach, s.self_floor_level, chest_arrive_range(gap)))
+}
+
+async fn chest_approach(
+    state: &Arc<Mutex<SharedState>>,
+    selector: &str,
+) -> Option<(Approach, &'static str)> {
+    let s = state.lock().await;
+    let sighted = s.chests_in_sight();
+    let chest = if asks_for_great_chest(Some(selector)) {
+        sighted
+            .iter()
+            .find(|c| c.kind == ChestKind::Treasure)
+            .or(sighted.first())
+    } else {
+        sighted.first()
+    }?;
+    let gap = crate::geom::PlanarDelta::between(&chest.approach, &chest.position).dist;
+    let label = match chest.kind {
+        ChestKind::Treasure => "the great chest",
+        ChestKind::Prop(_) => "a small chest",
+    };
+    Some((
+        (chest.approach, s.self_floor_level, chest_arrive_range(gap)),
+        label,
+    ))
+}
+
+/// Walk to a resolved dungeon sighting, reporting either way.
+async fn walk_to_sighting(state: &Arc<Mutex<SharedState>>, approach: Option<Approach>, what: &str) {
+    let Some((pos, floor, range)) = approach else {
+        let mut s = state.lock().await;
+        s.push_agent_event(format!(
+            "[MoveFailed] {what} is no longer in this room to walk to."
+        ));
+        return;
+    };
+    let outcome = match walk_to_point(state, pos, floor, range).await {
+        ChaseResult::InRange => format!("[Arrived] You stand next to {what}."),
+        ChaseResult::Lost(loss) => {
+            format!("[MoveFailed] You did not reach {what} — {}.", loss.clause())
+        }
+        ChaseResult::Error => {
+            format!("[MoveFailed] Something went wrong walking to {what}.")
+        }
+    };
+    state.lock().await.push_agent_event(outcome);
 }
 
 /// Feedback for an attack whose chase never reached the monster, so the agent
@@ -178,14 +289,13 @@ pub(super) async fn handle_response(
         Err(e) => {
             warn!("Failed to parse agent response: {e}");
             warn!("Raw response: {response}");
-            // Whole response was not valid JSON — tell the agent so, instead of
-            // leaving it to guess why nothing happened.
+            // The response itself stays out of the prompt: a model fed its
+            // own malformed output continues in that shape.
             let mut s = state.lock().await;
-            s.push_agent_event(
-                "[BadResponse] Your last message was not valid JSON and nothing ran. \
-                 Reply with only the JSON object — no prose, no code fences."
-                    .to_string(),
-            );
+            s.push_agent_event(format!(
+                "[BadResponse] Your last reply was not the required JSON object ({e}), so \
+                 nothing ran. Reply with only the JSON object — no prose, no code fences."
+            ));
             return None;
         }
     };
@@ -243,13 +353,39 @@ pub(super) async fn handle_response(
         }
     }
 
+    let mut pending: Option<(&AgentAction, (usize, u64))> = None;
+    let mut lost_position: Option<&str> = None;
+    let mut skipped: Vec<&str> = Vec::new();
+
     for action in &agent_resp.actions {
+        if let Some((prev, mark)) = pending.take() {
+            if settle_action(state, prev, mark).await == ActionOutcome::Failed
+                && prev.takes_over_movement()
+            {
+                warn!("Position lost by a failed {}", prev.label());
+                lost_position = lost_position.or(Some(prev.label()));
+            }
+        }
+
+        if lost_position.is_some() && action.takes_over_movement() {
+            skipped.push(action.label());
+            continue;
+        }
+
         // Skip movement/attack when the NPC must stay put — resting on a
         // scheduled object, or serving a customer with an open trade window.
         if skip_movement && action.blocked_while_holding_position() {
             debug!("Skipping {:?} action — NPC is holding position", action);
+            let mut s = state.lock().await;
+            s.push_agent_event(format!(
+                "[ActionFailed] You are holding position right now, so your {} did not \
+                 run. Finish what you are doing first.",
+                action.label()
+            ));
             continue;
         }
+
+        pending = Some((action, state.lock().await.action_progress()));
 
         // A running follow yields, or the two tasks fight over the same body.
         if action.takes_over_movement() {
@@ -890,111 +1026,224 @@ pub(super) async fn handle_response(
             depth,
         } = action
         {
-            // Name-targeted move: walk up to the character and stop a
-            // polite distance short instead of pathing onto their exact
-            // position (which would overlap the models).
-            if let Some(name) = target.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-                let target_id = {
+            // A name resolves across every namespace the world state prints,
+            // and that decides which mover runs.
+            let named = target.as_deref().map(str::trim).filter(|s| !s.is_empty());
+            let resolved = match named {
+                Some(name) => {
                     let mut s = state.lock().await;
-                    match s.resolve_nearby_player(name) {
-                        Some((id, _)) => id,
-                        None => {
-                            warn!("move: no nearby character named '{name}'");
-                            s.push_agent_event(format!(
-                                "[MoveFailed] No character named '{name}' is nearby to walk to."
-                            ));
+                    match s.resolve_move_target(name) {
+                        Ok(t) => Some(t),
+                        Err(e) => {
+                            warn!("move: could not resolve target '{name}' ({e:?})");
+                            s.push_agent_event(move_target_failure(&e));
                             continue;
                         }
                     }
-                };
-                match approach_player(state, &target_id).await {
+                }
+                None => None,
+            };
+
+            // A depth names a dungeon floor: walk to the entrance, then
+            // descend to that floor's landing (a cross-floor A* from across
+            // the map would blow its node budget). Only explicit coordinates
+            // override the landing.
+            match (&resolved, depth) {
+                (Some(MoveTarget::Dungeon { id, .. }), _) => {
+                    let goal = resolve_move_goal(x, z, &None, &None, None).ok();
+                    move_to_dungeon_floor(state, *depth, goal, Some(id)).await;
+                    continue;
+                }
+                (None, Some(_)) => {
+                    let goal = resolve_move_goal(x, z, &None, &None, None).ok();
+                    move_to_dungeon_floor(state, *depth, goal, None).await;
+                    continue;
+                }
+                (Some(other), Some(d)) => {
+                    let mut s = state.lock().await;
+                    s.push_agent_event(format!(
+                        "[MoveFailed] \"depth\": {d} only goes with a dungeon name, but \
+                         '{}' is {}. Move to it without a depth, or name a dungeon.",
+                        named.unwrap_or_default(),
+                        describe_target(other)
+                    ));
+                    continue;
+                }
+                (_, None) => {}
+            }
+
+            match resolved {
+                // Stop a polite distance short instead of pathing onto their
+                // exact position, which would overlap the models.
+                Some(MoveTarget::Character { id, name }) => {
+                    match approach_player(state, &id).await {
+                        ChaseResult::InRange => {
+                            info!("Agent walked up to {name}");
+                            let mut s = state.lock().await;
+                            if let Some(face_cmd) = s.face_player_command(&id) {
+                                if let Err(e) = s.send_command(face_cmd).await {
+                                    error!("Failed to send face-character move: {e}");
+                                }
+                            }
+                            s.push_agent_event(format!(
+                                "[Arrived] You walked up to character {} ({name}) and now stand \
+                                 right next to them. No further movement is needed to interact.",
+                                id.get()
+                            ));
+                        }
+                        ChaseResult::Lost(loss) => {
+                            warn!("move: could not reach '{name}' ({loss:?})");
+                            let why = match loss {
+                                LostReason::TargetGone => "they moved out of sight".to_string(),
+                                LostReason::TooFar(d) => {
+                                    format!("they are {d:.0}m away, too far to follow")
+                                }
+                                other => other.clause(),
+                            };
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[MoveFailed] You could not reach {name} — {why}."
+                            ));
+                        }
+                        ChaseResult::Error => {
+                            error!("move: error while approaching '{name}'");
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[MoveFailed] Something went wrong walking to {name}."
+                            ));
+                        }
+                    }
+                }
+                // Walking to a monster is the same chase an attack runs, minus
+                // the swing: it closes the gap so the next attack lands.
+                Some(MoveTarget::Monster { id }) => match chase_monster(state, &id).await {
                     ChaseResult::InRange => {
-                        info!("Agent walked up to {name}");
+                        info!("Agent walked up to monster {id}");
                         let mut s = state.lock().await;
-                        if let Some(face_cmd) = s.face_player_command(&target_id) {
+                        if let Some(face_cmd) = s.face_monster_command(&id) {
                             if let Err(e) = s.send_command(face_cmd).await {
-                                error!("Failed to send face-character move: {e}");
+                                error!("Failed to send face-monster move: {e}");
                             }
                         }
                         s.push_agent_event(format!(
-                            "[Arrived] You walked up to {name} and now stand right next \
-                             to them. No further movement is needed to interact."
+                            "[Arrived] You stand within striking distance of {id}. \
+                             Attack it with {{\"type\": \"attack\", \"target\": \"{id}\"}}."
                         ));
                     }
                     ChaseResult::Lost(loss) => {
-                        warn!("move: could not reach '{name}' ({loss:?})");
-                        let why = match loss {
-                            LostReason::TargetGone => "they moved out of sight".to_string(),
-                            LostReason::TooFar(d) => {
-                                format!("they are {d:.0}m away, too far to follow")
-                            }
-                            other => other.clause(),
-                        };
+                        warn!("move: could not reach monster {id} ({loss:?})");
                         let mut s = state.lock().await;
-                        s.push_agent_event(format!(
-                            "[MoveFailed] You could not reach {name} — {why}."
-                        ));
+                        s.push_agent_event(unreachable_note(&id, &loss));
                     }
                     ChaseResult::Error => {
-                        error!("move: error while approaching '{name}'");
-                    }
-                }
-                continue;
-            }
-
-            // A depth names a dungeon floor: walk to the entrance first (a
-            // cross-floor A* from across the map would blow its node budget),
-            // then descend to that floor's stair landing.
-            if let Some(depth) = depth {
-                // Only an explicit coordinate pair overrides the floor's landing;
-                // a direction/distance is meaningless across floors.
-                let goal = resolve_move_goal(x, z, &None, &None, None);
-                move_to_dungeon_floor(state, *depth, goal).await;
-                continue;
-            }
-
-            // A bare coordinate carries no floor, so stay on the one we're on
-            // rather than dropping to the ground floor.
-            let (goal, floor) = {
-                let s = state.lock().await;
-                let pp = s.self_player.as_ref().map(|p| &p.position);
-                (
-                    resolve_move_goal(x, z, direction, distance, pp),
-                    s.passability_floor(),
-                )
-            };
-            if let Some((gx, gz)) = goal {
-                match execute_move(state, gx, gz, floor).await {
-                    MoveResult::Arrived => {
-                        info!("Agent arrived at ({gx:.1}, {gz:.1})");
+                        error!("move: error while chasing monster {id}");
                         let mut s = state.lock().await;
                         s.push_agent_event(format!(
-                            "[Arrived] You reached ({gx:.1}, {gz:.1}). Look around and \
-                             decide your next move."
+                            "[MoveFailed] Something went wrong walking to {id}."
                         ));
                     }
-                    MoveResult::Blocked => {
-                        warn!("Path blocked to ({gx:.1}, {gz:.1})");
-                        let mut s = state.lock().await;
-                        s.push_agent_event(format!(
-                            "[MoveFailed] No route to ({gx:.1}, {gz:.1}) — a wall or a shut \
-                             door stands in the way. Try a different goal."
-                        ));
-                    }
-                    MoveResult::Error => {
-                        error!("Move error to ({gx:.1}, {gz:.1})");
+                },
+                Some(MoveTarget::GroundItem { instance_id, name }) => {
+                    match walk_to_ground_item(state, instance_id).await {
+                        ChaseResult::InRange => {
+                            info!("Agent walked to ground item {name} [{instance_id}]");
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[Arrived] You stand over ground item {instance_id} ({name}). \
+                                 Take it with {{\"type\": \"pickup\", \"target\": \
+                                 {instance_id}}}."
+                            ));
+                        }
+                        ChaseResult::Lost(loss) => {
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[MoveFailed] You did not reach {name} [id {instance_id}] — {}.",
+                                loss.clause()
+                            ));
+                        }
+                        ChaseResult::Error => {
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[MoveFailed] Something went wrong walking to {name}."
+                            ));
+                        }
                     }
                 }
-            } else {
-                // Partial coordinates (x without z, direction without
-                // distance) used to vanish silently — tell the LLM instead.
-                warn!("move: no usable goal (x={x:?} z={z:?} dir={direction:?} dist={distance:?})");
-                let mut s = state.lock().await;
-                s.push_agent_event(
-                    "[MoveFailed] That move had no usable goal — give both x and z, \
-                     or a direction with a distance."
-                        .to_string(),
-                );
+                Some(MoveTarget::Prop { prop_id }) => {
+                    walk_to_sighting(
+                        state,
+                        prop_approach(state, prop_id).await,
+                        &format!("prop {prop_id}"),
+                    )
+                    .await;
+                }
+                Some(MoveTarget::Chest { selector }) => {
+                    match chest_approach(state, &selector).await {
+                        Some((approach, label)) => {
+                            walk_to_sighting(state, Some(approach), label).await;
+                        }
+                        None => walk_to_sighting(state, None, "the selected chest").await,
+                    }
+                }
+                Some(MoveTarget::Dungeon { .. }) => unreachable!("handled above"),
+                None => {
+                    // A bare coordinate carries no floor, so stay on the one
+                    // we're on rather than dropping to the ground floor.
+                    let (goal, floor) = {
+                        let s = state.lock().await;
+                        let pp = s.self_player.as_ref().map(|p| &p.position);
+                        (
+                            resolve_move_goal(x, z, direction, distance, pp),
+                            s.passability_floor(),
+                        )
+                    };
+                    match goal {
+                        Ok((gx, gz)) => match execute_move(state, gx, gz, floor).await {
+                            MoveResult::Arrived => {
+                                info!("Agent arrived at ({gx:.1}, {gz:.1})");
+                                let mut s = state.lock().await;
+                                s.push_agent_event(format!(
+                                    "[Arrived] You reached ({gx:.1}, {gz:.1}). Look around and \
+                                     decide your next move."
+                                ));
+                            }
+                            MoveResult::Blocked => {
+                                warn!("Path blocked to ({gx:.1}, {gz:.1})");
+                                let mut s = state.lock().await;
+                                s.push_agent_event(format!(
+                                    "[MoveFailed] No route to ({gx:.1}, {gz:.1}) — a wall or a \
+                                     shut door stands in the way. Try a different goal."
+                                ));
+                            }
+                            MoveResult::Error => {
+                                error!("Move error to ({gx:.1}, {gz:.1})");
+                                let mut s = state.lock().await;
+                                s.push_agent_event(format!(
+                                    "[MoveFailed] Something went wrong on the way to \
+                                     ({gx:.1}, {gz:.1})."
+                                ));
+                            }
+                        },
+                        Err(GoalError::BadDirection(dir)) => {
+                            warn!("move: '{dir}' is not a direction");
+                            let mut s = state.lock().await;
+                            s.push_agent_event(format!(
+                                "[MoveFailed] '{dir}' is not a direction, so you stayed put. \
+                                 Use north, south, east, west, northeast, northwest, \
+                                 southeast or southwest."
+                            ));
+                        }
+                        Err(GoalError::NoGoal) => {
+                            warn!("move: no usable goal (x={x:?} z={z:?} dir={direction:?} dist={distance:?})");
+                            let mut s = state.lock().await;
+                            s.push_agent_event(
+                                "[MoveFailed] That move had no usable goal — give a target, \
+                                 both x and z, or a direction with a distance."
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
             }
             continue;
         }
@@ -1013,6 +1262,19 @@ pub(super) async fn handle_response(
                 }
             }
         }
+    }
+
+    if let Some((prev, mark)) = pending.take() {
+        settle_action(state, prev, mark).await;
+    }
+
+    if let Some(failed) = lost_position.filter(|_| !skipped.is_empty()) {
+        let mut s = state.lock().await;
+        s.push_agent_event(format!(
+            "[Aborted] Your {failed} failed, so the rest of the turn that needed you to be \
+             somewhere did not run: {}. Reissue what still applies.",
+            skipped.join(", ")
+        ));
     }
 
     last_attack_target
@@ -1119,31 +1381,40 @@ async fn reach_merchant(
 /// before it reaches the stairs.
 async fn move_to_dungeon_floor(
     state: &Arc<Mutex<SharedState>>,
-    depth: i32,
+    depth: Option<i32>,
     goal_xz: Option<(f32, f32)>,
+    named: Option<&str>,
 ) {
-    let depth = depth.unsigned_abs().min(u8::MAX as u32) as u8;
+    // No depth means "walk to that entrance and stop there", which only a
+    // named dungeon can ask for.
+    let depth = depth.map(|d| d.unsigned_abs().min(u8::MAX as u32) as u8);
 
-    let (dungeon, outside) = {
+    let (dungeon, outside, floor_level) = {
         let mut s = state.lock().await;
         let Some(position) = s.self_player.as_ref().map(|p| p.position) else {
             return;
         };
-        if depth == 0 && s.self_floor_level >= 0 {
-            debug!("move depth 0: already above ground");
+        if depth == Some(0) && s.self_floor_level >= 0 {
+            s.push_agent_event(
+                "[Arrived] You are already above ground — there is no dungeon to leave."
+                    .to_string(),
+            );
             return;
         }
         let dungeon = {
             let world = s.world_cache.read().unwrap();
-            world
-                .dungeon_at(position.x, position.z)
-                .or_else(|| world.nearest_dungeon(position.x, position.z))
+            match named {
+                Some(id) => world.dungeon_by_id(id),
+                None => world
+                    .dungeon_at(position.x, position.z)
+                    .or_else(|| world.nearest_dungeon(position.x, position.z)),
+            }
         };
         let Some(dungeon) = dungeon else {
             s.push_agent_event("[MoveFailed] There is no dungeon here to go into.".to_string());
             return;
         };
-        if depth > dungeon.max_depth() {
+        if depth.is_some_and(|d| d > dungeon.max_depth()) {
             s.push_agent_event(format!(
                 "[MoveFailed] {} only goes down to floor {}.",
                 dungeon.name,
@@ -1153,11 +1424,34 @@ async fn move_to_dungeon_floor(
         }
         s.request_dungeon_doors_here();
         let outside = !dungeon.footprint_contains(position.x, position.z);
-        (dungeon, outside)
+        (dungeon, outside, s.self_floor_level)
     };
 
+    // A bare "go to X" from underground asks to be at X, and we already are;
+    // walking the surface grid from three floors down would report the
+    // opposite of what happened.
+    if depth.is_none() && floor_level < 0 {
+        let mut s = state.lock().await;
+        s.push_agent_event(if outside {
+            format!(
+                "[MoveFailed] You are on floor {} of another dungeon. Come back up with \
+                 {{\"type\": \"move\", \"depth\": 0}} before heading for {}.",
+                floor_level.abs(),
+                dungeon.name
+            )
+        } else {
+            format!(
+                "[Arrived] You are already inside {}, on floor {}. Name a \"depth\" to change \
+                 floor, or 0 to leave.",
+                dungeon.name,
+                floor_level.abs()
+            )
+        });
+        return;
+    }
+
     // Leg 1: get onto the dungeon's own grid on the surface.
-    if outside || depth == 0 {
+    if outside || depth.is_none_or(|d| d == 0) {
         let entrance = dungeon.entrance;
         if matches!(
             execute_move(state, entrance.x, entrance.z, 0).await,
@@ -1172,11 +1466,29 @@ async fn move_to_dungeon_floor(
             return;
         }
         state.lock().await.request_dungeon_doors_here();
-        if depth == 0 {
-            info!("Agent left {}", dungeon.name);
-            return;
+        match depth {
+            Some(0) => {
+                info!("Agent left {}", dungeon.name);
+                let mut s = state.lock().await;
+                s.push_agent_event(format!("[Arrived] You are back outside {}.", dungeon.name));
+                return;
+            }
+            None => {
+                info!("Agent reached the {} entrance", dungeon.name);
+                let mut s = state.lock().await;
+                s.push_agent_event(format!(
+                    "[Arrived] You stand at the entrance of {} ({} floors deep). Go in with \
+                     {{\"type\": \"move\", \"target\": \"{}\", \"depth\": 1}}.",
+                    dungeon.name,
+                    dungeon.max_depth(),
+                    dungeon.name
+                ));
+                return;
+            }
+            Some(_) => {}
         }
     }
+    let depth = depth.unwrap_or(1);
 
     // Leg 2: descend. The shared A* walks the stair shafts on its own; the
     // mover opens whatever doors stand in the way.
@@ -1203,7 +1515,14 @@ async fn move_to_dungeon_floor(
                 dungeon.name
             ));
         }
-        MoveResult::Error => error!("Descent to {} floor {depth} errored", dungeon.name),
+        MoveResult::Error => {
+            error!("Descent to {} floor {depth} errored", dungeon.name);
+            let mut s = state.lock().await;
+            s.push_agent_event(format!(
+                "[MoveFailed] Something went wrong on the way to floor {depth} of {}.",
+                dungeon.name
+            ));
+        }
     }
 }
 
@@ -1439,5 +1758,117 @@ mod tests {
         ] {
             assert!(resolve_ground_item(&s, &r).is_none(), "for {r}");
         }
+    }
+
+    #[test]
+    fn failure_is_read_off_the_event_tag() {
+        for failure in [
+            "[MoveFailed] No route to (1.0, 2.0).",
+            "[ChestFailed] You see no chest.",
+            "[PropFailed] Prop 3 is already smashed.",
+            "[ActionFailed] 'dance' is not an action type.",
+            "[NoResult] Your use did nothing.",
+            "[Unreachable] Monster m2_1 is gone.",
+        ] {
+            assert!(reports_failure(failure), "{failure}");
+        }
+        for fine in [
+            "[Arrived] You reached (1.0, 2.0).",
+            "[Chat] Karl: hello",
+            "[Following] You are now following Karl.",
+            "no tag at all",
+        ] {
+            assert!(!reports_failure(fine), "{fine}");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_action_that_left_no_trace_gets_a_no_result() {
+        let (s, _rx) = test_state();
+        let state = Arc::new(Mutex::new(s));
+        let mark = state.lock().await.action_progress();
+
+        let outcome = settle_action(
+            &state,
+            &AgentAction::Use {
+                item: "torch".to_string(),
+            },
+            mark,
+        )
+        .await;
+
+        assert_eq!(outcome, ActionOutcome::Failed);
+        let events = state.lock().await.drain_agent_events();
+        assert!(
+            events.iter().any(|e| e.starts_with("[NoResult]")),
+            "{events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn self_reporting_actions_are_left_alone() {
+        let (s, _rx) = test_state();
+        let state = Arc::new(Mutex::new(s));
+        let mark = state.lock().await.action_progress();
+
+        for action in [
+            AgentAction::Say {
+                message: "hello".to_string(),
+            },
+            AgentAction::Wait,
+        ] {
+            assert_eq!(
+                settle_action(&state, &action, mark).await,
+                ActionOutcome::Ran
+            );
+        }
+        assert!(state.lock().await.drain_agent_events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_dispatched_command_counts_as_a_result() {
+        let (s, _rx) = test_state();
+        let state = Arc::new(Mutex::new(s));
+        let mark = state.lock().await.action_progress();
+        state
+            .lock()
+            .await
+            .send_command(onlinerpg_shared::ClientMessage::PartyLeave)
+            .await
+            .unwrap();
+
+        let outcome = settle_action(&state, &AgentAction::PartyLeave, mark).await;
+
+        assert_eq!(outcome, ActionOutcome::Ran);
+        assert!(state.lock().await.drain_agent_events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn background_traffic_is_not_an_actions_result() {
+        let (s, _rx) = test_state();
+        let state = Arc::new(Mutex::new(s));
+        let mark = state.lock().await.action_progress();
+        state
+            .lock()
+            .await
+            .send_background_command(onlinerpg_shared::ClientMessage::Heartbeat)
+            .await
+            .unwrap();
+
+        let outcome = settle_action(
+            &state,
+            &AgentAction::Use {
+                item: "torch".to_string(),
+            },
+            mark,
+        )
+        .await;
+
+        assert_eq!(outcome, ActionOutcome::Failed);
+        let events = state.lock().await.drain_agent_events();
+        assert!(
+            events.iter().any(|e| e.starts_with("[NoResult]")),
+            "{events:?}"
+        );
     }
 }

--- a/agent-client/src/driver/mod.rs
+++ b/agent-client/src/driver/mod.rs
@@ -19,6 +19,7 @@ mod action;
 mod combat;
 mod execute;
 mod movement;
+mod outcome;
 mod prompt;
 
 pub(crate) use prompt::format_event;

--- a/agent-client/src/driver/outcome.rs
+++ b/agent-client/src/driver/outcome.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::state::SharedState;
+
+use super::action::AgentAction;
+
+#[derive(Debug, PartialEq)]
+pub(super) enum ActionOutcome {
+    Ran,
+    Failed,
+}
+
+pub(super) async fn settle_action(
+    state: &Arc<Mutex<SharedState>>,
+    action: &AgentAction,
+    (events_before, commands_before): (usize, u64),
+) -> ActionOutcome {
+    let mut state = state.lock().await;
+    let failed = state
+        .agent_events_from(events_before)
+        .iter()
+        .any(|event| reports_failure(event));
+    if failed {
+        return ActionOutcome::Failed;
+    }
+
+    let (events_now, commands_now) = state.action_progress();
+    if action.outcome_speaks_for_itself()
+        || events_now > events_before
+        || commands_now > commands_before
+    {
+        return ActionOutcome::Ran;
+    }
+
+    warn!("Action {} produced no result at all", action.label());
+    state.push_agent_event(format!(
+        "[NoResult] Your {} did nothing and reached no one — it was not possible here. \
+         Try something else rather than repeating it.",
+        action.label()
+    ));
+    ActionOutcome::Failed
+}
+
+pub(super) fn reports_failure(event: &str) -> bool {
+    let Some(tag) = event
+        .strip_prefix('[')
+        .and_then(|event| event.split(']').next())
+    else {
+        return false;
+    };
+    tag.ends_with("Failed") || matches!(tag, "Unreachable" | "NoResult")
+}

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -487,7 +487,7 @@ async fn run_npc_session(
                 Ok(msg) => {
                     if matches!(msg, onlinerpg_shared::ServerMessage::GameTimeSync { .. }) {
                         let mut s = state_for_rx.lock().await;
-                        let _ = s.send_command(ClientMessage::Heartbeat).await;
+                        let _ = s.send_background_command(ClientMessage::Heartbeat).await;
                         s.push_event(msg);
                         continue;
                     }
@@ -571,7 +571,7 @@ async fn run_npc_session(
             };
 
             for cmd in commands.into_iter().chain(pending) {
-                if let Err(e) = s.send_command(cmd).await {
+                if let Err(e) = s.send_background_command(cmd).await {
                     tracing::warn!("Monster AI command failed: {e}");
                     break;
                 }

--- a/agent-client/src/state/commands.rs
+++ b/agent-client/src/state/commands.rs
@@ -2,6 +2,21 @@ use super::*;
 
 impl SharedState {
     pub async fn send_command(&mut self, msg: ClientMessage) -> anyhow::Result<()> {
+        self.dispatch_command(msg, true).await
+    }
+
+    /// Send something the agent did not ask for. The heartbeat and monster-AI
+    /// tick fire mid-action, and counting their traffic would rob a dropped
+    /// action of its `[NoResult]`.
+    pub async fn send_background_command(&mut self, msg: ClientMessage) -> anyhow::Result<()> {
+        self.dispatch_command(msg, false).await
+    }
+
+    async fn dispatch_command(
+        &mut self,
+        msg: ClientMessage,
+        from_action: bool,
+    ) -> anyhow::Result<()> {
         let msg = match msg {
             ClientMessage::PlayerMove {
                 position,
@@ -106,7 +121,18 @@ impl SharedState {
         self.cmd_tx
             .send(msg)
             .await
-            .map_err(|e| anyhow::anyhow!("Command channel closed: {e}"))
+            .map_err(|e| anyhow::anyhow!("Command channel closed: {e}"))?;
+        if from_action {
+            self.action_commands_sent += 1;
+        }
+        Ok(())
+    }
+
+    /// How much an action has done: events pushed and commands that reached
+    /// the wire. Neither moving means it left no trace — see the `[NoResult]`
+    /// backstop in `handle_response`.
+    pub fn action_progress(&self) -> (usize, u64) {
+        (self.agent_events.len(), self.action_commands_sent)
     }
 
     /// Drain pending commands (from monster AI reactions, spawn requests, etc.)

--- a/agent-client/src/state/dungeon.rs
+++ b/agent-client/src/state/dungeon.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+/// Fold a place name for comparison: case and inner spacing carry no meaning
+/// ("orc warrens", "Orc Warrens" and "orc_warrens" are one place).
+fn normalize_place(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
 impl SharedState {
     /// Ask for the door state of the dungeon we stand in. Doors default shut
     /// locally, so without this we would path around one another player left
@@ -156,19 +165,50 @@ impl SharedState {
             }
             return Some(line);
         }
-        let dungeon = self
-            .world_cache
+        // Every entrance, nearest first, whatever the distance: a dungeon the
+        // agent never sees named is one it can never ask to move to.
+        let world = self.world_cache.read().unwrap();
+        let mut named: Vec<(f32, String)> = world
+            .all_dungeons()
+            .iter()
+            .map(|d| {
+                let dist = crate::geom::PlanarDelta::between(&p.position, &d.entrance).dist;
+                (
+                    dist,
+                    format!(
+                        "Dungeon: {} entrance at ({:.0}, {:.0}), {dist:.0}m away, {} floors deep",
+                        d.name,
+                        d.entrance.x,
+                        d.entrance.z,
+                        d.max_depth()
+                    ),
+                )
+            })
+            .collect();
+        if named.is_empty() {
+            return None;
+        }
+        named.sort_by(|a, b| a.0.total_cmp(&b.0));
+        Some(
+            named
+                .into_iter()
+                .map(|(_, line)| line)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    /// Registered dungeon matching a name (or its registry id), however the
+    /// LLM cased and spaced it.
+    pub fn dungeon_named(&self, asked: &str) -> Option<Arc<Dungeon>> {
+        let key = normalize_place(asked);
+        self.world_cache
             .read()
             .unwrap()
-            .nearest_dungeon(p.position.x, p.position.z)?;
-        let dist = crate::geom::PlanarDelta::between(&p.position, &dungeon.entrance).dist;
-        Some(format!(
-            "Dungeon: {} entrance at ({:.0}, {:.0}), {dist:.0}m away, {} floors deep",
-            dungeon.name,
-            dungeon.entrance.x,
-            dungeon.entrance.z,
-            dungeon.max_depth()
-        ))
+            .all_dungeons()
+            .iter()
+            .find(|d| normalize_place(&d.name) == key || normalize_place(&d.id) == key)
+            .map(Arc::clone)
     }
 
     /// Whether a dungeon prop has already been smashed.

--- a/agent-client/src/state/events.rs
+++ b/agent-client/src/state/events.rs
@@ -895,6 +895,11 @@ impl SharedState {
         std::mem::take(&mut self.agent_events)
     }
 
+    /// Agent events pushed since a mark taken from [`Self::action_progress`].
+    pub fn agent_events_from(&self, from: usize) -> &[String] {
+        self.agent_events.get(from..).unwrap_or(&[])
+    }
+
     /// Push a synthetic agent event visible to the LLM. Synthetic events are
     /// feedback on the agent's own actions (arrival, a failed move, a kill),
     /// so they wake the LLM driver instead of waiting out the idle interval.

--- a/agent-client/src/state/mod.rs
+++ b/agent-client/src/state/mod.rs
@@ -148,6 +148,7 @@ mod world_state;
 
 pub use events::EventUrgency;
 pub use inventory::{Carried, CarriedBagCopies};
+pub use movement::{MoveTarget, MoveTargetError};
 pub use social::{PendingPartyInvite, PendingPartySummon};
 pub use world_cache::WorldCache;
 
@@ -268,6 +269,10 @@ pub struct SharedState {
     sighted_pois: HashSet<String>,
     /// Synthetic agent-side events (e.g. "player appeared nearby")
     agent_events: Vec<String>,
+    /// Commands an agent action put on the wire, ever. Read only as a
+    /// difference, so background traffic must stay out of it — see
+    /// [`Self::send_background_command`].
+    action_commands_sent: u64,
     /// Terrain height sampler (shared across NPC connections)
     pub height_sampler: Arc<HeightSampler>,
     pub splat_sampler: Arc<crate::splat::SplatSampler>,
@@ -366,6 +371,7 @@ impl SharedState {
             bad_song_title_refused: false,
             sighted_pois: HashSet::new(),
             agent_events: Vec::new(),
+            action_commands_sent: 0,
             height_sampler,
             splat_sampler,
             world_cache,

--- a/agent-client/src/state/movement.rs
+++ b/agent-client/src/state/movement.rs
@@ -1,6 +1,187 @@
 use super::*;
 
+/// A resolved `move` target.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MoveTarget {
+    Character { id: PlayerId, name: String },
+    Monster { id: String },
+    GroundItem { instance_id: u64, name: String },
+    Prop { prop_id: u32 },
+    Chest { selector: String },
+    Dungeon { id: String, name: String },
+}
+
+/// Why a `move` target did not resolve.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MoveTargetError {
+    /// A monster species where an id belongs, with the ids that match and
+    /// how far away each one is.
+    SpeciesNotId {
+        species: String,
+        candidates: Vec<(String, f32)>,
+    },
+    /// A well-formed monster id that is no longer in sight.
+    MonsterGone { id: String },
+    Unknown {
+        asked: String,
+        addressable: Vec<String>,
+    },
+}
+
+/// Whether a string has the shape of a monster id (`m2_1`), which is how the
+/// ladder tells "the goblin called m2_1" from "a goblin".
+fn looks_like_monster_id(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix(['m', 'M']) else {
+        return false;
+    };
+    let Some((floor, index)) = rest.split_once('_') else {
+        return false;
+    };
+    !floor.is_empty()
+        && !index.is_empty()
+        && floor.bytes().all(|b| b.is_ascii_digit())
+        && index.bytes().all(|b| b.is_ascii_digit())
+}
+
 impl SharedState {
+    /// Resolve a visible `move` target by id shape, then by exact name.
+    pub fn resolve_move_target(&self, raw: &str) -> Result<MoveTarget, MoveTargetError> {
+        let asked = raw.trim();
+
+        if looks_like_monster_id(asked) {
+            return match self
+                .monsters_on_my_floor()
+                .find(|m| m.id.eq_ignore_ascii_case(asked))
+            {
+                Some(m) => Ok(MoveTarget::Monster { id: m.id.clone() }),
+                None => Err(MoveTargetError::MonsterGone {
+                    id: asked.to_string(),
+                }),
+            };
+        }
+
+        if let Ok(n) = asked.parse::<u64>() {
+            if let Some((_, item)) = self
+                .ground_items_in_sight()
+                .iter()
+                .find(|(_, i)| i.instance_id == n)
+            {
+                return Ok(MoveTarget::GroundItem {
+                    instance_id: item.instance_id,
+                    name: item.item_def_id.clone(),
+                });
+            }
+            if let Some(b) = self
+                .breakables_in_sight()
+                .iter()
+                .find(|b| u64::from(b.prop_id) == n)
+            {
+                return Ok(MoveTarget::Prop { prop_id: b.prop_id });
+            }
+            if let Some((id, p)) = self.players_on_my_floor().find(|(id, _)| id.get() == n) {
+                return Ok(MoveTarget::Character {
+                    id: *id,
+                    name: p.name.clone(),
+                });
+            }
+            return Err(self.unknown_target(asked));
+        }
+
+        if let Some((id, p)) = self
+            .players_on_my_floor()
+            .find(|(_, p)| p.name.eq_ignore_ascii_case(asked))
+        {
+            return Ok(MoveTarget::Character {
+                id: *id,
+                name: p.name.clone(),
+            });
+        }
+
+        if let Some(d) = self.dungeon_named(asked) {
+            return Ok(MoveTarget::Dungeon {
+                id: d.id.clone(),
+                name: d.name.clone(),
+            });
+        }
+
+        if asked.to_lowercase().contains("chest") && !self.chests_in_sight().is_empty() {
+            return Ok(MoveTarget::Chest {
+                selector: asked.to_string(),
+            });
+        }
+
+        if let Some((_, item)) = self
+            .ground_items_in_sight()
+            .iter()
+            .find(|(_, i)| i.item_def_id.eq_ignore_ascii_case(asked))
+        {
+            return Ok(MoveTarget::GroundItem {
+                instance_id: item.instance_id,
+                name: item.item_def_id.clone(),
+            });
+        }
+
+        // A species name, not an id. Monsters are only ever addressed by id,
+        // so hand back the ids that match instead of guessing which one.
+        let candidates = self.monster_ids_of_species(asked);
+        if !candidates.is_empty() {
+            return Err(MoveTargetError::SpeciesNotId {
+                species: asked.to_string(),
+                candidates,
+            });
+        }
+
+        Err(self.unknown_target(asked))
+    }
+
+    /// Ids and distances of the monsters in sight of a given type, nearest
+    /// first — what a species-instead-of-id mistake gets told to use.
+    fn monster_ids_of_species(&self, species: &str) -> Vec<(String, f32)> {
+        let Some(sp) = self.self_player.as_ref() else {
+            return Vec::new();
+        };
+        let sight_sq = NPC_SIGHT_RADIUS * NPC_SIGHT_RADIUS;
+        let mut found: Vec<(String, f32)> = self
+            .monsters_on_my_floor()
+            .filter(|m| m.monster_type.eq_ignore_ascii_case(species))
+            .filter_map(|m| {
+                let d_sq = m.position.dist_xz_sq(&sp.position);
+                (d_sq <= sight_sq).then(|| (m.id.clone(), d_sq.sqrt()))
+            })
+            .collect();
+        found.sort_by(|a, b| a.1.total_cmp(&b.1));
+        found
+    }
+
+    /// A target that matched nothing, carrying a sample of what would have.
+    fn unknown_target(&self, asked: &str) -> MoveTargetError {
+        let mut addressable: Vec<String> = self
+            .players_on_my_floor()
+            .filter(|(_, p)| self.self_player_id.as_ref() != Some(&p.id))
+            .map(|(_, p)| p.name.clone())
+            .take(4)
+            .collect();
+        addressable.extend(self.monsters_on_my_floor().map(|m| m.id.clone()).take(4));
+        addressable.extend(
+            self.ground_items_in_sight()
+                .iter()
+                .take(3)
+                .map(|(_, i)| format!("{} [id {}]", i.item_def_id, i.instance_id)),
+        );
+        addressable.extend(
+            self.world_cache
+                .read()
+                .unwrap()
+                .all_dungeons()
+                .iter()
+                .map(|d| d.name.clone()),
+        );
+        MoveTargetError::Unknown {
+            asked: asked.to_string(),
+            addressable,
+        }
+    }
+
     /// Abort a running follow loop, if any. Returns the name that was being
     /// followed. A loop that already ended left its own note, so it does not
     /// count as cancelled.

--- a/agent-client/src/state/tests/mod.rs
+++ b/agent-client/src/state/tests/mod.rs
@@ -1,6 +1,7 @@
 mod dungeon_tests;
 mod events_tests;
 mod inventory_tests;
+mod movement_tests;
 mod music_tests;
 mod social_tests;
 mod world_tests;

--- a/agent-client/src/state/tests/movement_tests.rs
+++ b/agent-client/src/state/tests/movement_tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+/// A state with one of everything a `move` target can name, so the ladder
+/// is exercised against a populated world rather than an empty one.
+fn targetable_state() -> (SharedState, mpsc::Receiver<ClientMessage>) {
+    let (mut s, rx) = test_state();
+    let me = test_player(0.0, 0.0);
+    s.self_player_id = Some(me.id);
+    s.self_player = Some(me);
+
+    let mut karl = test_player(3.0, 0.0);
+    karl.id = PlayerId::from(2);
+    karl.name = "Karl".to_string();
+    s.nearby_players.insert(karl.id, karl);
+
+    let mut near = monster("m2_1");
+    near.monster_type = "goblin".to_string();
+    near.position = p(5.0, 0.0, 0.0);
+    let mut far = monster("m2_7");
+    far.monster_type = "goblin".to_string();
+    far.position = p(12.0, 0.0, 0.0);
+    let mut other = monster("m2_9");
+    other.monster_type = "slime".to_string();
+    other.position = p(4.0, 0.0, 0.0);
+    for m in [near, far, other] {
+        s.nearby_monsters.insert(m.id.clone(), m);
+    }
+
+    s.remember_ground_item(ground_item(6043, "torch", 2.0, 0.0, 0));
+    (s, rx)
+}
+
+/// The shape of the string picks the namespace before any name lookup
+/// runs, so an id and a name never compete.
+#[test]
+fn a_move_target_resolves_by_shape_then_by_name() {
+    let (s, _rx) = targetable_state();
+
+    assert_eq!(
+        s.resolve_move_target("m2_1"),
+        Ok(MoveTarget::Monster {
+            id: "m2_1".to_string()
+        })
+    );
+    assert_eq!(
+        s.resolve_move_target("6043"),
+        Ok(MoveTarget::GroundItem {
+            instance_id: 6043,
+            name: "torch".to_string()
+        })
+    );
+    assert_eq!(
+        s.resolve_move_target("karl"),
+        Ok(MoveTarget::Character {
+            id: PlayerId::from(2),
+            name: "Karl".to_string()
+        })
+    );
+    assert_eq!(
+        s.resolve_move_target("torch"),
+        Ok(MoveTarget::GroundItem {
+            instance_id: 6043,
+            name: "torch".to_string()
+        })
+    );
+}
+
+/// A species is not an id, and saying so with the matching ids is what
+/// lets the LLM fix the target on its next turn.
+#[test]
+fn a_monster_species_is_refused_with_the_ids_that_would_work() {
+    let (s, _rx) = targetable_state();
+
+    let Err(MoveTargetError::SpeciesNotId {
+        species,
+        candidates,
+    }) = s.resolve_move_target("goblin")
+    else {
+        panic!("expected a species rejection");
+    };
+    assert_eq!(species, "goblin");
+    // Nearest first, and only the goblins.
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect::<Vec<_>>(),
+        ["m2_1", "m2_7"]
+    );
+}
+
+/// An id that no longer names anything in sight is a dead target, not an
+/// unknown word — the LLM copied it from a stale world state.
+#[test]
+fn a_vanished_monster_id_says_it_is_gone() {
+    let (s, _rx) = targetable_state();
+    assert_eq!(
+        s.resolve_move_target("m2_4"),
+        Err(MoveTargetError::MonsterGone {
+            id: "m2_4".to_string()
+        })
+    );
+}
+
+/// Nothing matched, so the reply carries what would have.
+#[test]
+fn an_unknown_target_lists_what_is_addressable() {
+    let (s, _rx) = targetable_state();
+    let Err(MoveTargetError::Unknown { addressable, .. }) = s.resolve_move_target("the tavern")
+    else {
+        panic!("expected an unknown target");
+    };
+    assert!(addressable.contains(&"Karl".to_string()), "{addressable:?}");
+    assert!(addressable.contains(&"m2_1".to_string()), "{addressable:?}");
+}
+
+/// Dungeon names come from the registry and survive whatever casing and
+/// spacing the LLM read them back with.
+#[test]
+fn a_dungeon_name_resolves_however_it_is_written() {
+    let (s, _rx) = test_state();
+    s.world_cache.write().unwrap().register_dungeons();
+
+    for asked in ["Old Crypt", "old crypt", "old_crypt", "OldCrypt"] {
+        assert_eq!(
+            s.resolve_move_target(asked),
+            Ok(MoveTarget::Dungeon {
+                id: "old_crypt".to_string(),
+                name: "Old Crypt".to_string()
+            }),
+            "{asked}"
+        );
+    }
+}

--- a/agent-client/src/state/tests/world_tests.rs
+++ b/agent-client/src/state/tests/world_tests.rs
@@ -280,3 +280,25 @@ fn terrain_grid_is_absent_underground() {
     s.self_floor_level = -1;
     assert!(s.terrain_grid_job().is_none());
 }
+
+/// Entrances are listed above ground whatever the distance: a name the
+/// agent never sees is a name it can never move to.
+#[test]
+fn world_state_names_the_dungeon_entrances() {
+    let (mut s, _rx) = test_state();
+    s.self_player = Some(test_player(-1450.0, 4720.0));
+    s.world_cache.write().unwrap().register_dungeons();
+
+    let lines: Vec<String> = s
+        .format_world_state()
+        .lines()
+        .filter(|l| l.starts_with("Dungeon:"))
+        .map(str::to_string)
+        .collect();
+
+    // Nearest first, and the far one is listed too — the world state is
+    // the only place its name can be learned.
+    assert_eq!(lines.len(), 2, "{lines:?}");
+    assert!(lines[0].contains("Old Crypt"), "{lines:?}");
+    assert!(lines[1].contains("Orc Warrens"), "{lines:?}");
+}

--- a/agent-client/src/state/world_cache.rs
+++ b/agent-client/src/state/world_cache.rs
@@ -65,7 +65,8 @@ impl WorldCache {
         self.dungeons.iter().find(|d| d.id == id).map(Arc::clone)
     }
 
-    /// Every registered dungeon — the watch panel draws their entrances.
+    /// Every registered dungeon: the watch panel draws their entrances, and
+    /// name resolution and the world-state listing read it.
     pub fn all_dungeons(&self) -> &[Arc<Dungeon>] {
         &self.dungeons
     }


### PR DESCRIPTION
Visualization demo: https://www.tonypa.in/viz/agent-target-addressing

1. target — All actions use the same field name, target, instead of 12 different ones. One rule: put the thing you're acting on there, exactly as printed.
2. resolve_move_target() — move understands six kinds of targets (monsters, items, players, dungeons…). If it can't match, it tells you what you can use instead.
3. [NoResult] — Every action gets a reply. If nothing happened, the game says so out loud, so the agent never repeats a dead action forever.
4. [Aborted] — If your move fails, the rest of that turn is cancelled — except talking. You don't swing a sword where you never arrived.
5. BadDirection — Don't guess, just stop. Unknown directions used to silently move you north; now they stop and explain. Keeps wrong guesses off the record.
6. move_to_dungeon_floor() — Dungeons are now named and listed, so you can target any one — not just the nearest. Four ways to say where you want to go.