### PR TITLE
Add looping dance emotes: /emote twist, macarena and chicken

### DIFF
--- a/client/src/lib/components/FPSCounter.svelte
+++ b/client/src/lib/components/FPSCounter.svelte
@@ -64,6 +64,7 @@
   import { isAdminUser } from '../stores/gameStore'
   import { closeTopOverlay } from '../stores/overlayStack'
   import { friendPanelVisible } from '../stores/friendStore'
+  import { emoteStopRequest } from '../stores/emoteStore'
 
   function toDegrees(radians: number) {
     const degrees = (radians * 180) / Math.PI
@@ -87,9 +88,15 @@
       event.preventDefault()
       mapEditorMode.update((v) => !v)
     }
-    // Claim Escape only when it actually closed an overlay.
-    if (event.key === 'Escape' && isGameKey(event) && closeTopOverlay()) {
-      event.preventDefault()
+    // Claim Escape only when it actually closed an overlay. With nothing
+    // open, Escape ends a running emote performance instead (dance, tune);
+    // PlayerControl ignores the request unless one is playing.
+    if (event.key === 'Escape' && isGameKey(event)) {
+      if (closeTopOverlay()) {
+        event.preventDefault()
+      } else {
+        emoteStopRequest.set(true)
+      }
     }
     if ((event.key === 'm' || event.key === 'M') && isGameKey(event)) {
       event.preventDefault()

--- a/client/src/lib/components/PlayerControl.svelte
+++ b/client/src/lib/components/PlayerControl.svelte
@@ -118,6 +118,7 @@
   import {
     emoteRequest,
     emoteStopRequest,
+    LOOPING_EMOTE_ANIMS,
     MUSIC_EMOTE_ANIM,
     ONE_SHOT_EMOTE_ANIMS,
   } from '../stores/emoteStore'
@@ -359,7 +360,11 @@
     })
   }
 
-  const EMOTE_ANIMS = new Set([MUSIC_EMOTE_ANIM, ...ONE_SHOT_EMOTE_ANIMS])
+  const EMOTE_ANIMS = new Set([
+    MUSIC_EMOTE_ANIM,
+    ...ONE_SHOT_EMOTE_ANIMS,
+    ...LOOPING_EMOTE_ANIMS,
+  ])
 
   function exitObjectInteraction(notify = true) {
     // Stepping out walks the player off the seat they were using. An emote
@@ -1115,11 +1120,13 @@
   $effect(() => {
     if (!$emoteStopRequest) return
     emoteStopRequest.set(false)
-    // Only the performance ends here: by now the player may have sat down on
-    // something, and that pose is not ours to cancel.
+    // Only a performance ends here — the tune running out or Escape. By now
+    // the player may have sat down on something, and that pose is not ours
+    // to cancel.
     if (
       playerState.state === 'interact' &&
-      playerState.interactionAnim === MUSIC_EMOTE_ANIM
+      (playerState.interactionAnim === MUSIC_EMOTE_ANIM ||
+        LOOPING_EMOTE_ANIMS.has(playerState.interactionAnim ?? ''))
     ) {
       exitObjectInteraction()
     }

--- a/client/src/lib/components/PlayerModel.svelte
+++ b/client/src/lib/components/PlayerModel.svelte
@@ -58,7 +58,11 @@
   import ChatBubble from './ChatBubble.svelte'
   import DamageText from './DamageText.svelte'
   import type { PlayerDamageInfo, PlayerGoldInfo } from '../stores/gameStore'
-  import { MUSIC_EMOTE_ANIM, ONE_SHOT_EMOTE_ANIMS } from '../stores/emoteStore'
+  import {
+    LOOPING_EMOTE_ANIMS,
+    MUSIC_EMOTE_ANIM,
+    ONE_SHOT_EMOTE_ANIMS,
+  } from '../stores/emoteStore'
   import { billboardScale, billboardZoomT } from '../utils/billboardScale'
 
   interface Props {
@@ -629,13 +633,14 @@
 
     const newAction = mixer.clipAction(clip)
 
-    // The fishing idle and the music emote are stances held for the whole
-    // state, not one-shot gestures like pickup — they loop until it ends.
-    // Clamping instead would freeze the performance mid-strum.
+    // The fishing idle, the music emote and the dances are stances held for
+    // the whole state, not one-shot gestures like pickup — they loop until it
+    // ends. Clamping instead would freeze the performance mid-strum.
     const playOnce =
       playerState !== 'moving' &&
       interactionAnim !== FishingAnimationName.IDLE &&
-      interactionAnim !== MUSIC_EMOTE_ANIM
+      interactionAnim !== MUSIC_EMOTE_ANIM &&
+      !LOOPING_EMOTE_ANIMS.has(interactionAnim ?? '')
     newAction.reset()
     newAction.loop = playOnce ? THREE.LoopOnce : THREE.LoopRepeat
     newAction.clampWhenFinished = playOnce
@@ -932,7 +937,9 @@
       // Pickup, the fishing cast, and one-shot emotes are interactions
       // remote players end on their own rather than waiting a round-trip for
       // StopInteraction, so the finish callback must fire for remotes too.
-      // Held poses (bench, forge) keep waiting for their StopInteraction.
+      // Held poses (bench, forge) and looping emotes keep waiting for their
+      // StopInteraction — a looping clip never "finishes".
+      !LOOPING_EMOTE_ANIMS.has(interactionAnim) &&
       (isCurrentPlayer ||
         interactionAnim === 'pickup' ||
         interactionAnim === FishingAnimationName.CAST ||

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -92,6 +92,7 @@ import {
 import { refreshBardZone } from '../managers/bardZone'
 import {
   emoteRequest,
+  LOOPING_EMOTE_ANIMS,
   MUSIC_EMOTE_ANIM,
   ONE_SHOT_EMOTE_ANIMS,
 } from '../stores/emoteStore'
@@ -1018,7 +1019,11 @@ export function handleServerMessage(
       if (state.currentPlayer?.id === data.player_id) {
         // Our own /emote went to the server unresolved; this broadcast is
         // its reply, the way PlayerMusicStarted starts /play_music.
-        if (data.object_type && ONE_SHOT_EMOTE_ANIMS.has(data.object_type)) {
+        if (
+          data.object_type &&
+          (ONE_SHOT_EMOTE_ANIMS.has(data.object_type) ||
+            LOOPING_EMOTE_ANIMS.has(data.object_type))
+        ) {
           emoteRequest.set(data.object_type)
         }
         break

--- a/client/src/lib/stores/emoteStore.ts
+++ b/client/src/lib/stores/emoteStore.ts
@@ -19,3 +19,7 @@ export const MUSIC_EMOTE_ANIM = 'guitar_playing'
 /** One-shot clips `/emote <name>` plays. Must match `ONE_SHOT_EMOTES` in
  *  `shared/src/messages.rs` — the server validates the command against it. */
 export const ONE_SHOT_EMOTE_ANIMS = new Set(['excited', 'clap'])
+
+/** Clips `/emote <name>` loops until the player moves or presses Escape.
+ *  Must match `LOOPING_EMOTES` in `shared/src/messages.rs`. */
+export const LOOPING_EMOTE_ANIMS = new Set(['twist', 'macarena', 'chicken'])

--- a/doc/assets/animation.md
+++ b/doc/assets/animation.md
@@ -38,6 +38,12 @@
   - Excited와 같은 방식: `assets/Clapping.fbx`(버커니어 스킨, 33본)에서 리타겟 →
     `graft-glb-clip.py`로 이식.
 
+- Twist Dance https://www.mixamo.com/#/?query=twist+dance&type=Motion%2CMotionPack (social pack, `twist`, `/emote twist`)
+- Macarena Dance https://www.mixamo.com/#/?query=macarena&type=Motion%2CMotionPack (social pack, `macarena`, `/emote macarena`)
+- Chicken Dance https://www.mixamo.com/#/?query=chicken+dance&type=Motion%2CMotionPack (social pack, `chicken`, `/emote chicken`)
+  - 세 댄스 모두 Without Skin/30fps FBX를 social.glb 스켈레톤으로 리타겟 bake 후
+    `graft-glb-clip.py`로 이식 (2026-08-14).
+
 - Excited https://www.mixamo.com/#/?query=excited&type=Motion%2CMotionPack (social pack, `excited`, `/emote excited`)
   - 예외적으로 Without Skin이 아니라 night_merchant(버커니어) 스킨째 받은 FBX(`assets/Excited.fbx`,
     손가락 본 없는 33본)에서 리타겟했다 — social 팩 스킨 조인트도 33개라 손실 없음.

--- a/server/src/game_state/chat.rs
+++ b/server/src/game_state/chat.rs
@@ -508,9 +508,14 @@ impl super::GameState {
 
     /// `/emote <name>` — like `/play_music` with nothing attached: no object
     /// to claim, no item requirement. A typo or a bare `/emote` gets the list
-    /// back; the client-side flow is documented on `ONE_SHOT_EMOTES`.
+    /// back; the client-side flow is documented on `ONE_SHOT_EMOTES` and
+    /// `LOOPING_EMOTES`.
     async fn play_emote(&self, player_id: &PlayerId, name: &str) {
-        let emotes = onlinerpg_shared::messages::ONE_SHOT_EMOTES;
+        let emotes: Vec<&str> = onlinerpg_shared::messages::ONE_SHOT_EMOTES
+            .iter()
+            .chain(onlinerpg_shared::messages::LOOPING_EMOTES)
+            .copied()
+            .collect();
         if !emotes.contains(&name) {
             self.send_system_message(player_id, format!("Emotes: {}", emotes.join(", ")))
                 .await;

--- a/server/src/game_state/tests/chat_tests.rs
+++ b/server/src/game_state/tests/chat_tests.rs
@@ -1455,11 +1455,46 @@ async fn an_unknown_emote_lists_the_available_ones() {
     match cheerer_rx.try_recv() {
         Ok(ServerMessage::SystemMessage { message }) => {
             assert!(message.contains("excited"), "the list names each emote");
+            assert!(message.contains("twist"), "the list names looping emotes");
         }
         other => panic!("Expected the emote list, got {other:?}"),
     }
     assert!(cheerer_rx.try_recv().is_err());
     assert!(listener_rx.try_recv().is_err());
+}
+
+/// A looping emote is stored and broadcast like a one-shot one; only clients
+/// treat it differently (loop until the dancer moves or presses Escape).
+#[tokio::test]
+async fn a_dance_emote_stores_the_pose_like_any_other() {
+    let game_state = make_test_game_state("emote_dance");
+    let auth = make_test_auth("emote_dance");
+    let dancer_id = pid("dancer");
+    let watcher_id = pid("watcher");
+    game_state.add_player(make_player("dancer", 0.0, 0.0)).await;
+    game_state
+        .add_player(make_player("watcher", 10.0, 0.0))
+        .await;
+    let mut dancer_rx = game_state.register_direct_channel(&dancer_id).await;
+    let mut watcher_rx = game_state.register_direct_channel(&watcher_id).await;
+
+    game_state
+        .send_chat_message(&dancer_id, "/emote macarena".to_string(), &auth)
+        .await;
+
+    for rx in [&mut dancer_rx, &mut watcher_rx] {
+        match rx.try_recv() {
+            Ok(ServerMessage::PlayerInteractionChanged {
+                player_id,
+                object_type,
+            }) => {
+                assert_eq!(player_id, dancer_id);
+                assert_eq!(object_type.as_deref(), Some("macarena"));
+            }
+            other => panic!("Expected the dance pose, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
 }
 
 /// An unknown title is a typo, not a performance: no pose, no tune, and the

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -195,6 +195,12 @@ pub const MUSIC_EMOTE: &str = "guitar_playing";
 /// it ends. Clip names live in `social.glb`.
 pub const ONE_SHOT_EMOTES: &[&str] = &["excited", "clap"];
 
+/// Clips `/emote <name>` loops instead of playing once: the dancer's client
+/// repeats the clip until the player moves or presses Escape, then sends
+/// `StopInteraction` — the held-pose contract of [`MUSIC_EMOTE`], minus the
+/// music. Clip names live in `social.glb`.
+pub const LOOPING_EMOTES: &[&str] = &["twist", "macarena", "chicken"];
+
 /// `message` is `prefix` as a whole slash-command word; returns the trimmed
 /// remainder. Shared because the agent-client types the commands this parses —
 /// the two sides must agree on what counts as the command word.

--- a/tools/blender-scripts/export_animations.py
+++ b/tools/blender-scripts/export_animations.py
@@ -43,6 +43,9 @@ EXPORT_PACKS = {
         "guitar_playing",
         "excited",
         "clap",
+        "twist",
+        "macarena",
+        "chicken",
     ],
     "offhand": [
         "torch_idle1",


### PR DESCRIPTION
## Summary

Wherever players gather, there is now something to do together: dance.
`/emote twist`, `/emote macarena` and `/emote chicken` add three Mixamo
dances to the social pack — anytime, anywhere.

A dance would feel wrong ending after one bar, so these clips loop: the
dancer keeps going until they move or press Escape, reusing the held-pose
contract that `/play_music` already follows (the client keeps the clip
running and sends `StopInteraction` when the player cancels). Short
one-shot gestures like `/emote clap` and `/emote excited` stay exactly as
they were — a clap that loops forever is applause nobody asked for.

Implementation notes:

- `ONE_SHOT_EMOTES` is split into one-shot (`excited`, `clap`) and
  `LOOPING_EMOTES` (`twist`, `macarena`, `chicken`); the server validates
  `/emote` against the union, so `/emote` with a typo lists all five.
- Looping clips play with `LoopRepeat` and are excluded from the
  finished-clip notification, on remote players too — they end only on the
  dancer's `StopInteraction`, like a bench or forge pose.
- Escape ends a running performance (dance or tune) only when the overlay
  stack had nothing to close, so closing windows keeps priority.
- The three clips were retargeted from Mixamo FBX (Without Skin, 30 fps)
  onto the social.glb skeleton and grafted with `tools/graft-glb-clip.py`;
  sources are recorded in `doc/assets/animation.md`, and the social pack
  list in `export_animations.py` now names them so a future pack rebuild
  cannot silently drop them.

## Assets

`social.glb` (394 KB → 779 KB, 5 → 8 clips) is uploaded as a Hugging Face
community PR: https://huggingface.co/datasets/jake-song-openmmo/onlinerpg-assets/discussions/2. `assets.lock` is untouched, as the revision to
pin only exists after that PR merges.

## Testing

- Server: 490 tests passed, including two new ones (the emote list names
  the dances; a dance stores and broadcasts its pose like any other emote)
- Client: `vitest` 443 passed; `eslint`, `prettier --check`, `svelte-check`
  all clean
- Live on a local server: all three dances play; a dance keeps looping past
  its clip length (9.5 s clip observed still dancing at 15 s+); moving and
  Escape both end it; `/emote clap` still plays once

## Preview

<img width="480" height="480" alt="twist dance emote looping in game" src="https://github.com/user-attachments/assets/b832c494-7c35-4b3a-80f4-04a7508dc6b6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
