### PR TITLE
Make text selection opt-in across the game UI

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -436,6 +436,15 @@
     height: 100dvh;
     overflow: hidden;
     position: relative;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  /* Text entry stays selectable despite the app-wide user-select: none */
+  main :global(input),
+  main :global(textarea) {
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .canvas-layer {

--- a/client/src/lib/components/AnnouncementsPanel.svelte
+++ b/client/src/lib/components/AnnouncementsPanel.svelte
@@ -281,5 +281,7 @@
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
+    user-select: text;
+    -webkit-user-select: text;
   }
 </style>

--- a/client/src/lib/components/ChatPanel.svelte
+++ b/client/src/lib/components/ChatPanel.svelte
@@ -619,6 +619,8 @@
     gap: 5px;
     width: 100%;
     box-sizing: border-box;
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .chat-panel.transcript-faded .tabs,

--- a/client/src/lib/components/ItemTooltip.svelte
+++ b/client/src/lib/components/ItemTooltip.svelte
@@ -57,6 +57,8 @@
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 6px;
     pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
     z-index: 100;
     font-family: 'Courier New', monospace;
     color: #e6edf3;

--- a/client/src/lib/components/LoginScreen.svelte
+++ b/client/src/lib/components/LoginScreen.svelte
@@ -273,6 +273,8 @@
     text-align: center;
     font-family:
       -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .error-message {
@@ -285,6 +287,8 @@
     font-size: 13px;
     font-family:
       -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   @media (max-width: 600px), (max-height: 700px) {

--- a/client/src/text-selection.test.ts
+++ b/client/src/text-selection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { compile } from 'svelte/compiler'
+
+// Text selection is opt-in: <main> disables it app-wide and specific
+// copyable surfaces re-enable it. Pure CSS, so guard the compiled output.
+function compiledCss(relPath: string): string {
+  const file = path.resolve(__dirname, relPath)
+  const source = readFileSync(file, 'utf-8')
+  return compile(source, { filename: file }).css?.code ?? ''
+}
+
+function rule(selector: string, declaration: string): RegExp {
+  return new RegExp(`${selector}[^{]*\\{[^}]*${declaration}`)
+}
+
+describe('app-wide text selection policy', () => {
+  it('disables selection on the app root', () => {
+    const css = compiledCss('./App.svelte')
+    expect(css).toMatch(rule('main\\.svelte-\\S+', 'user-select: none'))
+  })
+
+  it('re-enables selection for text entry in any child component', () => {
+    const css = compiledCss('./App.svelte')
+    expect(css).toMatch(rule('main\\.svelte-\\S+ input', 'user-select: text'))
+    expect(css).toMatch(
+      rule('main\\.svelte-\\S+ textarea', 'user-select: text')
+    )
+  })
+
+  it('keeps the chat transcript copyable', () => {
+    const css = compiledCss('./lib/components/ChatPanel.svelte')
+    expect(css).toMatch(rule('\\.chat-messages', 'user-select: text'))
+  })
+
+  it('keeps announcement bodies copyable', () => {
+    const css = compiledCss('./lib/components/AnnouncementsPanel.svelte')
+    expect(css).toMatch(rule('\\.body', 'user-select: text'))
+  })
+
+  it('keeps login error messages copyable', () => {
+    const css = compiledCss('./lib/components/LoginScreen.svelte')
+    expect(css).toMatch(rule('\\.kicked-message', 'user-select: text'))
+    expect(css).toMatch(rule('\\.error-message', 'user-select: text'))
+  })
+
+  it('keeps the body-mounted item tooltip unselectable', () => {
+    const css = compiledCss('./lib/components/ItemTooltip.svelte')
+    expect(css).toMatch(rule('\\.tooltip', 'user-select: none'))
+  })
+})


### PR DESCRIPTION
## Summary

Dragging the mouse over UI panels — inventory, character panel, HUD, even the login screen — started a browser text selection, painting labels and numbers with selection highlight as if the game were a document.

The codebase had no app-wide selection policy: a handful of components opted out individually (`WorldMapDialog`, `FishingPrompt`, the map-editor panels), and every other panel was left selectable. Inventory felt intermittent because drags starting on an item cell are suppressed by the pointer-drag path (`preventDefault` in `onPointerDown`), while drags starting on empty cells, headers, or labels were not.

## Fix

Selection is now opt-in: the app root disables it once, and the few surfaces where copying text is a real use case re-enable it.

- `App.svelte` — `user-select: none` on `<main>` (inherited by every screen and panel), with `input`/`textarea` re-enabled globally so text entry keeps native selection on WebKit.
- `ChatPanel.svelte` — the chat transcript stays copyable.
- `AnnouncementsPanel.svelte` — announcement bodies (event notices, coupon codes) stay copyable.
- `LoginScreen.svelte` — kicked/error messages stay copyable; that is exactly the text users paste into bug reports.
- `ItemTooltip.svelte` — the one body-mounted element (outside `<main>`) gets its own `user-select: none`.

The right-click copy menu exemption from #101 keeps working on the surfaces above; everywhere else a selection can no longer exist, which is the point of the change. Pre-existing per-component `user-select: none` rules are left in place (now redundant, harmless). No server changes.

## Regression guard

`text-selection.test.ts` compiles the touched components with `svelte/compiler` and asserts the compiled CSS contains the root opt-out and each opt-in, so silently deleting an exception (breaking chat copy or iOS text entry) fails the suite.

## Testing

- `vitest` 459 passed (453 existing + 6 new); `eslint`, `prettier --check`, `svelte-check` all clean
- Live on a local server: drags across the inventory (empty cells), character panel stats, and the login screen select nothing; dragging the chat log still selects and copies the message; item drag (bag → quickslot registration) and chat input (including Korean IME composition) unaffected

## Before

<img width="1571" height="1100" alt="character panel fully highlighted by a single drag" src="https://github.com/user-attachments/assets/5ca8315c-5ecf-4b0e-a7d9-b88c729e044e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
