### PR TITLE
Add party XP sharing with an equal split and a party bonus

### DIFF
--- a/server/src/game_state/combat.rs
+++ b/server/src/game_state/combat.rs
@@ -436,121 +436,25 @@ impl super::GameState {
                 // Dungeon monsters: free their spawn slot for respawn.
                 self.on_dungeon_monster_dead(&monster_id).await;
 
-                // Award XP to the player who killed the monster.
-                self.drain_hunger_for_kill(player_id).await;
-                // Depth-scaled dungeon monsters yield XP for their
+                // Award XP to everyone sharing the kill: the killer plus
+                // party members alive on the same floor within the share
+                // radius. Depth-scaled dungeon monsters yield XP for their
                 // effective level, not the base definition level.
-                let xp_def = self.monster_defs.get(&monster_type);
-                if let Some(def) = xp_def {
+                self.drain_hunger_for_kill(player_id).await;
+                if let Some(def) = self.monster_defs.get(&monster_type) {
                     let effective_level = monster_level_override.unwrap_or(def.level);
-                    let xp_amount = xp::monster_xp(effective_level, def.guard);
-                    let player_char = {
-                        let map = self.player_characters.read().await;
-                        map.get(player_id).cloned()
-                    };
-                    if let Some((_, old_xp, attributes)) = player_char {
-                        let new_xp = old_xp + xp_amount as u64;
-                        let old_level = xp::level_from_xp(old_xp);
-                        let new_level = xp::level_from_xp(new_xp);
-                        let leveled_up = new_level > old_level;
-                        let levels_gained = new_level.saturating_sub(old_level);
-
-                        // Update in-memory XP
-                        {
-                            let mut map = self.player_characters.write().await;
-                            if let Some(entry) = map.get_mut(player_id) {
-                                entry.1 = new_xp;
-                            }
-                        }
-
-                        // Update level/max HP in player map if leveled up
-                        let mut new_max_hp = None;
-                        let mut new_current_hp = None;
-                        if leveled_up {
-                            let mut players_write = self.players.write().await;
-                            if let Some(p) = players_write.get_mut(player_id) {
-                                p.level = new_level;
-                                let mut updated_max_hp = p.max_health;
-                                for _ in 0..levels_gained {
-                                    match character_hp::level_up_max_hp(
-                                        updated_max_hp,
-                                        &p.class,
-                                        attributes.con,
-                                    ) {
-                                        Ok(next_max_hp) => {
-                                            updated_max_hp = next_max_hp;
-                                        }
-                                        Err(err) => {
-                                            warn!(
-                                                "Failed to roll level-up HP for player {}: {}",
-                                                player_name, err
-                                            );
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                if updated_max_hp != p.max_health {
-                                    p.max_health = updated_max_hp;
-                                    new_max_hp = Some(updated_max_hp);
-                                }
-
-                                // Level-up always fully restores current HP to max HP.
-                                p.health = p.max_health;
-                                new_current_hp = Some(p.health);
-                            }
-                        }
-
-                        // Mark dirty for periodic batch save
-                        self.mark_dirty(player_id).await;
-                        if leveled_up {
-                            self.mark_party_vitals_dirty(player_id).await;
-                        }
-
-                        // Notify the player directly
-                        let max_hp_for_msg = if let Some(max_hp) = new_max_hp {
-                            max_hp
-                        } else {
-                            self.players
-                                .read()
-                                .await
-                                .get(player_id)
-                                .map(|p| p.max_health)
-                                .unwrap_or(0)
-                        };
-                        let current_hp_for_msg = if let Some(current_hp) = new_current_hp {
-                            current_hp
-                        } else {
-                            self.players
-                                .read()
-                                .await
-                                .get(player_id)
-                                .map(|p| p.health)
-                                .unwrap_or(0)
-                        };
-                        self.send_direct_message(
+                    let base_xp = xp::monster_xp(effective_level, def.guard);
+                    let sharers = self
+                        .party_members_sharing_kill(
                             player_id,
-                            ServerMessage::XpGained {
-                                player_id: *player_id,
-                                xp_amount,
-                                xp_lost: 0,
-                                total_xp: new_xp,
-                                new_level,
-                                leveled_up,
-                                max_hp: max_hp_for_msg,
-                                current_hp: current_hp_for_msg,
-                            },
+                            monster_position,
+                            monster_floor_level,
                         )
                         .await;
-
-                        debug!(
-                            "Player {} gained {} XP (total: {}, level: {}{})",
-                            player_name,
-                            xp_amount,
-                            new_xp,
-                            new_level,
-                            if leveled_up { " LEVEL UP!" } else { "" }
-                        );
+                    let share = xp::party_xp_share(base_xp, sharers.len() as u32 + 1);
+                    self.grant_monster_kill_xp(player_id, share).await;
+                    for member in &sharers {
+                        self.grant_monster_kill_xp(member, share).await;
                     }
                 }
 
@@ -575,6 +479,120 @@ impl super::GameState {
                 });
             }
         }
+    }
+
+    /// Credit one player's share of a monster kill: cumulative XP, any
+    /// level-ups (HP rolls plus the full heal), dirty marks, and the direct
+    /// XpGained notice. A zero share (tiny monster split) sends nothing.
+    async fn grant_monster_kill_xp(&self, player_id: &PlayerId, xp_amount: u32) {
+        if xp_amount == 0 {
+            return;
+        }
+        let player_name = self.player_name_of(player_id).await;
+        // Read-modify-write under one lock: a shared member can receive two
+        // kills' shares concurrently, and a split read/write would lose one.
+        let updated = {
+            let mut map = self.player_characters.write().await;
+            map.get_mut(player_id).map(|entry| {
+                let old_xp = entry.1;
+                entry.1 += u64::from(xp_amount);
+                (old_xp, entry.1, entry.2.clone())
+            })
+        };
+        let Some((old_xp, new_xp, attributes)) = updated else {
+            return;
+        };
+        let old_level = xp::level_from_xp(old_xp);
+        let new_level = xp::level_from_xp(new_xp);
+        let leveled_up = new_level > old_level;
+        let levels_gained = new_level.saturating_sub(old_level);
+
+        let mut new_max_hp = None;
+        let mut new_current_hp = None;
+        if leveled_up {
+            let mut players_write = self.players.write().await;
+            if let Some(p) = players_write.get_mut(player_id) {
+                // Concurrent grants may reach this lock out of XP order; the
+                // HP rolls cover disjoint level spans either way, but the
+                // level itself must never move backwards.
+                if new_level > p.level {
+                    p.level = new_level;
+                }
+                let mut updated_max_hp = p.max_health;
+                for _ in 0..levels_gained {
+                    match character_hp::level_up_max_hp(updated_max_hp, &p.class, attributes.con) {
+                        Ok(next_max_hp) => {
+                            updated_max_hp = next_max_hp;
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Failed to roll level-up HP for player {}: {}",
+                                player_name, err
+                            );
+                            break;
+                        }
+                    }
+                }
+
+                if updated_max_hp != p.max_health {
+                    p.max_health = updated_max_hp;
+                    new_max_hp = Some(updated_max_hp);
+                }
+
+                // Level-up always fully restores current HP to max HP.
+                p.health = p.max_health;
+                new_current_hp = Some(p.health);
+            }
+        }
+
+        self.mark_dirty(player_id).await;
+        if leveled_up {
+            self.mark_party_vitals_dirty(player_id).await;
+        }
+
+        let max_hp_for_msg = if let Some(max_hp) = new_max_hp {
+            max_hp
+        } else {
+            self.players
+                .read()
+                .await
+                .get(player_id)
+                .map(|p| p.max_health)
+                .unwrap_or(0)
+        };
+        let current_hp_for_msg = if let Some(current_hp) = new_current_hp {
+            current_hp
+        } else {
+            self.players
+                .read()
+                .await
+                .get(player_id)
+                .map(|p| p.health)
+                .unwrap_or(0)
+        };
+        self.send_direct_message(
+            player_id,
+            ServerMessage::XpGained {
+                player_id: *player_id,
+                xp_amount,
+                xp_lost: 0,
+                total_xp: new_xp,
+                new_level,
+                leveled_up,
+                max_hp: max_hp_for_msg,
+                current_hp: current_hp_for_msg,
+            },
+        )
+        .await;
+
+        debug!(
+            "Player {} gained {} XP (total: {}, level: {}{})",
+            player_name,
+            xp_amount,
+            new_xp,
+            new_level,
+            if leveled_up { " LEVEL UP!" } else { "" }
+        );
     }
 
     pub async fn broadcast_monster_attack(

--- a/server/src/game_state/party.rs
+++ b/server/src/game_state/party.rs
@@ -3,6 +3,7 @@ use crate::types::{Player, PlayerId, ServerMessage};
 use onlinerpg_shared::messages::{
     PartyMember, PartyMemberPosition, PartyMemberVitals, PARTY_INVITE_TTL, PARTY_SUMMON_TTL,
 };
+use onlinerpg_shared::xp;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -411,6 +412,37 @@ impl super::GameState {
         let players = self.players.read().await;
         ids.into_iter()
             .filter(|id| id != player_id && players.contains_key(id))
+            .collect()
+    }
+
+    /// Party members who share a kill at `position`/`floor_level`: online,
+    /// alive, same floor, within the XP share radius. Killer excluded; empty
+    /// when the killer is partyless.
+    pub(crate) async fn party_members_sharing_kill(
+        &self,
+        killer_id: &PlayerId,
+        position: onlinerpg_shared::Position,
+        floor_level: i8,
+    ) -> Vec<PlayerId> {
+        let ids = self.other_party_members(killer_id).await;
+        if ids.is_empty() {
+            return ids;
+        }
+        let radius_sq = xp::PARTY_XP_SHARE_RADIUS * xp::PARTY_XP_SHARE_RADIUS;
+        let players = self.players.read().await;
+        ids.into_iter()
+            .filter(|id| {
+                players.get(id).is_some_and(|p| {
+                    p.health > 0
+                        && super::combat::reachable_dist_sq(
+                            position,
+                            floor_level,
+                            p.position,
+                            p.floor_level,
+                        )
+                        .is_some_and(|dist_sq| dist_sq <= radius_sq)
+                })
+            })
             .collect()
     }
 

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -1754,3 +1754,203 @@ async fn vitals_tick_pushes_only_dirty_parties() {
     assert!(matches!(dave_rx.try_recv(), Err(MpscTryRecvError::Empty)));
     assert!(matches!(alice_rx.try_recv(), Err(MpscTryRecvError::Empty)));
 }
+
+// ---- Party XP sharing ----
+
+/// scp939 (level 3, guard 10) is worth monster_xp(3, 10) = 10 XP.
+const SHARED_KILL_XP: u32 = 10;
+
+fn make_xp_monster(id: &str, position: Position) -> crate::types::Monster {
+    crate::types::Monster {
+        monster_type: "scp939".to_string(),
+        health: 1,
+        max_health: 1,
+        ..make_monster(id, position, 0)
+    }
+}
+
+async fn register_character(game_state: &GameState, name: &str) {
+    game_state
+        .register_player_character(&pid(name), 1, 0, attrs_with_cha(10), 0, Some(1000))
+        .await;
+}
+
+/// Swing until the kill lands; hits are dice rolls, so retry with the
+/// server-side attack interval reset between swings.
+async fn kill_monster(game_state: &GameState, killer: &str, monster_id: &str) {
+    for _ in 0..200 {
+        game_state.last_player_attacks.write().await.insert(
+            pid(killer),
+            GameState::now_ms().saturating_sub(*super::combat::PLAYER_ATTACK_INTERVAL_MS),
+        );
+        game_state
+            .broadcast_player_attack(&pid(killer), monster_id.to_string())
+            .await;
+        let dead = game_state
+            .monsters
+            .read()
+            .await
+            .get(monster_id)
+            .is_some_and(|m| m.state == MonsterState::Dead);
+        if dead {
+            return;
+        }
+    }
+    panic!("monster {monster_id} survived 200 swings");
+}
+
+fn xp_gains(rx: &mut DirectRx) -> Vec<u32> {
+    let mut gains = Vec::new();
+    while let Ok(msg) = rx.try_recv() {
+        if let ServerMessage::XpGained { xp_amount, .. } = msg {
+            gains.push(xp_amount);
+        }
+    }
+    gains
+}
+
+#[tokio::test]
+async fn kill_xp_splits_with_nearby_member() {
+    let game_state = make_test_game_state("party_xp_split");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 2.0).await;
+    register_character(&game_state, "alice").await;
+    register_character(&game_state, "bob").await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    // 10 * 1.15 = 11 total, floored equal split: 5 each, killer included.
+    assert_eq!(xp_gains(&mut alice_rx), [5]);
+    assert_eq!(xp_gains(&mut bob_rx), [5]);
+}
+
+#[tokio::test]
+async fn kill_xp_three_way_split() {
+    let game_state = make_test_game_state("party_xp_three_way");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 2.0).await;
+    let mut carol_rx = add(&game_state, "carol", 100.0).await;
+    for name in ["alice", "bob", "carol"] {
+        register_character(&game_state, name).await;
+    }
+    form_party(&game_state, "alice", "bob").await;
+    game_state.invite_to_party(&pid("alice"), "carol").await;
+    game_state
+        .respond_to_party_invite(&pid("carol"), &pid("alice"), true)
+        .await;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+    drain(&mut carol_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    // 10 * 1.30 = 13 total, floored equal split: 4 each, killer included.
+    assert_eq!(xp_gains(&mut alice_rx), [4]);
+    assert_eq!(xp_gains(&mut bob_rx), [4]);
+    assert_eq!(xp_gains(&mut carol_rx), [4]);
+}
+
+#[tokio::test]
+async fn distant_member_shares_no_kill_xp() {
+    let game_state = make_test_game_state("party_xp_distant");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 500.0).await;
+    register_character(&game_state, "alice").await;
+    register_character(&game_state, "bob").await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    // Bob is beyond the 150m share radius: alice keeps the full solo XP.
+    assert_eq!(xp_gains(&mut alice_rx), [SHARED_KILL_XP]);
+    assert!(xp_gains(&mut bob_rx).is_empty());
+}
+
+#[tokio::test]
+async fn dead_member_shares_no_kill_xp() {
+    let game_state = make_test_game_state("party_xp_dead_member");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 2.0).await;
+    register_character(&game_state, "alice").await;
+    register_character(&game_state, "bob").await;
+    form_party(&game_state, "alice", "bob").await;
+    set_health(&game_state, "bob", 0).await;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    assert_eq!(xp_gains(&mut alice_rx), [SHARED_KILL_XP]);
+    assert!(xp_gains(&mut bob_rx).is_empty());
+}
+
+#[tokio::test]
+async fn other_floor_member_shares_no_kill_xp() {
+    let game_state = make_test_game_state("party_xp_other_floor");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    let mut bob_rx = add(&game_state, "bob", 2.0).await;
+    register_character(&game_state, "alice").await;
+    register_character(&game_state, "bob").await;
+    form_party(&game_state, "alice", "bob").await;
+    game_state
+        .players
+        .write()
+        .await
+        .get_mut(&pid("bob"))
+        .unwrap()
+        .floor_level = -1;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+    drain(&mut bob_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    assert_eq!(xp_gains(&mut alice_rx), [SHARED_KILL_XP]);
+    assert!(xp_gains(&mut bob_rx).is_empty());
+}
+
+#[tokio::test]
+async fn partyless_kill_xp_is_unchanged() {
+    let game_state = make_test_game_state("party_xp_solo");
+    let mut alice_rx = add(&game_state, "alice", 0.0).await;
+    register_character(&game_state, "alice").await;
+    game_state
+        .monsters
+        .write()
+        .await
+        .insert("prey".to_string(), make_xp_monster("prey", pos(1.0)));
+    drain(&mut alice_rx);
+
+    kill_monster(&game_state, "alice", "prey").await;
+
+    assert_eq!(xp_gains(&mut alice_rx), [SHARED_KILL_XP]);
+}

--- a/server/src/game_state/tests/party_tests.rs
+++ b/server/src/game_state/tests/party_tests.rs
@@ -1827,9 +1827,9 @@ async fn kill_xp_splits_with_nearby_member() {
 
     kill_monster(&game_state, "alice", "prey").await;
 
-    // 10 * 1.15 = 11 total, floored equal split: 5 each, killer included.
-    assert_eq!(xp_gains(&mut alice_rx), [5]);
-    assert_eq!(xp_gains(&mut bob_rx), [5]);
+    // 10 * 1.25 = 12 total, floored equal split: 6 each, killer included.
+    assert_eq!(xp_gains(&mut alice_rx), [6]);
+    assert_eq!(xp_gains(&mut bob_rx), [6]);
 }
 
 #[tokio::test]
@@ -1857,10 +1857,10 @@ async fn kill_xp_three_way_split() {
 
     kill_monster(&game_state, "alice", "prey").await;
 
-    // 10 * 1.30 = 13 total, floored equal split: 4 each, killer included.
-    assert_eq!(xp_gains(&mut alice_rx), [4]);
-    assert_eq!(xp_gains(&mut bob_rx), [4]);
-    assert_eq!(xp_gains(&mut carol_rx), [4]);
+    // 10 * 1.50 = 15 total, floored equal split: 5 each, killer included.
+    assert_eq!(xp_gains(&mut alice_rx), [5]);
+    assert_eq!(xp_gains(&mut bob_rx), [5]);
+    assert_eq!(xp_gains(&mut carol_rx), [5]);
 }
 
 #[tokio::test]

--- a/shared/src/xp.rs
+++ b/shared/src/xp.rs
@@ -7,6 +7,33 @@ pub fn monster_xp(level: u8, guard: u8) -> u32 {
     base + guard_bonus
 }
 
+/// Party XP bonus: +15% of the monster's XP per eligible member beyond
+/// the first, applied to the pooled total before the split.
+pub const PARTY_XP_BONUS_PER_EXTRA_PERCENT: u64 = 15;
+
+/// XZ distance from the dying monster within which a living, same-floor
+/// party member shares the kill XP. Sized to cover one hunting ground
+/// (ambient spawns land within 60m of each member) without letting a
+/// party leech across the map.
+pub const PARTY_XP_SHARE_RADIUS: f32 = 150.0;
+
+/// Equal per-member share of a monster's XP among `eligible_members` party
+/// members. Whoever lands the killing blow gets no special cut — it only
+/// triggers the split. The pooled total gains the party bonus, the split is
+/// floored, and every member is guaranteed 1 XP so trash kills never read
+/// as nothing. For n >= 2 a share can never exceed the solo award (total is
+/// at most 1.6x base and n >= 2), so padding a party with idle members
+/// cannot beat soloing.
+pub fn party_xp_share(base_xp: u32, eligible_members: u32) -> u32 {
+    let n = eligible_members.max(1);
+    if n == 1 {
+        return base_xp;
+    }
+    let percent = 100 + PARTY_XP_BONUS_PER_EXTRA_PERCENT * u64::from(n - 1);
+    let total = (u64::from(base_xp) * percent / 100) as u32;
+    (total / n).max(1.min(base_xp))
+}
+
 /// Minimum cumulative XP required to reach the given level.
 /// Level 1: 0, Level n (n>=2): 20 * 2^(n-2)
 /// Saturates at u64::MAX for astronomically high levels (~62+).
@@ -145,6 +172,47 @@ mod tests {
         // Should terminate without panic at extreme values
         let _ = level_from_xp(u64::MAX);
         let _ = level_from_xp(u64::MAX - 1);
+    }
+
+    #[test]
+    fn party_share_solo_is_unchanged() {
+        assert_eq!(party_xp_share(17, 1), 17);
+        assert_eq!(party_xp_share(17, 0), 17);
+    }
+
+    #[test]
+    fn party_share_three_members_orc() {
+        // 17 * 1.30 = 22 -> 7 each, remainder dropped.
+        assert_eq!(party_xp_share(17, 3), 7);
+    }
+
+    #[test]
+    fn party_share_full_party_boss() {
+        // 107 * 1.60 = 171 -> 34 each.
+        assert_eq!(party_xp_share(107, 5), 34);
+    }
+
+    #[test]
+    fn party_share_tiny_monster_pays_everyone_one() {
+        // kobold (2 XP): the floored split would be 0; everyone gets 1.
+        assert_eq!(party_xp_share(2, 3), 1);
+        assert_eq!(party_xp_share(2, 5), 1);
+        assert_eq!(party_xp_share(1, 5), 1);
+        assert_eq!(party_xp_share(0, 5), 0);
+    }
+
+    #[test]
+    fn party_share_never_beats_soloing() {
+        // Regression for the remainder exploit: with two or more members no
+        // share — the killer's included — may exceed the solo award.
+        for base in [1u32, 2, 5, 10, 17, 28, 107, 401] {
+            for n in 2u32..=5 {
+                assert!(
+                    party_xp_share(base, n) <= base,
+                    "share for base {base} n {n} exceeds solo"
+                );
+            }
+        }
     }
 
     #[test]

--- a/shared/src/xp.rs
+++ b/shared/src/xp.rs
@@ -7,9 +7,10 @@ pub fn monster_xp(level: u8, guard: u8) -> u32 {
     base + guard_bonus
 }
 
-/// Party XP bonus: +15% of the monster's XP per eligible member beyond
-/// the first, applied to the pooled total before the split.
-pub const PARTY_XP_BONUS_PER_EXTRA_PERCENT: u64 = 15;
+/// Party XP bonus: +25% of the monster's XP per eligible member beyond
+/// the first, applied to the pooled total before the split. A full
+/// 5-member party pools exactly double the solo award.
+pub const PARTY_XP_BONUS_PER_EXTRA_PERCENT: u64 = 25;
 
 /// XZ distance from the dying monster within which a living, same-floor
 /// party member shares the kill XP. Sized to cover one hunting ground
@@ -182,14 +183,14 @@ mod tests {
 
     #[test]
     fn party_share_three_members_orc() {
-        // 17 * 1.30 = 22 -> 7 each, remainder dropped.
-        assert_eq!(party_xp_share(17, 3), 7);
+        // 17 * 1.50 = 25 -> 8 each, remainder dropped.
+        assert_eq!(party_xp_share(17, 3), 8);
     }
 
     #[test]
     fn party_share_full_party_boss() {
-        // 107 * 1.60 = 171 -> 34 each.
-        assert_eq!(party_xp_share(107, 5), 34);
+        // 107 * 2.00 = 214 -> 42 each.
+        assert_eq!(party_xp_share(107, 5), 42);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds shared kill XP for parties, so hunting together is rewarded mechanically — the first step toward making parties the natural way to play together.

**Rules:**
- When a monster dies, every party member who is online, alive, on the same floor, and within 150m (XZ) of the monster shares the kill — the killer included.
- The pooled total gains **+25% per eligible member beyond the first**, so a full 5-member party pools **exactly double** the solo award.
- Everyone receives the **same floored share** (minimum 1 XP). The killing blow only triggers the split — it earns no extra cut. Nobody needs to care who lands the last hit, and for n ≥ 2 a share is mathematically capped below the solo award, so padding the roster with idle members can never beat soloing (regression-tested).
- With one eligible member (or no party) a kill behaves exactly as before.

**Why 150m:** ambient monsters spawn within 60m of each player, so two members hunting the same ground can momentarily drift ~120m apart; 150m absorbs that natural scatter while still excluding town idlers and other hunting grounds. Both knobs are constants (`PARTY_XP_BONUS_PER_EXTRA_PERCENT`, `PARTY_XP_SHARE_RADIUS`) for later tuning.

**Implementation:** the XP-grant block in `combat.rs` moves into a `grant_monster_kill_xp` helper. Its read-modify-write now runs under a single `player_characters` lock (a member can receive two kills' shares concurrently; a split read/write could lose one), the level write is monotonic, and log lines name the player. No protocol change — `XpGained` was already per-player — and no client change needed.

## Test plan

- `xp.rs` unit tests: split values, min-1 clamp, `party_share_never_beats_soloing` regression sweep.
- `party_tests.rs` integration tests: 2-way and 3-way splits through real kills, exclusion by distance / death / floor, solo fallback, partyless unchanged.
- Live E2E on a local server with 5 players in one party (browser client + 4 agent-client bots): kills in both directions produced exactly the computed shares under the then-configured 15% bonus (kobold 1/1, goblin 2/2, orc 10/10 with two members in range), a cross-floor kill correctly fell back to solo XP, and a dead member was excluded from a split. The bonus was raised to 25% afterwards with unit/integration expectations updated.

## Screenshot
<img width="1540" height="1239" alt="image" src="https://github.com/user-attachments/assets/85814233-223d-48c0-8de8-c9be60542600" />

## 요약 (한국어)

파티로 함께 사냥하는 플레이가 보상받도록, 처치 경험치 공유를 추가합니다.

- 몬스터가 죽으면 **같은 층 · 150m 이내 · 생존** 파티원 전원이 (막타 포함) 경험치를 나눕니다.
- 총량은 추가 인원당 **+25%** — **5인 풀파티는 정확히 솔로의 2배**를 나눠 갖습니다.
- 전원이 **동일한 몫**(버림, 최소 1)을 받습니다. 막타는 분배를 발동할 뿐 추가 몫이 없어, 누가 마지막 타격을 했는지 신경 쓸 필요가 없습니다. 2인 이상에서는 몫이 솔로 원본을 넘지 못하도록 수학적으로 보장되어 유령 파티원 악용이 불가능합니다 (회귀 테스트 포함).
- 자격자가 1명뿐이거나 파티가 없으면 기존과 완전히 동일하게 동작합니다.
- 150m 근거: 몬스터 스폰 버블(플레이어당 60m) 기준, 같은 사냥터에서의 자연스러운 흩어짐(~120m)을 포용하면서 마을 대기·다른 사냥터는 제외되는 크기입니다. 보너스율·반경 모두 상수로 분리해 튜닝할 수 있습니다.
- 프로토콜·클라이언트 변경은 없으며, 지급 경로를 헬퍼로 추출하면서 동시 지급 시 유실 가능성(잠금 분리)도 함께 수정했습니다.

검증: 단위·통합 테스트에 더해, 로컬 서버에서 브라우저 + 봇 4명으로 5인 파티 라이브 테스트를 수행했습니다 — 양방향 킬 분배가 계산값과 정확히 일치(당시 15% 설정 기준), 층 분리 폴백·사망자 제외도 실측 확인했습니다. 이후 보너스를 25%로 상향하고 테스트 기대값을 갱신했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
