### PR TITLE
Draggable hud panels

### DIFF
--- a/client/src/lib/actions/draggablePanel.ts
+++ b/client/src/lib/actions/draggablePanel.ts
@@ -1,0 +1,126 @@
+import {
+  clampPanelPos,
+  panelLayout,
+  panelZ,
+  raisePanel,
+  savePanelPos,
+  type PanelId,
+  type PanelPos,
+} from '../stores/panelLayout'
+
+const DRAG_THRESHOLD_SQ = 16
+
+/**
+ * Makes a `position: fixed` HUD panel draggable by its `[data-drag-handle]`
+ * descendant, persisting position and stacking order.
+ *
+ * A press on a button inside the handle never starts a drag, so the existing
+ * close/collapse buttons keep behaving exactly as before. The panel's CSS
+ * position (including `right` and `translateY`) is only overridden once the
+ * panel has actually been moved.
+ */
+export function draggablePanel(node: HTMLElement, id: PanelId) {
+  const handle = node.querySelector<HTMLElement>('[data-drag-handle]')
+  if (!handle) return
+
+  handle.style.touchAction = 'none'
+  handle.style.cursor = 'grab'
+  // Otherwise dragging selects the title text instead of moving the panel.
+  handle.style.userSelect = 'none'
+
+  let stored: PanelPos | undefined
+  let dragging = false
+
+  function place(x: number, y: number) {
+    node.style.left = `${x}px`
+    node.style.top = `${y}px`
+    node.style.right = 'auto'
+    node.style.transform = 'none'
+  }
+
+  function apply() {
+    if (dragging) return
+    if (!stored) {
+      node.style.left = ''
+      node.style.top = ''
+      node.style.right = ''
+      node.style.transform = ''
+      return
+    }
+    const rect = node.getBoundingClientRect()
+    const { x, y } = clampPanelPos(
+      stored,
+      rect,
+      window.innerWidth,
+      window.innerHeight
+    )
+    place(x, y)
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return
+    if ((e.target as HTMLElement).closest('button')) return
+
+    raisePanel(id)
+    // Anchor on the on-screen rect so handing over from the CSS defaults
+    // (right / translateY) causes no visual jump.
+    const rect = node.getBoundingClientRect()
+    place(rect.left, rect.top)
+
+    const startX = e.clientX
+    const startY = e.clientY
+    let moved = false
+    let last: PanelPos = { x: rect.left, y: rect.top }
+
+    function onMove(me: PointerEvent) {
+      const dx = me.clientX - startX
+      const dy = me.clientY - startY
+      if (!moved && dx * dx + dy * dy < DRAG_THRESHOLD_SQ) return
+      moved = true
+      dragging = true
+      last = clampPanelPos(
+        { x: rect.left + dx, y: rect.top + dy },
+        rect,
+        window.innerWidth,
+        window.innerHeight
+      )
+      // Compositor-only move: no layout pass while the 3D scene keeps rendering.
+      node.style.transform = `translate3d(${last.x - rect.left}px, ${
+        last.y - rect.top
+      }px, 0)`
+    }
+
+    function onUp() {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      dragging = false
+      if (moved) {
+        place(last.x, last.y)
+        savePanelPos(id, last)
+      }
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+  }
+
+  const unsubscribe = panelLayout.subscribe((layout) => {
+    stored = layout.pos[id]
+    const z = panelZ(layout.order, id)
+    node.style.zIndex = z === null ? '' : String(z)
+    apply()
+  })
+
+  handle.addEventListener('pointerdown', onPointerDown)
+  window.addEventListener('resize', apply)
+
+  return {
+    destroy() {
+      unsubscribe()
+      handle.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('resize', apply)
+    },
+  }
+}

--- a/client/src/lib/components/CharacterPanel.svelte
+++ b/client/src/lib/components/CharacterPanel.svelte
@@ -24,6 +24,7 @@
     FALLBACK_ICON,
   } from '../stores/dragStore'
   import { itemTooltip } from '../actions/itemTooltip'
+  import { draggablePanel } from '../actions/draggablePanel'
   import CharacterStatusPane from './CharacterStatusPane.svelte'
   import {
     characterPanelTab,
@@ -199,8 +200,13 @@
 </script>
 
 {#if visible}
-  <div class="character-panel" role="dialog" aria-label="Character">
-    <div class="panel-header">
+  <div
+    class="character-panel"
+    role="dialog"
+    aria-label="Character"
+    use:draggablePanel={'character'}
+  >
+    <div class="panel-header" data-drag-handle>
       <span class="panel-title">{name}</span>
       <span class="panel-class">{classLabel}</span>
       <button class="close-btn" onclick={onClose}>&times;</button>

--- a/client/src/lib/components/FriendPanel.svelte
+++ b/client/src/lib/components/FriendPanel.svelte
@@ -11,6 +11,7 @@
   } from '../stores/friendStore'
   import { networkManager } from '../network/socket'
   import { requestChatDraft } from '../stores/npcMenuStore'
+  import { draggablePanel } from '../actions/draggablePanel'
 
   const visible = $derived($friendPanelVisible)
   const friends = $derived(sortFriends($friendList, $onlineFriends))
@@ -40,8 +41,8 @@
 </script>
 
 {#if visible}
-  <div class="friend-panel" aria-label="Friends">
-    <div class="panel-header">
+  <div class="friend-panel" aria-label="Friends" use:draggablePanel={'friends'}>
+    <div class="panel-header" data-drag-handle>
       <span class="panel-title">Friends</span>
       <span class="friend-count">{friends.length}/{MAX_FRIENDS}</span>
       <button

--- a/client/src/lib/components/InventoryPanel.svelte
+++ b/client/src/lib/components/InventoryPanel.svelte
@@ -24,6 +24,7 @@
   import QuantityPopup from './QuantityPopup.svelte'
   import { playerTrade, reservedQuantity } from '../stores/playerTradeStore'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { draggablePanel } from '../actions/draggablePanel'
 
   interface Props {
     visible: boolean
@@ -253,8 +254,9 @@
     aria-label="Inventory"
     data-panel="inventory"
     bind:this={panelEl}
+    use:draggablePanel={'inventory'}
   >
-    <div class="panel-header">
+    <div class="panel-header" data-drag-handle>
       <span class="panel-title">Inventory</span>
       <span class="gold-display"><GoldAmount copper={$playerGold} /></span>
       <span class="weight-display">

--- a/client/src/lib/components/PartyPanel.svelte
+++ b/client/src/lib/components/PartyPanel.svelte
@@ -8,6 +8,7 @@
   import { gameStore } from '../stores/gameStore'
   import { npcContextMenu, type NpcMenuEntry } from '../stores/npcMenuStore'
   import { networkManager } from '../network/socket'
+  import { draggablePanel } from '../actions/draggablePanel'
 
   const roster = $derived($partyRoster)
   const selfId = $derived($gameStore.currentPlayer?.id)
@@ -70,8 +71,8 @@
 </script>
 
 {#if roster}
-  <div class="party-panel" aria-label="Party">
-    <div class="party-header">
+  <div class="party-panel" aria-label="Party" use:draggablePanel={'party'}>
+    <div class="party-header" data-drag-handle>
       <span class="party-title">
         PARTY
         <span class="party-count">

--- a/client/src/lib/components/SettingsPanel.svelte
+++ b/client/src/lib/components/SettingsPanel.svelte
@@ -14,6 +14,7 @@
   import ToggleSwitch from './ToggleSwitch.svelte'
   import { friendOnlineNoticeEnabled } from '../stores/friendStore'
   import { mountOverlay } from '../stores/overlayStack'
+  import { resetPanelLayout } from '../stores/panelLayout'
 
   interface Props {
     onClose: () => void
@@ -80,6 +81,14 @@
         >
       </div>
     {/if}
+
+    <div class="setting-row">
+      <span class="setting-label">
+        UI Layout
+        <span class="setting-hint">Panel positions</span>
+      </span>
+      <button class="quality-btn" onclick={resetPanelLayout}>Reset</button>
+    </div>
 
     <div class="divider"></div>
 

--- a/client/src/lib/stores/panelLayout.test.ts
+++ b/client/src/lib/stores/panelLayout.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { clampPanelPos, panelZ, parseLayout } from './panelLayout'
+
+const SIZE = { width: 364, height: 600 }
+
+describe('parseLayout', () => {
+  it('falls back to empty on missing or corrupt storage', () => {
+    const empty = { pos: {}, order: [] }
+    expect(parseLayout(null)).toEqual(empty)
+    expect(parseLayout('{oops')).toEqual(empty)
+    expect(parseLayout('"a string"')).toEqual(empty)
+  })
+
+  it('drops unknown ids, duplicates and non-numeric positions', () => {
+    const raw = JSON.stringify({
+      pos: {
+        character: { x: 5, y: 6 },
+        bogus: { x: 1, y: 2 },
+        party: { x: 'a' },
+      },
+      order: ['party', 'party', 'nope', 'character'],
+    })
+    expect(parseLayout(raw)).toEqual({
+      pos: { character: { x: 5, y: 6 } },
+      order: ['party', 'character'],
+    })
+  })
+})
+
+describe('clampPanelPos', () => {
+  it('leaves an on-screen position alone', () => {
+    expect(clampPanelPos({ x: 100, y: 200 }, SIZE, 1920, 1080)).toEqual({
+      x: 100,
+      y: 200,
+    })
+  })
+
+  it('keeps a grabbable sliver on each edge', () => {
+    expect(clampPanelPos({ x: -9999, y: 0 }, SIZE, 1920, 1080).x).toBe(
+      48 - SIZE.width
+    )
+    expect(clampPanelPos({ x: 9999, y: 0 }, SIZE, 1920, 1080).x).toBe(1920 - 48)
+  })
+
+  it('never lets the header leave the viewport vertically', () => {
+    expect(clampPanelPos({ x: 0, y: -50 }, SIZE, 1920, 1080).y).toBe(0)
+    expect(clampPanelPos({ x: 0, y: 9999 }, SIZE, 1920, 1080).y).toBe(1080 - 28)
+  })
+
+  it('stays non-negative on a viewport shorter than the header', () => {
+    expect(clampPanelPos({ x: 0, y: 500 }, SIZE, 320, 20).y).toBe(0)
+  })
+})
+
+describe('panelZ', () => {
+  it('is null until raised, then ranks under the trade windows', () => {
+    expect(panelZ([], 'party')).toBeNull()
+    expect(panelZ(['party', 'character'], 'party')).toBe(41)
+    expect(panelZ(['party', 'character'], 'character')).toBe(42)
+    expect(
+      panelZ(['party', 'character', 'friends', 'inventory'], 'inventory')
+    ).toBeLessThan(45)
+  })
+})

--- a/client/src/lib/stores/panelLayout.ts
+++ b/client/src/lib/stores/panelLayout.ts
@@ -1,0 +1,107 @@
+import { writable } from 'svelte/store'
+
+export type PanelId = 'character' | 'inventory' | 'friends' | 'party'
+
+export interface PanelPos {
+  x: number
+  y: number
+}
+
+export interface PanelLayout {
+  pos: Partial<Record<PanelId, PanelPos>>
+  /** Raise order, bottom first. Only raised panels get an inline z-index. */
+  order: PanelId[]
+}
+
+const STORAGE_KEY = 'hudPanelLayout'
+const PANEL_IDS: PanelId[] = ['character', 'inventory', 'friends', 'party']
+
+/** A dragged-off-screen panel keeps this much of itself grabbable. */
+const MIN_VISIBLE_X = 48
+const HEADER_H = 28
+/** 41..44 stays under the trade windows' z-index 45. */
+const BASE_Z = 41
+
+const EMPTY: PanelLayout = { pos: {}, order: [] }
+
+export function parseLayout(raw: string | null): PanelLayout {
+  if (!raw) return EMPTY
+  try {
+    const data = JSON.parse(raw) as Partial<PanelLayout>
+    const pos: PanelLayout['pos'] = {}
+    for (const id of PANEL_IDS) {
+      const p = data.pos?.[id]
+      if (p && Number.isFinite(p.x) && Number.isFinite(p.y)) {
+        pos[id] = { x: p.x, y: p.y }
+      }
+    }
+    const order = Array.isArray(data.order)
+      ? data.order.filter(
+          (id, i, all) => PANEL_IDS.includes(id) && all.indexOf(id) === i
+        )
+      : []
+    return { pos, order }
+  } catch {
+    return EMPTY
+  }
+}
+
+/** Keeps the header row reachable; the rest of the panel may leave the viewport. */
+export function clampPanelPos(
+  pos: PanelPos,
+  size: { width: number; height: number },
+  viewportWidth: number,
+  viewportHeight: number
+): PanelPos {
+  return {
+    x: Math.min(
+      Math.max(pos.x, MIN_VISIBLE_X - size.width),
+      viewportWidth - MIN_VISIBLE_X
+    ),
+    y: Math.min(Math.max(pos.y, 0), Math.max(0, viewportHeight - HEADER_H)),
+  }
+}
+
+/** null for a panel that was never raised: it keeps its CSS z-index. */
+export function panelZ(order: PanelId[], id: PanelId): number | null {
+  const index = order.indexOf(id)
+  return index < 0 ? null : BASE_Z + index
+}
+
+function load(): PanelLayout {
+  try {
+    return parseLayout(localStorage.getItem(STORAGE_KEY))
+  } catch {
+    return EMPTY
+  }
+}
+
+export const panelLayout = writable<PanelLayout>(load())
+
+panelLayout.subscribe((layout) => {
+  try {
+    if (layout.order.length === 0 && Object.keys(layout.pos).length === 0) {
+      localStorage.removeItem(STORAGE_KEY)
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(layout))
+    }
+  } catch {
+    // unavailable storage; the layout just won't persist
+  }
+})
+
+export function savePanelPos(id: PanelId, pos: PanelPos) {
+  panelLayout.update((l) => ({ ...l, pos: { ...l.pos, [id]: pos } }))
+}
+
+export function raisePanel(id: PanelId) {
+  panelLayout.update((l) =>
+    l.order.at(-1) === id
+      ? l
+      : { ...l, order: [...l.order.filter((o) => o !== id), id] }
+  )
+}
+
+export function resetPanelLayout() {
+  panelLayout.set(EMPTY)
+}


### PR DESCRIPTION
Character, Inventory and Friends can be dragged by their title bars.
Positions and stacking order persist in localStorage, and Settings gets a
Reset that returns everything to the default layout.

## Screenshots

Draggable panels

<img width="2730" height="1742" alt="Xnip2026-08-18_23-53-53" src="https://github.com/user-attachments/assets/8d6c0410-3cd6-4407-a1e4-6939b082ba4b" />

Reset UI

<img width="1290" height="1290" alt="Xnip2026-08-18_23-55-17" src="https://github.com/user-attachments/assets/0521d7d8-0ecb-4618-81a1-3f8cf15df764" />
