### PR TITLE
Add /tp admin command: teleport to coordinates or named destinations

### DIFF
--- a/client/src/lib/chat-commands.ts
+++ b/client/src/lib/chat-commands.ts
@@ -12,11 +12,30 @@ import {
   riverWireframeVisible,
   shoreWaveDebugVisible,
   passabilityDebugVisible,
+  teleportLoading,
 } from './stores/debugStore'
+import { wrapWorldX } from './terrain/world-wrap'
 import { computeGrassPlacement, regenerateVegMeta } from './utils/grass-data'
+import { parseTpArgs, resolveTpDestination } from './utils/tp-args'
+import { tpDestinations } from './utils/tp-destinations'
+
 import { dungeonManager } from './managers/dungeonManager'
 import { chatChannel } from './stores/chatChannelStore'
 import { partyRoster } from './stores/partyStore'
+
+function teleportTo(x: number, y: number, z: number) {
+  const wrappedX = wrapWorldX(x)
+  gameStore.update((state) => {
+    state.currentPlayer?.position.set(wrappedX, y, z)
+    return state
+  })
+  networkManager.sendDebugTeleport({ x: wrappedX, y, z })
+  teleportLoading.set(true)
+  addChatMessage({
+    text: `Teleport: moving to (${wrappedX.toFixed(1)}, ${y.toFixed(1)}, ${z.toFixed(1)})`,
+    sender: 'system',
+  })
+}
 
 /** Every command lives here once: its `/help` line, whether it is admin-only,
  *  and who executes it. */
@@ -122,6 +141,51 @@ const COMMANDS: Record<string, Command> = {
       } else {
         addChatMessage({ text: 'Position: unknown', sender: 'system' })
       }
+    },
+  },
+
+  '/tp': {
+    desc: 'Teleport: /tp <x> <z> [y] or /tp <name|number>; bare /tp lists destinations',
+    admin: true,
+    run: (args) => {
+      const trimmed = args.trim()
+      if (!trimmed) {
+        addChatMessage({
+          text: 'Teleport destinations — /tp <name|number>, or /tp <x> <z> [y]:',
+          sender: 'system',
+        })
+        for (const [i, d] of tpDestinations().entries()) {
+          addChatMessage({
+            text: `${i + 1}. ${d.name} — ${d.label}`,
+            sender: 'system',
+          })
+        }
+        return
+      }
+
+      const parts = trimmed.split(/\s+/)
+      if (parts.length === 1) {
+        const dest = resolveTpDestination(parts[0], tpDestinations())
+        if (!dest) {
+          addChatMessage({
+            text: `Teleport: unknown destination '${parts[0]}' — bare /tp lists them`,
+            sender: 'system',
+          })
+          return
+        }
+        teleportTo(dest.x, dest.y, dest.z)
+        return
+      }
+
+      const parsed = parseTpArgs(trimmed)
+      if (!parsed) {
+        addChatMessage({
+          text: 'Usage: /tp <x> <z> [y] — teleport to world coordinates (e.g. /tp -1450 4720)',
+          sender: 'system',
+        })
+        return
+      }
+      teleportTo(parsed.x, parsed.y, parsed.z)
     },
   },
 

--- a/client/src/lib/managers/dungeonManager.ts
+++ b/client/src/lib/managers/dungeonManager.ts
@@ -927,16 +927,16 @@ class DungeonManager {
       }
       return
     }
-    if (!this.active) {
-      const grid = constants().grid
-      const covering = DUNGEON_ENTRANCES.find((e) => {
-        const ox = Math.floor(e.x) - grid / 2
-        const oz = Math.floor(e.z) - grid / 2
-        return x >= ox && x < ox + grid && z >= oz && z < oz + grid
-      })
-      if (!covering) return
-      this.enter(covering.id, { x: covering.x, y: covering.y, z: covering.z })
-    }
+    const grid = constants().grid
+    const covering = DUNGEON_ENTRANCES.find((e) => {
+      const ox = Math.floor(e.x) - grid / 2
+      const oz = Math.floor(e.z) - grid / 2
+      return x >= ox && x < ox + grid && z >= oz && z < oz + grid
+    })
+    if (!covering) return
+    // A teleport can land in a different dungeon than the registered one;
+    // enter() no-ops for the same id and switches otherwise.
+    this.enter(covering.id, { x: covering.x, y: covering.y, z: covering.z })
     currentDungeonDepth.set(-floorLevel)
   }
 

--- a/client/src/lib/utils/tp-args.test.ts
+++ b/client/src/lib/utils/tp-args.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { parseTpArgs, resolveTpDestination } from './tp-args'
+
+describe('parseTpArgs', () => {
+  it('parses x z with y defaulting to 0', () => {
+    expect(parseTpArgs('-1450 4720')).toEqual({ x: -1450, z: 4720, y: 0 })
+  })
+
+  it('parses an explicit y', () => {
+    expect(parseTpArgs('-1443.5 4711.5 -19.3')).toEqual({
+      x: -1443.5,
+      z: 4711.5,
+      y: -19.3,
+    })
+  })
+
+  it('tolerates extra whitespace', () => {
+    expect(parseTpArgs('  10   20  ')).toEqual({ x: 10, z: 20, y: 0 })
+  })
+
+  it('rejects wrong argument counts', () => {
+    expect(parseTpArgs('')).toBeNull()
+    expect(parseTpArgs('5')).toBeNull()
+    expect(parseTpArgs('1 2 3 4')).toBeNull()
+  })
+
+  it('rejects non-numeric input', () => {
+    expect(parseTpArgs('abc 5')).toBeNull()
+    expect(parseTpArgs('5 5.5.5')).toBeNull()
+  })
+
+  // isNaN() admits Infinity; these poisoned the position with NaN after
+  // world-wrap and stalled the server's whole save batch.
+  it('rejects non-finite values', () => {
+    expect(parseTpArgs('Infinity 0')).toBeNull()
+    expect(parseTpArgs('0 -Infinity')).toBeNull()
+    expect(parseTpArgs('1e999 0')).toBeNull()
+    expect(parseTpArgs('0 0 NaN')).toBeNull()
+  })
+
+  it('rejects values that overflow f32 on the wire', () => {
+    expect(parseTpArgs('0 1e39')).toBeNull()
+    expect(parseTpArgs('1e39 0')).toBeNull()
+  })
+})
+
+describe('resolveTpDestination', () => {
+  const dests = [
+    { name: 'spawn', x: 0 },
+    { name: 'crypt-boss', x: 1 },
+    { name: 'Snowpeak', x: 2 },
+  ]
+
+  it('resolves by case-insensitive name', () => {
+    expect(resolveTpDestination('crypt-boss', dests)?.x).toBe(1)
+    expect(resolveTpDestination('SNOWPEAK', dests)?.x).toBe(2)
+  })
+
+  it('resolves by 1-based index', () => {
+    expect(resolveTpDestination('1', dests)?.name).toBe('spawn')
+    expect(resolveTpDestination('3', dests)?.name).toBe('Snowpeak')
+  })
+
+  it('returns null for unknown names and out-of-range indices', () => {
+    expect(resolveTpDestination('nowhere', dests)).toBeNull()
+    expect(resolveTpDestination('0', dests)).toBeNull()
+    expect(resolveTpDestination('4', dests)).toBeNull()
+  })
+})

--- a/client/src/lib/utils/tp-args.ts
+++ b/client/src/lib/utils/tp-args.ts
@@ -1,0 +1,26 @@
+/** Parse `/tp <x> <z> [y]` arguments; null when malformed. Values must stay
+ *  finite after f32 rounding — the wire format is f32, so e.g. 1e39 would
+ *  arrive server-side as Infinity. */
+export function parseTpArgs(
+  args: string
+): { x: number; z: number; y: number } | null {
+  const parts = args.trim().split(/\s+/).filter(Boolean)
+  if (parts.length < 2 || parts.length > 3) return null
+  const [x, z, y = 0] = parts.map(Number)
+  if (![x, z, y].every((v) => Number.isFinite(Math.fround(v)))) return null
+  return { x, z, y }
+}
+
+/** Resolve a single-token `/tp` argument against the destination list:
+ *  a 1-based list index, or a case-insensitive destination name. */
+export function resolveTpDestination<T extends { name: string }>(
+  token: string,
+  destinations: T[]
+): T | null {
+  const trimmed = token.trim()
+  if (/^\d+$/.test(trimmed)) {
+    return destinations[parseInt(trimmed, 10) - 1] ?? null
+  }
+  const lower = trimmed.toLowerCase()
+  return destinations.find((d) => d.name.toLowerCase() === lower) ?? null
+}

--- a/client/src/lib/utils/tp-destinations.ts
+++ b/client/src/lib/utils/tp-destinations.ts
@@ -1,0 +1,98 @@
+/**
+ * Named /tp destinations for admins. Static landmarks plus entries derived
+ * from data: dungeon entrances and final-floor boss rooms come from the
+ * registry + shared wasm layout generator, cities from the world-map labels —
+ * so the list tracks content changes without hand-kept coordinates.
+ */
+import { dungeon_constants, dungeon_layout } from '../wasm/onlinerpg_shared'
+import type {
+  DungeonConstants,
+  DungeonFloorLayout,
+} from '../managers/dungeonManager'
+import { DUNGEON_ENTRANCES } from '../data/dungeonDefs'
+import mapLabelsJson from '../../../../data/map_labels.json'
+
+export interface TpDestination {
+  name: string
+  label: string
+  x: number
+  y: number
+  z: number
+}
+
+interface MapLabel {
+  id: string
+  name: string
+  kind: string
+  x: number
+  z: number
+}
+
+/** Surface entries use y=0: the client snaps to terrain height on arrival. */
+const STATIC_DESTINATIONS: TpDestination[] = [
+  {
+    name: 'spawn',
+    label: 'Aldermark village (start)',
+    x: -1475.2,
+    y: 0,
+    z: 4741.6,
+  },
+  {
+    name: 'snowpeak',
+    label: 'Snow mountain summit (1438m)',
+    x: -1078,
+    y: 0,
+    z: 5067,
+  },
+]
+
+const CITY_KINDS = new Set(['capital', 'city', 'town'])
+
+let cached: TpDestination[] | null = null
+
+export function tpDestinations(): TpDestination[] {
+  if (cached) return cached
+
+  const out = [...STATIC_DESTINATIONS]
+  const consts = dungeon_constants() as DungeonConstants
+
+  for (const e of DUNGEON_ENTRANCES) {
+    const short = e.id.split('_').pop() ?? e.id
+    out.push({
+      name: short,
+      label: `${e.name} entrance`,
+      x: e.x,
+      y: 0,
+      z: e.z,
+    })
+
+    const layouts = dungeon_layout(e.id) as DungeonFloorLayout[]
+    const last = layouts[layouts.length - 1]
+    const boss = last?.spawns.find((s) => s.isBoss)
+    if (!last || !boss) continue
+    out.push({
+      name: `${short}-boss`,
+      label: `${e.name} floor ${last.depth} boss room`,
+      x: Math.floor(e.x) - consts.grid / 2 + boss.x + 0.5,
+      y: e.y - last.depth * consts.floorHeight,
+      z: Math.floor(e.z) - consts.grid / 2 + boss.z + 0.5,
+    })
+  }
+
+  for (const label of Object.values(
+    mapLabelsJson as unknown as Record<string, MapLabel>
+  )) {
+    // Aldermark duplicates the spawn entry.
+    if (!CITY_KINDS.has(label.kind) || label.id === 'aldermark') continue
+    out.push({
+      name: label.id,
+      label: `${label.name} (${label.kind})`,
+      x: label.x,
+      y: 0,
+      z: label.z,
+    })
+  }
+
+  cached = out
+  return out
+}

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -1498,6 +1498,11 @@ impl super::GameState {
         new_rotation: f32,
         new_floor_level: i8,
     ) {
+        // A NaN position would poison the SQLite save batch for everyone.
+        if !(new_position.is_finite() && new_rotation.is_finite()) {
+            warn!("Rejected non-finite teleport for player {player_id}");
+            return;
+        }
         new_position.x = wrap_world_x(new_position.x);
         self.apply_player_position(
             player_id,

--- a/server/src/game_state/tests/movement_tests.rs
+++ b/server/src/game_state/tests/movement_tests.rs
@@ -555,6 +555,30 @@ async fn teleport_clears_pending_move_intent() {
     assert_eq!(player_x(&game_state, &player_id).await, 5.0);
 }
 
+/// A NaN position would poison the SQLite save batch for every player.
+#[tokio::test]
+async fn teleport_rejects_non_finite_position() {
+    let game_state = make_test_game_state("movement_teleport_non_finite");
+    let player_id = pid("gm");
+    game_state.add_player(make_player("gm", 3.0, 4.0)).await;
+
+    for bad_x in [f32::INFINITY, f32::NEG_INFINITY, f32::NAN] {
+        game_state
+            .teleport_player(
+                &player_id,
+                Position {
+                    x: bad_x,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                0.0,
+                0,
+            )
+            .await;
+        assert_eq!(player_x(&game_state, &player_id).await, 3.0);
+    }
+}
+
 #[tokio::test]
 async fn rejected_far_move_snaps_client_back() {
     let game_state = make_test_game_state("movement_far_reject_snap");


### PR DESCRIPTION
## Motivation

Admins currently have no way to reach an exact location. The existing tools each cover a different case: `/goto` / `/summon` target a *player*, the world map's admin click-teleport is surface-only (y is fixed to 0) and only as precise as a mouse click on a zoomed-out map, and `/dungeon` enters a debug-only dungeon, not the real registry ones.

That gap shows up constantly in admin work: reproducing a bug report ("stand at these coordinates and do X"), inspecting spawned content (a specific dungeon floor, a boss room), or reaching landmarks that have no map label to click on. `/tp` fills it — exact coordinates in one chat line, the `y` argument reaches real dungeon floors (which no existing tool can), and the named-destination list makes the common trips (spawn, entrances, boss rooms) repeatable without memorizing numbers.

## Summary

New admin chat command `/tp`:

- `/tp <x> <z> [y]` teleports to world coordinates. The optional `y` selects the dungeon floor (the server infers `floor_level` from it), so an admin can jump straight into e.g. a boss room: `/tp -1443.5 4711.5 -19.3`.
- `/tp <name|number>` teleports to a named destination, and bare `/tp` lists them.
- The destination list is data-driven: dungeon entrances and final-floor boss rooms are computed at runtime from the entrance registry + shared layout generator (so they track content changes), cities come from `data/map_labels.json`. Only the spawn point and a scenic snow-peak summit are hand-curated entries.

Hardening found while reviewing the teleport path:

- Client-side validation rejects non-finite coordinates, including values that only overflow to Infinity after the f32 wire conversion (e.g. `1e39`). A NaN position previously reached the DB save batch and failed its NOT NULL constraint, stalling persistence for every player until the character unloaded.
- `teleport_player` now rejects non-finite positions server-side, mirroring the existing guard in `update_player_position` — the teleport path was the one relocation route without it, and it is reachable from a hand-crafted packet regardless of client validation.
- `dungeonManager.syncFromFloorLevel` re-registers to the dungeon covering the arrival position; previously a teleport from inside dungeon A into dungeon B kept rendering A's geometry at A's origin with no recovery path.

## Testing

- Unit tests for argument parsing (argument counts, NaN / Infinity / f32 overflow rejection) and destination resolution (name, 1-based index).
- Server regression test `teleport_rejects_non_finite_position`.
- Live-verified against a local server: coordinate teleport into the Old Crypt floor-5 boss room and back to the surface, named teleport (`/tp spawn`), destination listing, and the snow-peak entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
