### PR TITLE
Agent-client LLM chat translation with a configurable history cap

### DIFF
--- a/agent-client/src/openai.rs
+++ b/agent-client/src/openai.rs
@@ -29,7 +29,15 @@ pub struct OpenAiConfig {
     /// budget goes to the reply; "" omits the field for models that reject an
     /// unrecognized value.
     pub reasoning_effort: String,
+    /// Conversation history carried per call, system prompt included.
+    pub max_messages: usize,
 }
+
+/// System prompt plus 20 user/assistant pairs. OpenRouter still uses it.
+pub const DEFAULT_MAX_MESSAGES: usize = 41;
+
+/// Below this the trim would drop the system prompt or the turn being sent.
+const MIN_MAX_MESSAGES: usize = 3;
 
 impl Default for OpenAiConfig {
     fn default() -> Self {
@@ -41,6 +49,7 @@ impl Default for OpenAiConfig {
             max_tokens: 1024,
             temperature: 0.7,
             reasoning_effort: "none".to_string(),
+            max_messages: DEFAULT_MAX_MESSAGES,
         }
     }
 }
@@ -74,6 +83,8 @@ impl OpenAiConfig {
             temperature: self.temperature,
             reasoning_effort: (!self.reasoning_effort.is_empty())
                 .then(|| self.reasoning_effort.clone()),
+            // Clamped, not rejected: a bad value should still start.
+            max_messages: self.max_messages.max(MIN_MAX_MESSAGES),
         })
     }
 }
@@ -88,6 +99,7 @@ pub struct Endpoint {
     pub max_tokens: u32,
     pub temperature: f32,
     pub reasoning_effort: Option<String>,
+    pub max_messages: usize,
 }
 
 #[derive(Serialize)]
@@ -208,11 +220,11 @@ impl LlmBackend for OpenAiInvoker {
             content: content.to_string(),
         });
 
-        // Trim conversation history if it gets too long (keep system + last 20 turns)
-        const MAX_MESSAGES: usize = 41; // system + 20 user/assistant pairs
-        if turn.len() > MAX_MESSAGES {
+        // Keep the system prompt plus the most recent turns, up to the cap.
+        let max_messages = self.endpoint.max_messages.max(MIN_MAX_MESSAGES);
+        if turn.len() > max_messages {
             let system = turn[0].clone();
-            let keep_from = turn.len() - (MAX_MESSAGES - 1);
+            let keep_from = turn.len() - (max_messages - 1);
             turn = std::iter::once(system)
                 .chain(turn[keep_from..].iter().cloned())
                 .collect();
@@ -273,6 +285,20 @@ mod tests {
         }
         .endpoint()
         .is_err());
+    }
+
+    /// The trim subtracts `max_messages - 1` from a Vec length: under 3 that
+    /// underflows a usize and panics mid-turn.
+    #[test]
+    fn max_messages_never_resolves_below_the_trim_floor() {
+        let mut cfg = config("http://host/v1");
+        assert_eq!(cfg.endpoint().unwrap().max_messages, DEFAULT_MAX_MESSAGES);
+        for asked in [0, 1, 2] {
+            cfg.max_messages = asked;
+            assert_eq!(cfg.endpoint().unwrap().max_messages, MIN_MAX_MESSAGES);
+        }
+        cfg.max_messages = 9;
+        assert_eq!(cfg.endpoint().unwrap().max_messages, 9);
     }
 
     #[test]

--- a/agent-client/src/openrouter.rs
+++ b/agent-client/src/openrouter.rs
@@ -52,6 +52,7 @@ pub fn invoker(config: &OpenRouterConfig, system_prompt: String) -> anyhow::Resu
             max_tokens: config.max_tokens,
             temperature: config.temperature,
             reasoning_effort: None,
+            max_messages: crate::openai::DEFAULT_MAX_MESSAGES,
         },
         system_prompt,
     ))

--- a/client/src/lib/translation/chatTranslator.ts
+++ b/client/src/lib/translation/chatTranslator.ts
@@ -2,6 +2,11 @@
 // is auto-detected per message (chat has many speakers, not one fixed
 // source); instances are cached so repeat language pairs/detection don't each
 // pay model-load cost.
+//
+// Electron has no Translator API, so the agent-client answers from its own
+// LLM endpoint and this stays the browser's path.
+
+import { translateViaHost } from './llmTranslator'
 
 export function isTranslatorApiSupported(): boolean {
   return (
@@ -68,6 +73,8 @@ export async function translateChatText(
   text: string,
   targetLanguage: string
 ): Promise<string> {
+  const viaHost = await translateViaHost(text, targetLanguage)
+  if (viaHost !== null) return viaHost
   try {
     const sourceLanguage = await detectLanguage(text)
     if (!sourceLanguage || sourceLanguage === targetLanguage) return text

--- a/client/src/lib/translation/llmTranslator.ts
+++ b/client/src/lib/translation/llmTranslator.ts
@@ -1,0 +1,59 @@
+// Chat translation via the agent-client's configured LLM endpoint, proxied
+// across the iframe boundary.
+
+import { TRANSLATION_LANGUAGES } from '../stores/translationSettings'
+
+const TIMEOUT_MS = 15000
+
+let nextId = 0
+const pending = new Map<number, (text: string | null) => void>()
+let listening = false
+
+function listen() {
+  if (listening) return
+  listening = true
+  window.addEventListener('message', (event: MessageEvent) => {
+    if (event.data?.type !== 'openmmo-translate-result') return
+    const resolve = pending.get(event.data.id)
+    if (!resolve) return
+    pending.delete(event.data.id)
+    resolve(typeof event.data.text === 'string' ? event.data.text : null)
+  })
+}
+
+export function isLlmTranslationAvailable(): boolean {
+  return typeof window !== 'undefined' && window.parent !== window
+}
+
+function labelFor(code: string): string {
+  return TRANSLATION_LANGUAGES.find((l) => l.code === code)?.label ?? code
+}
+
+/** Null means "fall back to the on-device translator". */
+export function translateViaHost(
+  text: string,
+  targetLanguage: string
+): Promise<string | null> {
+  if (!isLlmTranslationAvailable()) return Promise.resolve(null)
+  listen()
+
+  const id = nextId++
+  return new Promise<string | null>((resolve) => {
+    const done = (value: string | null) => {
+      clearTimeout(timer)
+      pending.delete(id)
+      resolve(value)
+    }
+    const timer = setTimeout(() => done(null), TIMEOUT_MS)
+    pending.set(id, done)
+    window.parent.postMessage(
+      {
+        type: 'openmmo-translate',
+        id,
+        text,
+        target: labelFor(targetLanguage),
+      },
+      '*'
+    )
+  })
+}


### PR DESCRIPTION
Visualization Demo: https://tonypa.in/viz/agent-client-llm-changes

1. LLM chat translation in the agent-client – Chat can now be translated via the agent-client's configured LLM endpoint (llmTranslator.ts), falling back to the on-device translator when unavailable.
2. Configurable LLM history cap – The conversation-memory limit is now a max_messages setting (default 41) clamped to a minimum of 3 to prevent a crash, shared by OpenAI and OpenRouter.