### PR TITLE
Close the remaining player-agent social action gap

### DIFF
--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -116,6 +116,66 @@ pub(super) enum AgentAction {
     /// Leave your current party.
     #[serde(rename = "party_leave", alias = "leave_party")]
     PartyLeave,
+    /// Leader-only: remove a member from the party.
+    #[serde(rename = "party_kick", alias = "kick", alias = "kick_from_party")]
+    PartyKick {
+        #[serde(alias = "target", alias = "player_name", alias = "target_player")]
+        player: String,
+    },
+    /// Leader-only: hand party leadership to a member.
+    #[serde(rename = "party_promote", alias = "promote", alias = "promote_leader")]
+    PartyPromote {
+        #[serde(alias = "target", alias = "player_name", alias = "target_player")]
+        player: String,
+    },
+    /// Accept a pending friend request — the oldest, or the named requester's.
+    #[serde(rename = "friend_accept", alias = "accept_friend")]
+    FriendAccept {
+        #[serde(default, alias = "target", alias = "player_name", alias = "requester")]
+        player: Option<String>,
+    },
+    /// Decline a pending friend request — the oldest, or the named requester's.
+    #[serde(
+        rename = "friend_decline",
+        alias = "decline_friend",
+        alias = "reject_friend"
+    )]
+    FriendDecline {
+        #[serde(default, alias = "target", alias = "player_name", alias = "requester")]
+        player: Option<String>,
+    },
+    /// Drop a friendship, both directions. Name-based: the friend may be
+    /// offline.
+    #[serde(rename = "friend_remove", alias = "remove_friend", alias = "unfriend")]
+    FriendRemove {
+        #[serde(alias = "target", alias = "player_name", alias = "friend")]
+        player: String,
+    },
+    /// Ask which friends are online right now; the answer arrives as a
+    /// [FriendsOnline] event.
+    #[serde(
+        rename = "friends_online",
+        alias = "check_friends",
+        alias = "list_friends"
+    )]
+    FriendsOnline,
+    /// Drop copper into a performer's tip hat — the nearest one, or the
+    /// named hat id.
+    #[serde(rename = "tip_hat", alias = "tip")]
+    TipHat {
+        #[serde(default, alias = "target", alias = "id", alias = "hat_id")]
+        hat: Option<u64>,
+        #[serde(alias = "gold", alias = "copper", alias = "coins")]
+        amount: i64,
+    },
+    /// Wave off the trade window an NPC pushed onto our screen ("Not now"
+    /// on the web client's offer toast).
+    #[serde(
+        rename = "decline_trade",
+        alias = "wave_off_trade",
+        alias = "refuse_trade"
+    )]
+    DeclineTrade,
     /// Say something to your party, wherever its members are.
     #[serde(rename = "party_say", alias = "party_chat")]
     PartySay {
@@ -358,7 +418,8 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         doc: r#"- Use an item you are carrying — wear a piece of gear, drink a potion, read
   a scroll, eat food. Name it as it appears in your bag. Using gear you
   already wear takes it off; wearing a torch is how you light your way at
-  night:
+  night (it lights on equip, so other players see your light too, and goes
+  out when you take it off):
   {"type": "use", "target": "worn_torch"}"#,
     },
     ActionSpec {
@@ -491,6 +552,54 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   {"type": "party_leave"}"#,
     },
     ActionSpec {
+        names: &["party_kick", "party_promote"],
+        aliases: &["kick", "kick_from_party", "promote", "promote_leader"],
+        doc: r#"- (party leader only) Remove a member from your party, or hand them the
+  lead. Your roster in the world state marks who leads:
+  {"type": "party_kick", "target": "darkcocoa"}
+  {"type": "party_promote", "target": "darkcocoa"}"#,
+    },
+    ActionSpec {
+        names: &["friend_accept", "friend_decline"],
+        aliases: &["accept_friend", "decline_friend", "reject_friend"],
+        doc: r#"- Answer a friend request (the world state lists pending ones). Friends
+  see each other in their friend panels and can check who is online. With
+  several requests pending, name the requester — bare answers the oldest:
+  {"type": "friend_accept"}
+  {"type": "friend_decline", "target": "darkcocoa"}"#,
+    },
+    ActionSpec {
+        names: &["friend_remove"],
+        aliases: &["remove_friend", "unfriend"],
+        doc: r#"- Drop a friendship, both directions. Works while they are offline:
+  {"type": "friend_remove", "target": "darkcocoa"}"#,
+    },
+    ActionSpec {
+        names: &["friends_online"],
+        aliases: &["check_friends", "list_friends"],
+        doc: r#"- Ask which of your friends are online right now; a [FriendsOnline]
+  event answers:
+  {"type": "friends_online"}"#,
+    },
+    ActionSpec {
+        names: &["tip_hat"],
+        aliases: &["tip"],
+        doc: r#"- Drop copper into a performer's tip hat (the world state lists hats
+  near you with their ids). You must stand within 5m of the hat; "amount"
+  is in copper (100 copper = 1 silver). Bare form tips the nearest hat
+  that is not your own:
+  {"type": "tip_hat", "amount": 20}
+  {"type": "tip_hat", "target": 7, "amount": 20}"#,
+    },
+    ActionSpec {
+        names: &["decline_trade"],
+        aliases: &["wave_off_trade", "refuse_trade"],
+        doc: r#"- Wave off the trade window a merchant pushed onto your screen (the
+  [TradeOffer] event) without buying anything — they will stop offering
+  for a while:
+  {"type": "decline_trade"}"#,
+    },
+    ActionSpec {
         names: &["reroll"],
         aliases: &["reroll_stats", "roll_again"],
         doc: r#"- Reroll your starting stats (character creation only — does nothing once
@@ -539,7 +648,15 @@ impl AgentAction {
             | Self::SummonAccept { .. }
             | Self::SummonDecline { .. }
             | Self::PartyLeave
+            | Self::PartyKick { .. }
+            | Self::PartyPromote { .. }
             | Self::PartySay { .. }
+            | Self::FriendAccept { .. }
+            | Self::FriendDecline { .. }
+            | Self::FriendRemove { .. }
+            | Self::FriendsOnline
+            | Self::TipHat { .. }
+            | Self::DeclineTrade
             | Self::Use { .. }
             | Self::Drop { .. }
             | Self::Reroll
@@ -566,6 +683,8 @@ impl AgentAction {
                     | Self::OfferDeal { .. }
                     | Self::Use { .. }
                     | Self::Drop { .. }
+                    // Tipping is gated on standing within 5m of the hat.
+                    | Self::TipHat { .. }
             )
     }
 
@@ -593,6 +712,14 @@ impl AgentAction {
             | Self::SummonAccept { .. }
             | Self::SummonDecline { .. }
             | Self::PartyLeave
+            | Self::PartyKick { .. }
+            | Self::PartyPromote { .. }
+            | Self::FriendAccept { .. }
+            | Self::FriendDecline { .. }
+            | Self::FriendRemove { .. }
+            | Self::FriendsOnline
+            | Self::TipHat { .. }
+            | Self::DeclineTrade
             | Self::Use { .. }
             | Self::Drop { .. }
             | Self::Reroll => false,
@@ -617,6 +744,14 @@ impl AgentAction {
             Self::SummonAccept { .. } => "summon_accept",
             Self::SummonDecline { .. } => "summon_decline",
             Self::PartyLeave => "party_leave",
+            Self::PartyKick { .. } => "party_kick",
+            Self::PartyPromote { .. } => "party_promote",
+            Self::FriendAccept { .. } => "friend_accept",
+            Self::FriendDecline { .. } => "friend_decline",
+            Self::FriendRemove { .. } => "friend_remove",
+            Self::FriendsOnline => "friends_online",
+            Self::TipHat { .. } => "tip_hat",
+            Self::DeclineTrade => "decline_trade",
             Self::PartySay { .. } => "party_say",
             Self::Use { .. } => "use",
             Self::Pickup { .. } => "pickup",
@@ -832,6 +967,13 @@ fn normalize_targets(value: &mut serde_json::Value) {
             );
         } else if action_is(tag, "break_prop") {
             coerce_id_fields(action, &["target", "id", "prop", "prop_id"]);
+        } else if action_is(tag, "tip_hat") {
+            coerce_id_fields(
+                action,
+                &[
+                    "target", "id", "hat_id", "hat", "amount", "gold", "copper", "coins",
+                ],
+            );
         } else if ["sell", "buy", "buyback"].iter().any(|c| action_is(tag, c)) {
             // "target" aliases the merchant, but a sell/buy naming only one
             // thing means the goods — give the value to the item field the
@@ -1060,12 +1202,22 @@ pub(super) fn action_to_command(
         AgentAction::PartySay { message } => Some(ClientMessage::PartyChat {
             message: message.clone(),
         }),
+        AgentAction::FriendsOnline => Some(ClientMessage::RequestFriendsOnline),
         // Answering needs the stored invite; handled in
         // `execute::handle_response`.
         AgentAction::PartyAccept { .. }
         | AgentAction::PartyDecline { .. }
         | AgentAction::SummonAccept { .. }
         | AgentAction::SummonDecline { .. } => None,
+        // Need pending-request, roster or nearby-hat state from SharedState;
+        // handled in `execute::handle_response`.
+        AgentAction::PartyKick { .. }
+        | AgentAction::PartyPromote { .. }
+        | AgentAction::FriendAccept { .. }
+        | AgentAction::FriendDecline { .. }
+        | AgentAction::FriendRemove { .. }
+        | AgentAction::TipHat { .. }
+        | AgentAction::DeclineTrade => None,
         // Need player-name → id resolution from SharedState; handled in
         // `execute::handle_response`, not here.
         AgentAction::OfferDeal { .. } => None,
@@ -1654,6 +1806,92 @@ mod tests {
         assert!(!wants_reroll(""));
         assert!(!wants_reroll("Hmm, hard to say."));
         assert!(!wants_reroll(r#"{"actions": []}"#));
+    }
+
+    #[test]
+    fn party_kick_and_promote_parse_their_member() {
+        let AgentAction::PartyKick { player } =
+            parse_single_action(r#"{"actions": [{"type": "party_kick", "target": "darkcocoa"}]}"#)
+        else {
+            panic!("expected PartyKick");
+        };
+        assert_eq!(player, "darkcocoa");
+
+        let AgentAction::PartyPromote { player } =
+            parse_single_action(r#"{"actions": [{"type": "promote", "player": "darkcocoa"}]}"#)
+        else {
+            panic!("expected PartyPromote via alias");
+        };
+        assert_eq!(player, "darkcocoa");
+    }
+
+    #[test]
+    fn friend_actions_parse_with_aliases() {
+        let AgentAction::FriendAccept { player } =
+            parse_single_action(r#"{"actions": [{"type": "friend_accept"}]}"#)
+        else {
+            panic!("expected FriendAccept");
+        };
+        assert_eq!(player, None);
+
+        let AgentAction::FriendDecline { player } = parse_single_action(
+            r#"{"actions": [{"type": "decline_friend", "target": "Mallory"}]}"#,
+        ) else {
+            panic!("expected FriendDecline via alias");
+        };
+        assert_eq!(player.as_deref(), Some("Mallory"));
+
+        let AgentAction::FriendRemove { player } =
+            parse_single_action(r#"{"actions": [{"type": "unfriend", "target": "Mallory"}]}"#)
+        else {
+            panic!("expected FriendRemove via alias");
+        };
+        assert_eq!(player, "Mallory");
+
+        assert!(matches!(
+            parse_single_action(r#"{"actions": [{"type": "friends_online"}]}"#),
+            AgentAction::FriendsOnline
+        ));
+    }
+
+    #[test]
+    fn friends_online_sends_the_request_over_the_socket() {
+        let action = parse_single_action(r#"{"actions": [{"type": "friends_online"}]}"#);
+        assert!(matches!(
+            action_to_command(&action, None),
+            Some(ClientMessage::RequestFriendsOnline)
+        ));
+    }
+
+    #[test]
+    fn tip_hat_parses_bare_and_with_a_float_or_string_id() {
+        let AgentAction::TipHat { hat, amount } =
+            parse_single_action(r#"{"actions": [{"type": "tip_hat", "amount": 20}]}"#)
+        else {
+            panic!("expected TipHat");
+        };
+        assert_eq!(hat, None);
+        assert_eq!(amount, 20);
+
+        // Ids print as numbers, so LLMs send floats and quoted numbers.
+        for json in [
+            r#"{"actions": [{"type": "tip_hat", "target": 7.0, "amount": 20}]}"#,
+            r#"{"actions": [{"type": "tip", "hat_id": "7", "copper": 20}]}"#,
+        ] {
+            let AgentAction::TipHat { hat, amount } = parse_single_action(json) else {
+                panic!("expected TipHat for {json}");
+            };
+            assert_eq!(hat, Some(7), "for {json}");
+            assert_eq!(amount, 20, "for {json}");
+        }
+    }
+
+    #[test]
+    fn decline_trade_parses_and_stays_off_the_socket() {
+        let action = parse_single_action(r#"{"actions": [{"type": "decline_trade"}]}"#);
+        assert!(matches!(action, AgentAction::DeclineTrade));
+        assert!(action_to_command(&action, None).is_none());
+        assert!(!action.takes_over_movement());
     }
 
     #[test]

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -623,6 +623,197 @@ pub(super) async fn handle_response(
             continue;
         }
 
+        // Kick and promote need the party roster: resolve the named member
+        // and check we actually lead before bothering the server.
+        if let AgentAction::PartyKick { player } | AgentAction::PartyPromote { player } = action {
+            let kick = matches!(action, AgentAction::PartyKick { .. });
+            let verb = if kick { "remove" } else { "promote" };
+            let mut s = state.lock().await;
+            if s.party_members.is_empty() {
+                s.push_agent_event(format!(
+                    "[PartyFailed] You are not in a party — nobody to {verb}."
+                ));
+                continue;
+            }
+            if s.party_leader != s.self_player_id {
+                s.push_agent_event(format!(
+                    "[PartyFailed] Only the party leader can {verb} members."
+                ));
+                continue;
+            }
+            let member = s
+                .party_members
+                .iter()
+                .find(|m| m.name.eq_ignore_ascii_case(player.trim()));
+            let Some(member) = member else {
+                let roster = s
+                    .party_members
+                    .iter()
+                    .map(|m| m.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                s.push_agent_event(format!(
+                    "[PartyFailed] '{player}' is not in your party. Members: {roster}."
+                ));
+                continue;
+            };
+            let (target_id, target_name) = (member.id, member.name.clone());
+            if Some(target_id) == s.self_player_id {
+                s.push_agent_event(format!(
+                    "[PartyFailed] That names yourself — party_leave quits, and you \
+                     already lead. Name another member to {verb}."
+                ));
+                continue;
+            }
+            let cmd = if kick {
+                onlinerpg_shared::ClientMessage::PartyKick { target_id }
+            } else {
+                onlinerpg_shared::ClientMessage::PartyPromote { target_id }
+            };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send party {verb}: {e}");
+            } else if kick {
+                s.push_agent_event(format!("[Party] You removed {target_name} from the party."));
+            } else {
+                s.push_agent_event(format!("[Party] {target_name} now leads the party."));
+            }
+            continue;
+        }
+
+        // Friend answers need the stored request: the requester may be
+        // outside the AOI, like a party inviter.
+        if let AgentAction::FriendAccept { player } | AgentAction::FriendDecline { player } = action
+        {
+            let accept = matches!(action, AgentAction::FriendAccept { .. });
+            let mut s = state.lock().await;
+            s.prune_expired_friend_requests();
+            let idx = pick_pending(&s.pending_friend_requests, player.as_deref(), |r| {
+                &r.requester_name
+            });
+            let Some(idx) = idx else {
+                s.push_agent_event(
+                    "[FriendFailed] No pending friend request to answer.".to_string(),
+                );
+                continue;
+            };
+            let request = s.pending_friend_requests.remove(idx);
+            let cmd = onlinerpg_shared::ClientMessage::FriendRespond {
+                requester_id: request.requester_id,
+                accept,
+            };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send friend response: {e}");
+            } else if accept {
+                s.push_agent_event(format!(
+                    "[Friend] You and {} are friends now.",
+                    request.requester_name
+                ));
+            } else {
+                s.push_agent_event(format!(
+                    "[Friend] You declined {}'s friend request.",
+                    request.requester_name
+                ));
+            }
+            continue;
+        }
+
+        // Dropping a friend is name-based — the friend may be offline — so
+        // check the roster rather than nearby players.
+        if let AgentAction::FriendRemove { player } = action {
+            let mut s = state.lock().await;
+            let name = s
+                .friends
+                .iter()
+                .find(|f| f.name.eq_ignore_ascii_case(player.trim()))
+                .map(|f| f.name.clone());
+            let Some(name) = name else {
+                s.push_agent_event(format!(
+                    "[FriendFailed] '{player}' is not on your friend list."
+                ));
+                continue;
+            };
+            let cmd = onlinerpg_shared::ClientMessage::FriendRemove { name: name.clone() };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send friend removal: {e}");
+            } else {
+                s.push_agent_event(format!("[Friend] You dropped {name} as a friend."));
+            }
+            continue;
+        }
+
+        // Tip a performer's hat: resolve the named hat (or the nearest one
+        // that is not ours) and let the server judge wallet and distance —
+        // its system messages report the outcome either way.
+        if let AgentAction::TipHat { hat, amount } = action {
+            let mut s = state.lock().await;
+            if *amount <= 0 {
+                s.push_agent_event(
+                    "[TipFailed] \"amount\" must be a positive number of copper.".to_string(),
+                );
+                continue;
+            }
+            let hat_id = match hat {
+                Some(id) if s.tip_hats.contains_key(id) => Some(*id),
+                Some(id) => {
+                    s.push_agent_event(format!(
+                        "[TipFailed] No tip hat with id {id} is around — the world state \
+                         lists the hats you can see."
+                    ));
+                    continue;
+                }
+                None => {
+                    let me = s.self_player_id;
+                    let my_pos = s.self_player.as_ref().map(|p| p.position);
+                    s.tip_hats
+                        .values()
+                        .filter(|h| Some(h.owner) != me)
+                        .min_by(|a, b| match my_pos {
+                            Some(p) => a
+                                .position
+                                .dist_xz_sq(&p)
+                                .total_cmp(&b.position.dist_xz_sq(&p)),
+                            None => std::cmp::Ordering::Equal,
+                        })
+                        .map(|h| h.id)
+                }
+            };
+            let Some(hat_id) = hat_id else {
+                s.push_agent_event("[TipFailed] No tip hat is laid out near you.".to_string());
+                continue;
+            };
+            let cmd = onlinerpg_shared::ClientMessage::TipHat {
+                hat_id,
+                amount: *amount,
+            };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send tip: {e}");
+            }
+            continue;
+        }
+
+        // Wave off a pushed trade window. The offer is stored when ShopState
+        // arrives; the server relays the decline to the merchant's agent.
+        if matches!(action, AgentAction::DeclineTrade) {
+            let mut s = state.lock().await;
+            let Some((merchant_id, merchant_name)) = s.pushed_trade.take() else {
+                s.push_agent_event(
+                    "[TradeFailed] No trade window is open on your screen to decline.".to_string(),
+                );
+                continue;
+            };
+            let cmd = onlinerpg_shared::ClientMessage::DeclineTrade {
+                merchant_player_id: merchant_id,
+            };
+            if let Err(e) = s.send_command(cmd).await {
+                error!("Failed to send trade decline: {e}");
+            } else {
+                s.push_agent_event(format!(
+                    "[Trade] You waved off {merchant_name}'s trade window."
+                ));
+            }
+            continue;
+        }
+
         // Use an item: worn gear comes off, anything else is equipped or
         // consumed out of the bag. Lighting a torch is equipping one.
         if let AgentAction::Use { item } = action {
@@ -633,6 +824,15 @@ pub(super) async fn handle_response(
                     "[UseFailed] You are not carrying anything called '{item}'."
                 ));
                 continue;
+            };
+            // A torch changes hands → tell the server so the light other
+            // players see follows it. The web client's torch button sends the
+            // same message; there the light is a toggle beside the gear, here
+            // equipping IS the toggle.
+            let torch_now_lit = match (is_torch(&def_id), &placed) {
+                (true, Carried::InBag(_)) => Some(true),
+                (true, Carried::Worn(_)) => Some(false),
+                (false, _) => None,
             };
             let cmd = match placed {
                 Carried::Worn(slot) => onlinerpg_shared::ClientMessage::UnequipItem { slot },
@@ -650,6 +850,11 @@ pub(super) async fn handle_response(
             };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send use action: {e}");
+            } else if let Some(enabled) = torch_now_lit {
+                let toggle = onlinerpg_shared::ClientMessage::TorchToggle { enabled };
+                if let Err(e) = s.send_command(toggle).await {
+                    error!("Failed to send torch toggle: {e}");
+                }
             }
             continue;
         }
@@ -1326,6 +1531,12 @@ fn resolve_trade_push_target(
         return None;
     }
     Some(target_id)
+}
+
+/// The item ids that are torches — the same list the web client's
+/// `isTorchItemDefId` keeps.
+fn is_torch(def_id: &str) -> bool {
+    matches!(def_id, "torch" | "worn_torch")
 }
 
 /// Resolve the trader an LLM action named and walk up to them, answering with

--- a/agent-client/src/driver/mod.rs
+++ b/agent-client/src/driver/mod.rs
@@ -162,6 +162,21 @@ pub async fn llm_driver(
 
     info!("[{label}] LLM driver: in game, ready.");
 
+    // Operator announcements — what a web player reads once on the login
+    // screen. Delivered as one-shot events for the same reason: the next
+    // prompt carries them, then they drain away instead of riding every
+    // world state.
+    {
+        let notices = fetch_announcements(&api_base_url).await;
+        if !notices.is_empty() {
+            info!("[{label}] {} server announcement(s) loaded", notices.len());
+            let mut s = state.lock().await;
+            for notice in notices {
+                s.push_agent_event_quiet(format!("[Notice] {notice}"));
+            }
+        }
+    }
+
     // Favor persists across sessions; the map feeds prompt rendering and
     // the keepsake gate from the first turn.
     if let Some(path) = &favor_file {
@@ -199,7 +214,7 @@ pub async fn llm_driver(
     // (a plain player agent) has no route to prefetch along, so cover where it
     // stands — otherwise its A* knows of no buildings at all and it walks
     // straight through the town it spawned in.
-    {
+    let mut world_data_at: Option<(f32, f32)> = {
         let (world_cache, around) = {
             let s = state.lock().await;
             (
@@ -214,7 +229,8 @@ pub async fn llm_driver(
             fetch_houses_around(&world_cache, &area, &api_base_url, &label),
             fetch_furniture_around(&world_cache, &area, &api_base_url, &label),
         );
-    }
+        around.map(|p| (p.x, p.z))
+    };
 
     // Execute initial schedule move (go to correct position for current time)
     if !schedule.is_empty() {
@@ -295,6 +311,35 @@ pub async fn llm_driver(
     }
 
     loop {
+        // Housing data was fetched around the start position; the initial
+        // prefetch covers ±96m (the chunk and its neighbors). An exploring
+        // agent walks out of that in minutes, after which buildings vanish
+        // from pathfinding, the terrain map and the watch page — so refetch
+        // around the new position whenever we've moved a chunk away.
+        {
+            let (world_cache, pos) = {
+                let s = state.lock().await;
+                (
+                    Arc::clone(&s.world_cache),
+                    s.self_player.as_ref().map(|p| p.position),
+                )
+            };
+            if let Some(p) = pos {
+                let moved_a_chunk = world_data_at.is_none_or(|(x, z)| {
+                    let (dx, dz) = (p.x - x, p.z - z);
+                    dx * dx + dz * dz > 64.0 * 64.0
+                });
+                if moved_a_chunk {
+                    let area = [(p.x, p.z)];
+                    tokio::join!(
+                        fetch_houses_around(&world_cache, &area, &api_base_url, &label),
+                        fetch_furniture_around(&world_cache, &area, &api_base_url, &label),
+                    );
+                    world_data_at = Some((p.x, p.z));
+                }
+            }
+        }
+
         // Tick interval: ATTACK_COOLDOWN when in combat, otherwise 1s (responsive to events)
         let tick_duration = if attack_target.is_some() {
             attack_cooldown.saturating_sub(last_attack_at.elapsed())
@@ -562,6 +607,51 @@ async fn await_llm_response(
             None
         }
     }
+}
+
+/// Fetch the operator announcements a web player reads on the login screen.
+/// Best-effort: served notices are login-screen content, so a failure means
+/// an empty list, not an error the driver should stall on.
+async fn fetch_announcements(api_base_url: &str) -> Vec<String> {
+    let url = format!("{api_base_url}/api/announcements");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return Vec::new(),
+    };
+    let resp = match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp,
+        _ => return Vec::new(),
+    };
+    let Ok(list) = resp.json::<Vec<serde_json::Value>>().await else {
+        return Vec::new();
+    };
+    list.iter()
+        .take(3)
+        .filter_map(|a| {
+            let date = a.get("date").and_then(|d| d.as_str()).unwrap_or("");
+            let translations = a.get("translations")?;
+            // Prefer Korean (the server's default locale), fall back to any.
+            let t = translations
+                .get("ko")
+                .or_else(|| translations.as_object()?.values().next())?;
+            let title = t.get("title").and_then(|s| s.as_str())?;
+            let body = t.get("body").and_then(|s| s.as_str()).unwrap_or("");
+            let mut line = format!("[{date}] {title}");
+            let body = body.trim();
+            if !body.is_empty() {
+                let short: String = body.chars().take(200).collect();
+                line.push_str(" — ");
+                line.push_str(&short);
+                if body.chars().count() > 200 {
+                    line.push('…');
+                }
+            }
+            Some(line)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/agent-client/src/state/events.rs
+++ b/agent-client/src/state/events.rs
@@ -81,6 +81,14 @@ impl SharedState {
             ServerMessage::PartyInviteReceived { .. }
             | ServerMessage::PartyInviteResult { .. }
             | ServerMessage::PartySummonReceived { .. } => EventUrgency::Urgent,
+            // Urgent: a friend request to answer while it is live, and the
+            // answer to our own friends_online ask.
+            ServerMessage::FriendRequestReceived { .. } | ServerMessage::FriendsOnline { .. } => {
+                EventUrgency::Urgent
+            }
+            // Urgent: someone opened their trade window on us — a person is
+            // standing there waiting for an answer.
+            ServerMessage::ShopState { .. } => EventUrgency::Urgent,
             ServerMessage::PartyState { .. } => EventUrgency::Routine,
             // Urgent: kicked
             ServerMessage::Kicked { .. } => EventUrgency::Urgent,
@@ -404,11 +412,27 @@ impl SharedState {
             }
             ServerMessage::ShopState {
                 merchant_player_id,
+                ref merchant_name,
                 ref buyback,
                 ..
             } => {
                 self.merchant_buyback
                     .insert(*merchant_player_id, buyback.clone());
+                // The agent never sends OpenShop, so a ShopState is always a
+                // trade window pushed at us by an NPC's OpenTrade — the offer
+                // toast a web player would see. A re-send from the same
+                // merchant (a deal changed mid-trade) is not a new offer.
+                let repeat = self
+                    .pushed_trade
+                    .as_ref()
+                    .is_some_and(|(id, _)| id == merchant_player_id);
+                self.pushed_trade = Some((*merchant_player_id, merchant_name.clone()));
+                if !repeat {
+                    self.push_agent_event(format!(
+                        "[TradeOffer] {merchant_name} opened their trade window on you — buy or \
+                         sell with them, or wave it off with decline_trade."
+                    ));
+                }
             }
             ServerMessage::GameState {
                 players,
@@ -416,7 +440,7 @@ impl SharedState {
                 ground_items,
                 campfires,
                 stalls,
-                tip_hats: _,
+                tip_hats,
             } => {
                 self.nearby_players = players.iter().map(|p| (p.id, p.clone())).collect();
                 self.nearby_monsters = monsters.clone();
@@ -431,6 +455,10 @@ impl SharedState {
                 self.stalls.clear();
                 for stall in stalls {
                     self.stalls.insert(stall.id, stall.clone());
+                }
+                self.tip_hats.clear();
+                for hat in tip_hats {
+                    self.tip_hats.insert(hat.id, hat.clone());
                 }
                 // Update self_player from game state
                 if let Some(self_id) = self.self_player_id {
@@ -643,6 +671,60 @@ impl SharedState {
                     caster_name: caster_name.clone(),
                     expires_at: std::time::Instant::now() + PARTY_SUMMON_TTL,
                 });
+            }
+            ServerMessage::FriendRequestReceived {
+                requester_id,
+                ref requester_name,
+            } => {
+                self.prune_expired_friend_requests();
+                let queue = &mut self.pending_friend_requests;
+                if !queue.iter().any(|r| r.requester_id == *requester_id) {
+                    queue.push(PendingFriendRequest {
+                        requester_id: *requester_id,
+                        requester_name: requester_name.clone(),
+                        expires_at: std::time::Instant::now()
+                            + onlinerpg_shared::messages::FRIEND_REQUEST_TTL,
+                    });
+                }
+            }
+            ServerMessage::FriendList { ref friends } => {
+                // Answering a request settles it; the roster names the verdict.
+                self.pending_friend_requests
+                    .retain(|r| !friends.iter().any(|f| f.name == r.requester_name));
+                self.friends = friends.clone();
+            }
+            ServerMessage::FriendsOnline { ref friends } => {
+                // The answer to our own friends_online ask. Ids map to names
+                // through the roster; an id off the roster shows as is.
+                if friends.is_empty() {
+                    self.push_agent_event(
+                        "[FriendsOnline] None of your friends are online right now.".to_string(),
+                    );
+                } else {
+                    let names: Vec<String> = friends
+                        .iter()
+                        .map(|f| {
+                            let name = self
+                                .friends
+                                .iter()
+                                .find(|e| e.character_id == f.character_id)
+                                .map(|e| e.name.as_str())
+                                .unwrap_or("(unknown)");
+                            format!("{name} (Lv.{})", f.level)
+                        })
+                        .collect();
+                    self.push_agent_event(format!(
+                        "[FriendsOnline] Online now: {}.",
+                        names.join(", ")
+                    ));
+                }
+            }
+            ServerMessage::TipHatPlaced { ref tip_hat }
+            | ServerMessage::TipHatAppeared { ref tip_hat } => {
+                self.tip_hats.insert(tip_hat.id, tip_hat.clone());
+            }
+            ServerMessage::TipHatRemoved { tip_hat_id } => {
+                self.tip_hats.remove(tip_hat_id);
             }
             ServerMessage::PartyState {
                 leader_id,

--- a/agent-client/src/state/mod.rs
+++ b/agent-client/src/state/mod.rs
@@ -150,7 +150,7 @@ pub use commands::ActionProgress;
 pub use events::EventUrgency;
 pub use inventory::{Carried, CarriedBagCopies};
 pub use movement::{MoveTarget, MoveTargetError};
-pub use social::{PendingPartyInvite, PendingPartySummon};
+pub use social::{PendingFriendRequest, PendingPartyInvite, PendingPartySummon};
 pub use world_cache::WorldCache;
 
 /// Shared state between WebSocket reader and Claude driver tasks.
@@ -213,6 +213,17 @@ pub struct SharedState {
     pub pending_party_invites: Vec<PendingPartyInvite>,
     /// Unanswered summons, same queue discipline as invites.
     pub pending_party_summons: Vec<PendingPartySummon>,
+    /// Unanswered friend requests, same queue discipline as invites.
+    pub pending_friend_requests: Vec<PendingFriendRequest>,
+    /// Friend roster from `FriendList`, re-sent by the server on any change.
+    /// Maps the character ids in `FriendsOnline` back to names.
+    pub friends: Vec<onlinerpg_shared::messages::FriendEntry>,
+    /// Tip hats in our AOI, so the agent can drop coins in one.
+    pub tip_hats: HashMap<u64, onlinerpg_shared::tip_hat::TipHat>,
+    /// An NPC-pushed trade window not yet acted on (`ShopState` arrives
+    /// unrequested — the agent never sends `OpenShop`). `decline_trade`
+    /// answers and clears it.
+    pub pushed_trade: Option<(PlayerId, String)>,
     /// Current party roster from `PartyState`; empty = not in a party.
     pub party_members: Vec<onlinerpg_shared::messages::PartyMember>,
     pub party_leader: Option<PlayerId>,
@@ -356,6 +367,10 @@ impl SharedState {
             fishing_reaction: None,
             pending_party_invites: Vec::new(),
             pending_party_summons: Vec::new(),
+            pending_friend_requests: Vec::new(),
+            friends: Vec::new(),
+            tip_hats: HashMap::new(),
+            pushed_trade: None,
             party_members: Vec::new(),
             party_leader: None,
             nearby_players: HashMap::new(),

--- a/agent-client/src/state/social.rs
+++ b/agent-client/src/state/social.rs
@@ -14,6 +14,13 @@ pub struct PendingPartySummon {
     pub expires_at: std::time::Instant,
 }
 
+/// A friend request the agent hasn't answered yet.
+pub struct PendingFriendRequest {
+    pub requester_id: PlayerId,
+    pub requester_name: String,
+    pub expires_at: std::time::Instant,
+}
+
 impl SharedState {
     /// Returns true if any non-NPC (human) player is in `nearby_players`.
     pub fn has_nearby_human_players(&self) -> bool {
@@ -218,6 +225,19 @@ impl SharedState {
     pub fn prune_expired_party_summons(&mut self) {
         let now = std::time::Instant::now();
         self.pending_party_summons.retain(|s| s.expires_at > now);
+    }
+
+    pub fn prune_expired_friend_requests(&mut self) {
+        let now = std::time::Instant::now();
+        self.pending_friend_requests.retain(|r| r.expires_at > now);
+    }
+
+    /// Friend requests still answerable right now, `live_party_invites`'s twin.
+    pub fn live_friend_requests(&self) -> impl Iterator<Item = &PendingFriendRequest> {
+        let now = std::time::Instant::now();
+        self.pending_friend_requests
+            .iter()
+            .filter(move |r| r.expires_at > now)
     }
 
     /// Summons still answerable right now, `live_party_invites`'s twin.

--- a/agent-client/src/state/world_state.rs
+++ b/agent-client/src/state/world_state.rs
@@ -129,6 +129,21 @@ impl SharedState {
                 summon.caster_name
             ));
         }
+        for request in self.live_friend_requests() {
+            lines.push(format!(
+                "Pending friend request from {} — answer with friend_accept or friend_decline",
+                request.requester_name
+            ));
+        }
+        if !self.friends.is_empty() {
+            let names: Vec<&str> = self.friends.iter().map(|f| f.name.as_str()).collect();
+            lines.push(format!("Your friends: {}", names.join(", ")));
+        }
+        if let Some((_, name)) = &self.pushed_trade {
+            lines.push(format!(
+                "{name}'s trade window is open on your screen — buy, sell, or decline_trade"
+            ));
+        }
 
         // Nearby players (exclude self and humans beyond the sight radius)
         let sp = self.self_player.as_ref();
@@ -204,6 +219,30 @@ impl SharedState {
         }
         if hidden > 0 {
             lines.push(format!("(and {hidden} more items further away)"));
+        }
+
+        // Tip hats within sight on our floor: where to drop coins after a
+        // performance. Our own hat is listed too (it shows as yours).
+        if let Some(sp) = sp {
+            for hat in self.tip_hats.values() {
+                if hat.floor_level != sp.floor_level {
+                    continue;
+                }
+                let d_sq = hat.position.dist_xz_sq(&sp.position);
+                if d_sq > sight_sq {
+                    continue;
+                }
+                let whose = if Some(hat.owner) == self.self_player_id {
+                    "yours".to_string()
+                } else {
+                    format!("{}'s — drop coins in it with tip_hat", hat.owner_name)
+                };
+                lines.push(format!(
+                    "Tip hat [id {}] {:.1}m away: {whose}",
+                    hat.id,
+                    d_sq.sqrt()
+                ));
+            }
         }
 
         if lines.is_empty() {


### PR DESCRIPTION
A survey of all 66 `ClientMessage` variants against the agent's action set found these things a web player can do that the agent cannot. This closes them.

- **Party admin** — `party_kick` / `party_promote`. Leader-gated client-side against the roster, so a non-leader or a wrong name answers in one turn instead of a silent server drop.
- **Friends** — `friend_accept` / `friend_decline` / `friend_remove` / `friends_online`. Friend requests queue like party invites (TTL from shared) and show in the world state; the `FriendList` roster maps `FriendsOnline` ids back to names for the `[FriendsOnline]` answer.
- **Tips** — `tip_hat`. Hats sync from `GameState`/`TipHatPlaced`/`Appeared`/`Removed` and list in the world state with their ids; the bare form tips the nearest hat that isn't the agent's own. The server's system messages report every outcome.
- **Trade** — `decline_trade`. The agent never sends `OpenShop`, so an arriving `ShopState` is always an NPC-pushed trade window; it's surfaced as a `[TradeOffer]` event and waved off with the same `DeclineTrade` a web player's "Not now" sends.
- **Torch** — equipping a torch now sends `TorchToggle`, so other players see the light at night; taking it off turns it out.
- **Announcements** — fetched once per boot from `/api/announcements` and delivered as one-shot `[Notice]` events, mirroring the login screen.
- Housing/furniture data now refetches as the agent moves (a chunk past the last fetch point) instead of only around the start position, so an exploring agent keeps buildings in its pathfinding and terrain map.

After this, every `ClientMessage` the agent still doesn't send is a batch/singular twin of one it does, debug/admin-only, or telemetry — with one exception we'd like your take on: `RequestPartyPositions`/`PartyPositions` (party members beyond AOI), which we can follow up on.

**On housing**: we also built agent housing (`build_house`/`edit_house`/`demolish_house` over the housing REST API, floor-plan-only interface with client-side pre-validation), but left it out of this PR — since cbc6a283 housing writes are admin-gated and the editor UI is admin-only, so it isn't a player-parity item. We'd like to hear your plans for housing: if player-owned housing is something you want, we're happy to send that work as a follow-up.

**Testing**
- `cargo test` 198 passed in agent-client (new: parse tests for each action, friend-queue and tip-hat resolution), workspace `clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean. No changes under `client/` or `shared/`.
- End-to-end against a local server (two scripted agents): party invite → accept → `/friend add` → friend_accept → roster in world state → party_promote → party_kick → friends_online (ids resolved to names) → friend_remove, plus the no-hat and no-window failure answers for tip_hat / decline_trade. All expected events and world-state lines appeared.

---

### 한국어

에이전트 액션과 `ClientMessage` 66종 전수 대조에서 나온, 웹 플레이어는 되는데 에이전트는 안 되는 것들을 닫는 PR입니다.

- **파티 관리** — `party_kick` / `party_promote`. 리더 여부·명단을 클라이언트에서 선검사해서, 리더가 아니거나 이름이 틀리면 서버에서 조용히 버려지는 대신 한 턴 안에 답이 돌아옵니다.
- **친구** — `friend_accept` / `friend_decline` / `friend_remove` / `friends_online`. 친구 요청이 파티 초대와 같은 큐 규율(shared의 TTL)로 쌓이고 world state에 표시됩니다. `FriendList` 명단으로 `FriendsOnline`의 id를 이름으로 되돌립니다.
- **팁** — `tip_hat`. 모자가 `GameState`/`TipHatPlaced`/`Appeared`/`Removed`에서 동기화되어 world state에 id와 함께 표시되고, 대상 없이 쓰면 자기 것이 아닌 최근접 모자에 넣습니다. 결과는 서버 시스템 메시지가 알려줍니다.
- **거래** — `decline_trade`. 에이전트는 `OpenShop`을 보내지 않으므로 도착하는 `ShopState`는 전부 NPC가 밀어넣은 거래창입니다. `[TradeOffer]` 이벤트로 올리고, 웹의 "Not now"와 같은 `DeclineTrade`로 거절합니다.
- **횃불** — 장착 시 `TorchToggle`을 보내 다른 플레이어에게도 불빛이 보이고, 벗으면 꺼집니다.
- **공지** — 부팅 시 `/api/announcements`에서 한 번 받아 일회성 `[Notice]` 이벤트로 전달합니다. 로그인 화면과 같은 방식입니다.
- 하우징·가구 데이터를 시작 지점 주변 한 번이 아니라 이동에 따라(마지막 지점에서 청크 이상 벗어나면) 다시 받아, 멀리 탐험해도 건물이 경로탐색과 지형 지도에 남습니다.

이 PR 이후 에이전트가 안 보내는 `ClientMessage`는 전부 이미 쓰는 것의 단발/묶음 쌍둥이, 디버그·관리자 전용, 텔레메트리입니다. 예외 하나가 `RequestPartyPositions`/`PartyPositions`(AOI 밖 파티원 위치)인데, 의견 주시면 후속으로 작업하겠습니다.

**하우징에 대해**: 에이전트 집짓기(`build_house`/`edit_house`/`demolish_house`, 하우징 REST 경유, 평면도만 그리는 인터페이스 + 클라이언트 사전 검증)도 만들었지만 이 PR에서는 뺐습니다 — cbc6a283 이후 하우징 쓰기가 관리자 인증이고 에디터 UI도 관리자 전용이라, 플레이어 동등성 항목이 아니어서요. 하우징 계획이 궁금합니다. 플레이어 소유 집짓기를 원하시면 그 작업을 후속 PR로 보내겠습니다.

**테스트**
- agent-client `cargo test` 198개 통과(액션별 파싱, 친구 큐, 팁 모자 해석 테스트 신규), workspace `clippy -D warnings`·`cargo fmt --check` 깨끗. `client/`·`shared/` 변경 없음.
- 로컬 서버 상대 종단 간 시험(스크립트 에이전트 2기): 파티 초대 → 수락 → `/friend add` → friend_accept → world state 명단 → party_promote → party_kick → friends_online(id→이름 해석) → friend_remove, 그리고 tip_hat/decline_trade의 모자 없음·창 없음 실패 응답까지 기대한 이벤트와 world state 줄이 전부 나왔습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
