### PR TITLE
Let agent NPCs sprint by default, with a per-action opt-out

### DIFF
--- a/agent-client/data/config.toml.example
+++ b/agent-client/data/config.toml.example
@@ -48,6 +48,11 @@ activity_window_secs = 30                   # How long after last activity to st
 # and an NPC nobody can see has no one to act for. Set per NPC to override.
 # always_active = true
 
+# Sprint on every walk while well fed (default). Off walks everywhere, which
+# costs far less satiation. Individual actions can still opt out with
+# "sprint": false.
+# always_sprint = true
+
 # LLM Scheduler: controls concurrent LLM calls across all NPCs
 max_concurrent = 2                          # Max simultaneous LLM calls (min 1, default 2)
 request_timeout_secs = 120                  # Give up on one call (0 = never); applies to every

--- a/agent-client/src/driver/action.rs
+++ b/agent-client/src/driver/action.rs
@@ -22,6 +22,9 @@ pub(super) enum AgentAction {
             alias = "id"
         )]
         monster_id: String,
+        /// Unset = the agent's `always_sprint` default; false walks instead.
+        #[serde(default)]
+        sprint: Option<bool>,
     },
     #[serde(rename = "move")]
     Move {
@@ -42,6 +45,9 @@ pub(super) enum AgentAction {
         // which is how the agent enters and descends a dungeon.
         #[serde(alias = "dungeon_depth", alias = "floor", alias = "floor_level")]
         depth: Option<i32>,
+        /// Unset = the agent's `always_sprint` default; false walks instead.
+        #[serde(default)]
+        sprint: Option<bool>,
     },
     /// Keep following a character: re-approach whenever they move, until the
     /// LLM issues anything else that walks us somewhere, or the target is lost.
@@ -49,6 +55,9 @@ pub(super) enum AgentAction {
     Follow {
         #[serde(alias = "player", alias = "name", alias = "character")]
         target: String,
+        /// Unset = the agent's `always_sprint` default; false walks instead.
+        #[serde(default)]
+        sprint: Option<bool>,
     },
     #[serde(rename = "respawn")]
     Respawn,
@@ -208,6 +217,9 @@ pub(super) enum AgentAction {
             alias = "target"
         )]
         item: PickupRef,
+        /// Unset = the agent's `always_sprint` default; false walks instead.
+        #[serde(default)]
+        sprint: Option<bool>,
     },
     /// Sell one or more units of a bag item to a nearby merchant, walking up
     /// to them first. The server owns pricing, proximity and wallet checks.
@@ -338,7 +350,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         aliases: &[],
         doc: r#"- Attack a monster:
   {"type": "attack", "target": "m2_1"}
-  You walk into range first, then strike."#,
+  You walk into range first, then strike. Add "sprint": false to walk that
+  approach instead of sprinting it:
+  {"type": "attack", "target": "m2_1", "sprint": false}"#,
     },
     ActionSpec {
         names: &["follow"],
@@ -348,7 +362,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   {"type": "follow", "target": "PlayerName"}
   Any other action that takes your body over — a move, attack, pickup, chest,
   trade or fishing — stops the follow. Losing them ends it with a
-  [FollowEnded] event."#,
+  [FollowEnded] event. Add "sprint": false to pace yourself behind someone
+  who is walking:
+  {"type": "follow", "target": "PlayerName", "sprint": false}"#,
     },
     ActionSpec {
         names: &["move"],
@@ -369,6 +385,12 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   stay where you are.
   Never copy a character's coordinates into a move — use their name, or you
   walk right into them.
+
+  You sprint by default whenever you are well fed, which is half again as
+  fast as walking. Sprinting burns satiation about 30 times faster than
+  walking does, and stops on its own once you are no longer well fed. On a
+  long journey you may prefer to save the food — add "sprint": false to walk:
+  {"type": "move", "x": 10.0, "z": -5.0, "sprint": false}
 
 - Go into a dungeon. The world state names each entrance and how far away it
   is. Name the dungeon and the floor you want with "depth" — 1 is the first
@@ -431,7 +453,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
   {"type": "pickup", "target": 6043}
   The world state marks who put an item down ("dropped by Mira"); a
   [GroundItem] event tells you when someone collects such an item, and an
-  item that is no longer listed is gone — don't reach for bare ground."#,
+  item that is no longer listed is gone — don't reach for bare ground.
+  A few steps rarely justify the hunger; add "sprint": false to walk:
+  {"type": "pickup", "target": 6043, "sprint": false}"#,
     },
     ActionSpec {
         names: &["open_chest"],
@@ -1144,7 +1168,7 @@ pub(super) fn action_to_command(
         AgentAction::Say { message } => Some(ClientMessage::ChatMessage {
             message: message.clone(),
         }),
-        AgentAction::Attack { monster_id } => Some(ClientMessage::PlayerAttack {
+        AgentAction::Attack { monster_id, .. } => Some(ClientMessage::PlayerAttack {
             monster_id: monster_id.clone(),
         }),
         AgentAction::Move {
@@ -1155,6 +1179,7 @@ pub(super) fn action_to_command(
             direction,
             distance,
             depth,
+            ..
         } => {
             // Name-targeted and dungeon-floor moves need SharedState (name
             // resolution, layouts); handled in `execute::handle_response`.
@@ -1264,6 +1289,50 @@ mod tests {
         let turn = parse_turn_tolerant(json).unwrap();
         assert!(turn.errors.is_empty(), "{:?}", turn.errors);
         turn.actions.into_iter().next().unwrap()
+    }
+
+    /// "Unset" must stay distinguishable from `false`: only the former takes
+    /// the agent's default.
+    #[test]
+    fn the_sprint_opt_out_parses_on_every_walking_action() {
+        let sprint_of = |json: &str| match parse_single_action(json) {
+            AgentAction::Move { sprint, .. }
+            | AgentAction::Attack { sprint, .. }
+            | AgentAction::Pickup { sprint, .. }
+            | AgentAction::Follow { sprint, .. } => sprint,
+            other => panic!("expected a walking action for {json}, got {other:?}"),
+        };
+
+        for (bare, opted_out) in [
+            (
+                r#"{"actions": [{"type": "move", "x": 1.0, "z": 2.0}]}"#,
+                r#"{"actions": [{"type": "move", "x": 1.0, "z": 2.0, "sprint": false}]}"#,
+            ),
+            (
+                r#"{"actions": [{"type": "attack", "target": "m2_1"}]}"#,
+                r#"{"actions": [{"type": "attack", "target": "m2_1", "sprint": false}]}"#,
+            ),
+            (
+                r#"{"actions": [{"type": "pickup", "target": 6043}]}"#,
+                r#"{"actions": [{"type": "pickup", "target": 6043, "sprint": false}]}"#,
+            ),
+            (
+                r#"{"actions": [{"type": "follow", "target": "Karl"}]}"#,
+                r#"{"actions": [{"type": "follow", "target": "Karl", "sprint": false}]}"#,
+            ),
+        ] {
+            assert_eq!(sprint_of(bare), None, "{bare}");
+            assert_eq!(sprint_of(opted_out), Some(false), "{opted_out}");
+        }
+    }
+
+    /// The prompt must state the default speed, or the LLM cannot weigh travel
+    /// time against the food it costs.
+    #[test]
+    fn the_action_reference_explains_the_default_movement_speed() {
+        let reference = action_reference();
+        assert!(reference.contains("sprint by default"), "{reference}");
+        assert!(reference.contains(r#""sprint": false"#), "{reference}");
     }
 
     #[test]
@@ -1554,7 +1623,7 @@ mod tests {
             r#"{"actions": [{"type": "loot", "instance_id": 6043}]}"#,
             r#"{"actions": [{"type": "pick_up", "id": 6043}]}"#,
         ] {
-            let AgentAction::Pickup { item } = parse_single_action(json) else {
+            let AgentAction::Pickup { item, .. } = parse_single_action(json) else {
                 panic!("expected Pickup for {json}");
             };
             assert!(matches!(item, PickupRef::Id(6043)), "for {json}");
@@ -1684,7 +1753,7 @@ mod tests {
     /// or quoted — the same tolerance move targets already had.
     #[test]
     fn pickup_and_break_prop_tolerate_float_and_quoted_ids() {
-        let AgentAction::Pickup { item } =
+        let AgentAction::Pickup { item, .. } =
             parse_single_action(r#"{"actions": [{"type": "pickup", "target": 6043.0}]}"#)
         else {
             panic!("expected Pickup");
@@ -1764,7 +1833,7 @@ mod tests {
             r#"{"actions": [{"type": "pickup", "item": "small_sword"}]}"#,
             r#"{"actions": [{"type": "take", "name": "small_sword"}]}"#,
         ] {
-            let AgentAction::Pickup { item } = parse_single_action(json) else {
+            let AgentAction::Pickup { item, .. } = parse_single_action(json) else {
                 panic!("expected Pickup for {json}");
             };
             let PickupRef::Name(name) = item else {
@@ -2219,9 +2288,11 @@ mod tests {
                 direction: None,
                 distance: None,
                 depth: None,
+                sprint: None,
             },
             AgentAction::Attack {
                 monster_id: "m2_1".to_string(),
+                sprint: None,
             },
             AgentAction::Use {
                 item: "torch".to_string(),

--- a/agent-client/src/driver/combat.rs
+++ b/agent-client/src/driver/combat.rs
@@ -25,7 +25,7 @@ const DEFAULT_ATTACK_COOLDOWN_MS: u64 = 1500;
 /// Relative to agent-client working directory.
 const ANIMATION_DURATIONS_PATH: &str = "data/animation_durations.json";
 
-use super::movement::{open_blocking_door, MAX_STEP_DIST, MOVE_SPEED};
+use super::movement::{open_blocking_door, travel_ms, MAX_STEP_DIST};
 
 /// How often to poll when waiting (no active step to send), in ms.
 const CHASE_IDLE_TICK_MS: u64 = 200;
@@ -102,7 +102,7 @@ pub(super) async fn tick_combat(
     monster_id: String,
 ) -> Option<String> {
     // Chase until in range (handles monster movement during chase)
-    match chase_monster(state, &monster_id).await {
+    match chase_monster(state, &monster_id, None).await {
         ChaseResult::InRange => {}
         ChaseResult::Lost(reason) => {
             info!("Combat ended: monster {monster_id} lost during chase ({reason:?})");
@@ -313,8 +313,9 @@ impl std::fmt::Display for ChaseTarget<'_> {
 pub(super) async fn chase_monster(
     state: &Arc<Mutex<SharedState>>,
     monster_id: &str,
+    sprint: Option<bool>,
 ) -> ChaseResult {
-    chase_target(state, &ChaseTarget::Monster(monster_id), false).await
+    chase_target(state, &ChaseTarget::Monster(monster_id), false, sprint).await
 }
 
 /// Walk up to another character and stop APPROACH_RANGE short of them,
@@ -322,8 +323,9 @@ pub(super) async fn chase_monster(
 pub(super) async fn approach_player(
     state: &Arc<Mutex<SharedState>>,
     player_id: &PlayerId,
+    sprint: Option<bool>,
 ) -> ChaseResult {
-    chase_target(state, &ChaseTarget::Player(player_id), false).await
+    chase_target(state, &ChaseTarget::Player(player_id), false, sprint).await
 }
 
 /// The follow task's approach: the same walk, but its steps are background —
@@ -332,8 +334,9 @@ pub(super) async fn approach_player(
 pub(super) async fn follow_player(
     state: &Arc<Mutex<SharedState>>,
     player_id: &PlayerId,
+    sprint: Option<bool>,
 ) -> ChaseResult {
-    chase_target(state, &ChaseTarget::Player(player_id), true).await
+    chase_target(state, &ChaseTarget::Player(player_id), true, sprint).await
 }
 
 /// Walk to a ground item and stop inside pickup range. Same loop as the
@@ -342,8 +345,9 @@ pub(super) async fn follow_player(
 pub(super) async fn walk_to_ground_item(
     state: &Arc<Mutex<SharedState>>,
     instance_id: u64,
+    sprint: Option<bool>,
 ) -> ChaseResult {
-    chase_target(state, &ChaseTarget::GroundItem(instance_id), false).await
+    chase_target(state, &ChaseTarget::GroundItem(instance_id), false, sprint).await
 }
 
 /// Walk to a fixed position on a floor, stopping within `arrive_range` of it.
@@ -352,6 +356,7 @@ pub(super) async fn walk_to_point(
     pos: onlinerpg_shared::Position,
     floor_level: i8,
     arrive_range: f32,
+    sprint: Option<bool>,
 ) -> ChaseResult {
     chase_target(
         state,
@@ -361,6 +366,7 @@ pub(super) async fn walk_to_point(
             arrive_range,
         },
         false,
+        sprint,
     )
     .await
 }
@@ -372,6 +378,7 @@ async fn chase_target(
     state: &Arc<Mutex<SharedState>>,
     target: &ChaseTarget<'_>,
     background: bool,
+    sprint: Option<bool>,
 ) -> ChaseResult {
     let chase_start = Instant::now();
     let mut path_waypoints: Vec<onlinerpg_shared::pathfinding::PathWaypoint> = Vec::new();
@@ -448,7 +455,9 @@ async fn chase_target(
             // fallback below assumes. Unlatch what we can, and give up rather
             // than walk a line through the geometry.
             if underground && !result.found {
-                if doors_opened < MAX_CHASE_DOORS && open_blocking_door(state, background).await {
+                if doors_opened < MAX_CHASE_DOORS
+                    && open_blocking_door(state, background, sprint).await
+                {
                     doors_opened += 1;
                     continue;
                 }
@@ -468,7 +477,7 @@ async fn chase_target(
         // Step toward next waypoint, subdividing long segments so the chase
         // walks at MOVE_SPEED. Fall back to a direct step toward the target
         // if A* returned no path.
-        let step_dist = if path_index < path_waypoints.len() {
+        let (step_dist, sprinting) = if path_index < path_waypoints.len() {
             let wp = path_waypoints[path_index].clone();
             let mut s = state.lock().await;
             let player = match s.self_player.as_ref() {
@@ -479,7 +488,7 @@ async fn chase_target(
 
             if to_wp.dist < 0.1 {
                 path_index += 1;
-                0.0
+                (0.0, false)
             } else {
                 let (step_x, step_z, sd) = if to_wp.dist <= MAX_STEP_DIST {
                     path_index += 1;
@@ -492,35 +501,45 @@ async fn chase_target(
                         MAX_STEP_DIST,
                     )
                 };
-                if let Err(e) = s
-                    .send_step(step_x, step_z, wp.floor, to_wp.rotation(), background)
+                match s
+                    .send_step(
+                        step_x,
+                        step_z,
+                        wp.floor,
+                        to_wp.rotation(),
+                        background,
+                        sprint,
+                    )
                     .await
                 {
-                    error!("Failed to send chase move: {e}");
-                    return ChaseResult::Error;
+                    Ok(sprinting) => (sd, sprinting),
+                    Err(e) => {
+                        error!("Failed to send chase move: {e}");
+                        return ChaseResult::Error;
+                    }
                 }
-                sd
             }
         } else {
             let mut s = state.lock().await;
-            match compute_step_toward(&s, target) {
+            let sprinting = s.sprint_allowed(sprint);
+            match compute_step_toward(&s, target, sprinting) {
                 Some((cmd, sd)) => {
                     if let Err(e) = s.send_flagged_command(cmd, background).await {
                         error!("Failed to send chase move: {e}");
                         return ChaseResult::Error;
                     }
-                    sd
+                    (sd, sprinting)
                 }
-                None => 0.0,
+                None => (0.0, false),
             }
         };
 
-        let travel_ms = if step_dist > 0.0 {
-            ((step_dist / MOVE_SPEED) * 1000.0) as u64
+        let step_ms = if step_dist > 0.0 {
+            travel_ms(step_dist, sprinting)
         } else {
             CHASE_IDLE_TICK_MS
         };
-        tokio::time::sleep(Duration::from_millis(travel_ms.max(50))).await;
+        tokio::time::sleep(Duration::from_millis(step_ms.max(50))).await;
     }
 }
 
@@ -529,7 +548,11 @@ async fn chase_target(
 /// return a path (e.g. target on un-pathable terrain) so the chase can still
 /// inch the player closer at walk speed. Steps stop short of the target by
 /// the tuning's `step_stop_dist`.
-fn compute_step_toward(state: &SharedState, target: &ChaseTarget) -> Option<(ClientMessage, f32)> {
+fn compute_step_toward(
+    state: &SharedState,
+    target: &ChaseTarget,
+    sprinting: bool,
+) -> Option<(ClientMessage, f32)> {
     let target_pos = target.position(state)?;
     let self_player = state.self_player.as_ref()?;
 
@@ -542,15 +565,17 @@ fn compute_step_toward(state: &SharedState, target: &ChaseTarget) -> Option<(Cli
     let target_dist = to_target.dist - stop_dist;
     let step_dist = target_dist.min(MAX_STEP_DIST);
     let ratio = step_dist / to_target.dist;
-    let cmd = ClientMessage::player_move(
-        onlinerpg_shared::Position {
+    let cmd = ClientMessage::PlayerMove {
+        position: onlinerpg_shared::Position {
             x: self_player.position.x + to_target.dx * ratio,
             y: target_pos.y,
             z: self_player.position.z + to_target.dz * ratio,
         },
-        to_target.rotation(),
-        0,
-    );
+        rotation: to_target.rotation(),
+        floor_level: 0,
+        append: false,
+        sprinting,
+    };
     Some((cmd, step_dist))
 }
 

--- a/agent-client/src/driver/execute.rs
+++ b/agent-client/src/driver/execute.rs
@@ -183,7 +183,7 @@ async fn walk_to_sighting(state: &Arc<Mutex<SharedState>>, approach: Option<Appr
         ));
         return;
     };
-    let outcome = match walk_to_point(state, pos, floor, range).await {
+    let outcome = match walk_to_point(state, pos, floor, range, None).await {
         ChaseResult::InRange => format!("[Arrived] You stand next to {what}."),
         ChaseResult::Lost(loss) => {
             format!("[MoveFailed] You did not reach {what} — {}.", loss.clause())
@@ -419,7 +419,7 @@ pub(super) async fn handle_response(
         }
 
         // Keep following a character until something else takes over.
-        if let AgentAction::Follow { target } = action {
+        if let AgentAction::Follow { target, sprint } = action {
             let name = target.trim();
             let target_id = {
                 let mut s = state.lock().await;
@@ -437,10 +437,11 @@ pub(super) async fn handle_response(
             let name = name.to_string();
             let task_state = Arc::clone(state);
             let task_name = name.clone();
+            let sprint = *sprint;
             let handle = tokio::spawn(async move {
                 loop {
                     let before = target_pos(&task_state, &target_id).await;
-                    let ended = match follow_player(&task_state, &target_id).await {
+                    let ended = match follow_player(&task_state, &target_id, sprint).await {
                         ChaseResult::InRange => {
                             tokio::time::sleep(FOLLOW_RECHECK).await;
                             None
@@ -480,9 +481,9 @@ pub(super) async fn handle_response(
         }
 
         // For attack actions, chase the monster and attack
-        if let AgentAction::Attack { monster_id } = action {
+        if let AgentAction::Attack { monster_id, sprint } = action {
             info!("Agent attacking monster {monster_id}, chasing...");
-            match chase_monster(state, monster_id).await {
+            match chase_monster(state, monster_id, *sprint).await {
                 ChaseResult::InRange => {
                     // Face the monster before attacking
                     let mut s = state.lock().await;
@@ -1068,7 +1069,7 @@ pub(super) async fn handle_response(
                 continue;
             };
             let (pos, floor, range) = approach_beside(&prop.position, prop.approach, floor_level);
-            match walk_to_point(state, pos, floor, range).await {
+            match walk_to_point(state, pos, floor, range, None).await {
                 ChaseResult::InRange => {
                     let mut s = state.lock().await;
                     let cmd = onlinerpg_shared::ClientMessage::BreakDungeonProp {
@@ -1119,7 +1120,7 @@ pub(super) async fn handle_response(
                 continue;
             };
             let (pos, floor, range) = approach_beside(&chest.position, chest.approach, chest_floor);
-            match walk_to_point(state, pos, floor, range).await {
+            match walk_to_point(state, pos, floor, range, None).await {
                 ChaseResult::InRange => {
                     let depth = chest_floor.unsigned_abs();
                     let mut s = state.lock().await;
@@ -1164,7 +1165,7 @@ pub(super) async fn handle_response(
         // Pick up a ground item: resolve the reference, walk into pickup
         // range, and send the pickup. The server owns the range, floor and
         // weight checks and answers with InventoryUpdated or a SystemMessage.
-        if let AgentAction::Pickup { item } = action {
+        if let AgentAction::Pickup { item, sprint } = action {
             let resolved = {
                 let s = state.lock().await;
                 resolve_ground_item(&s, item)
@@ -1177,7 +1178,7 @@ pub(super) async fn handle_response(
                 ));
                 continue;
             };
-            match walk_to_ground_item(state, instance_id).await {
+            match walk_to_ground_item(state, instance_id, *sprint).await {
                 ChaseResult::InRange => {
                     let mut s = state.lock().await;
                     // The crouch nearby players see from a web client.
@@ -1233,8 +1234,10 @@ pub(super) async fn handle_response(
             direction,
             distance,
             depth,
+            sprint,
         } = action
         {
+            let sprint = *sprint;
             // A name resolves across every namespace the world state prints,
             // and that decides which mover runs.
             let named = target.as_deref().map(str::trim).filter(|s| !s.is_empty());
@@ -1260,12 +1263,12 @@ pub(super) async fn handle_response(
             match (&resolved, depth) {
                 (Some(MoveTarget::Dungeon { id, .. }), _) => {
                     let goal = resolve_move_goal(x, z, &None, &None, None).ok();
-                    move_to_dungeon_floor(state, *depth, goal, Some(id)).await;
+                    move_to_dungeon_floor(state, *depth, goal, Some(id), sprint).await;
                     continue;
                 }
                 (None, Some(_)) => {
                     let goal = resolve_move_goal(x, z, &None, &None, None).ok();
-                    move_to_dungeon_floor(state, *depth, goal, None).await;
+                    move_to_dungeon_floor(state, *depth, goal, None, sprint).await;
                     continue;
                 }
                 (Some(other), Some(d)) => {
@@ -1285,7 +1288,7 @@ pub(super) async fn handle_response(
                 // Stop a polite distance short instead of pathing onto their
                 // exact position, which would overlap the models.
                 Some(MoveTarget::Character { id, name }) => {
-                    match approach_player(state, &id).await {
+                    match approach_player(state, &id, sprint).await {
                         ChaseResult::InRange => {
                             info!("Agent walked up to {name}");
                             let mut s = state.lock().await;
@@ -1325,7 +1328,7 @@ pub(super) async fn handle_response(
                 }
                 // Walking to a monster is the same chase an attack runs, minus
                 // the swing: it closes the gap so the next attack lands.
-                Some(MoveTarget::Monster { id }) => match chase_monster(state, &id).await {
+                Some(MoveTarget::Monster { id }) => match chase_monster(state, &id, sprint).await {
                     ChaseResult::InRange => {
                         info!("Agent walked up to monster {id}");
                         let mut s = state.lock().await;
@@ -1353,7 +1356,7 @@ pub(super) async fn handle_response(
                     }
                 },
                 Some(MoveTarget::GroundItem { instance_id, name }) => {
-                    match walk_to_ground_item(state, instance_id).await {
+                    match walk_to_ground_item(state, instance_id, sprint).await {
                         ChaseResult::InRange => {
                             info!("Agent walked to ground item {name} [{instance_id}]");
                             let mut s = state.lock().await;
@@ -1407,7 +1410,7 @@ pub(super) async fn handle_response(
                         )
                     };
                     match goal {
-                        Ok((gx, gz)) => match execute_move(state, gx, gz, floor).await {
+                        Ok((gx, gz)) => match execute_move(state, gx, gz, floor, sprint).await {
                             MoveResult::Arrived => {
                                 info!("Agent arrived at ({gx:.1}, {gz:.1})");
                                 let mut s = state.lock().await;
@@ -1573,7 +1576,7 @@ async fn reach_merchant(
         id.map(|id| (id, super::prompt::player_name(&s, &id)))
     };
     let (id, name) = resolved?;
-    match approach_player(state, &id).await {
+    match approach_player(state, &id, None).await {
         ChaseResult::InRange => Some((id, name)),
         ChaseResult::Lost(loss) => {
             let mut s = state.lock().await;
@@ -1601,6 +1604,7 @@ async fn move_to_dungeon_floor(
     depth: Option<i32>,
     goal_xz: Option<(f32, f32)>,
     named: Option<&str>,
+    sprint: Option<bool>,
 ) {
     // No depth means "walk to that entrance and stop there", which only a
     // named dungeon can ask for.
@@ -1671,7 +1675,7 @@ async fn move_to_dungeon_floor(
     if outside || depth.is_none_or(|d| d == 0) {
         let entrance = dungeon.entrance;
         if matches!(
-            execute_move(state, entrance.x, entrance.z, 0).await,
+            execute_move(state, entrance.x, entrance.z, 0, sprint).await,
             MoveResult::Blocked
         ) {
             warn!("Could not reach the {} entrance", dungeon.name);
@@ -1714,7 +1718,7 @@ async fn move_to_dungeon_floor(
     };
     let (gx, gz) = goal_xz.unwrap_or((landing.x, landing.z));
     let floor = dungeon.passability_floor(depth);
-    match execute_move(state, gx, gz, floor).await {
+    match execute_move(state, gx, gz, floor, sprint).await {
         MoveResult::Arrived => {
             info!("Agent reached {} floor {depth}", dungeon.name);
             let mut s = state.lock().await;

--- a/agent-client/src/driver/movement.rs
+++ b/agent-client/src/driver/movement.rs
@@ -22,6 +22,17 @@ use onlinerpg_shared::schedule::resolve_active_schedule;
 
 pub(super) const MOVE_SPEED: f32 = onlinerpg_shared::PLAYER_MOVE_SPEED;
 
+/// How long a step takes at the speed the server actually moves us. Pace a
+/// sprint like a walk and every step leaves from a stale position.
+pub(super) fn travel_ms(step_dist: f32, sprinting: bool) -> u64 {
+    let mult = if sprinting {
+        onlinerpg_shared::hunger::SPRINT_MOVE_MULT
+    } else {
+        1.0
+    };
+    ((step_dist / (MOVE_SPEED * mult)) * 1000.0) as u64
+}
+
 /// Maximum distance per move step (units). Longer segments are subdivided
 /// so the NPC walks at MOVE_SPEED instead of teleporting.
 pub(super) const MAX_STEP_DIST: f32 = 3.0;
@@ -136,7 +147,7 @@ async fn execute_schedule_move(state: &Arc<Mutex<SharedState>>, entry: &Schedule
             wx,
             wz
         );
-        match execute_move(state, wx, wz, entry.floor_level).await {
+        match execute_move(state, wx, wz, entry.floor_level, None).await {
             MoveResult::Arrived => {}
             MoveResult::Blocked => {
                 warn!("Patrol waypoint {i} blocked — skipping ({wx:.1}, {wz:.1})");
@@ -168,7 +179,7 @@ async fn execute_schedule_move(state: &Arc<Mutex<SharedState>>, entry: &Schedule
         s.walkable_near(x, z, entry.floor_level)
     };
 
-    let arrived = match execute_move(state, walk_x, walk_z, entry.floor_level).await {
+    let arrived = match execute_move(state, walk_x, walk_z, entry.floor_level, None).await {
         MoveResult::Arrived => true,
         MoveResult::Blocked => {
             // Force-move to schedule position (e.g. cross-floor moves through
@@ -197,13 +208,14 @@ async fn execute_schedule_move(state: &Arc<Mutex<SharedState>>, entry: &Schedule
         // A forced move can span the whole map; legs keep every target under
         // the server's distance cap so none is silently refused.
         let from = s.self_player.as_ref().map_or(target, |p| p.position);
+        let sprinting = s.sprint_allowed(None);
         for (i, leg) in force_move_legs(&from, target).into_iter().enumerate() {
             let cmd = ClientMessage::PlayerMove {
                 position: leg,
                 rotation: rot_rad,
                 floor_level: entry.floor_level as i8,
                 append: i > 0,
-                sprinting: false,
+                sprinting,
             };
             if let Err(e) = s.send_command(cmd).await {
                 error!("Failed to send schedule move: {e}");
@@ -243,12 +255,13 @@ pub(super) async fn execute_move(
     goal_x: f32,
     goal_z: f32,
     goal_floor: u8,
+    sprint: Option<bool>,
 ) -> MoveResult {
     let mut doors_opened = 0;
     let mut repaths = 0;
     while doors_opened <= MAX_DOORS_PER_MOVE && repaths <= MAX_CORRECTION_REPATHS {
         let before = state.lock().await.position_corrections;
-        match walk_path(state, goal_x, goal_z, goal_floor).await {
+        match walk_path(state, goal_x, goal_z, goal_floor, sprint).await {
             MoveResult::Blocked => {
                 // A refused step is a disagreement with the server, not a shut
                 // door. The correction already resynced our predicted position
@@ -259,7 +272,7 @@ pub(super) async fn execute_move(
                     info!("Re-pathing after a server position correction ({repaths}/{MAX_CORRECTION_REPATHS})");
                     continue;
                 }
-                if !open_blocking_door(state, false).await {
+                if !open_blocking_door(state, false, sprint).await {
                     return MoveResult::Blocked;
                 }
                 doors_opened += 1;
@@ -288,6 +301,7 @@ async fn walk_path(
     goal_x: f32,
     goal_z: f32,
     goal_floor: u8,
+    sprint: Option<bool>,
 ) -> MoveResult {
     let (path_result, start_floor) = {
         let s = state.lock().await;
@@ -315,7 +329,7 @@ async fn walk_path(
         &path_result.waypoints[..keep]
     };
 
-    match walk_waypoints(state, walked, false).await {
+    match walk_waypoints(state, walked, false, sprint).await {
         MoveResult::Arrived if !path_result.found => MoveResult::Blocked,
         other => other,
     }
@@ -328,12 +342,13 @@ async fn walk_waypoints(
     state: &Arc<Mutex<SharedState>>,
     waypoints: &[PathWaypoint],
     background: bool,
+    sprint: Option<bool>,
 ) -> MoveResult {
     let corrections = state.lock().await.position_corrections;
 
     for wp in waypoints {
         loop {
-            let travel_ms = {
+            let step_ms = {
                 let mut s = state.lock().await;
                 // The server snapped us back: this path walks into a step it
                 // refuses, so drop it rather than grind the same wall.
@@ -362,17 +377,26 @@ async fn walk_waypoints(
                     )
                 };
 
-                if let Err(e) = s
-                    .send_step(step_x, step_z, wp.floor, to_wp.rotation(), background)
+                match s
+                    .send_step(
+                        step_x,
+                        step_z,
+                        wp.floor,
+                        to_wp.rotation(),
+                        background,
+                        sprint,
+                    )
                     .await
                 {
-                    error!("Failed to send move waypoint: {e}");
-                    return MoveResult::Error;
+                    Ok(sprinting) => travel_ms(step_dist, sprinting),
+                    Err(e) => {
+                        error!("Failed to send move waypoint: {e}");
+                        return MoveResult::Error;
+                    }
                 }
-                ((step_dist / MOVE_SPEED) * 1000.0) as u64
             };
 
-            tokio::time::sleep(Duration::from_millis(travel_ms.max(50))).await;
+            tokio::time::sleep(Duration::from_millis(step_ms.max(50))).await;
         }
     }
 
@@ -392,7 +416,11 @@ struct DoorCandidate {
 /// unreachable. Covers dungeon corridor doors and house doors alike: a shut
 /// front door leaves a resident NPC with no route out of their own house just
 /// as surely as a shut crypt door hides the stairs down.
-pub(super) async fn open_blocking_door(state: &Arc<Mutex<SharedState>>, background: bool) -> bool {
+pub(super) async fn open_blocking_door(
+    state: &Arc<Mutex<SharedState>>,
+    background: bool,
+    sprint: Option<bool>,
+) -> bool {
     let Some((door, route)) = pick_reachable_door(state).await else {
         return false;
     };
@@ -400,7 +428,7 @@ pub(super) async fn open_blocking_door(state: &Arc<Mutex<SharedState>>, backgrou
     // The probe already proved this route; walk the waypoints it found rather
     // than paying for the same search again.
     if matches!(
-        walk_waypoints(state, &route, background).await,
+        walk_waypoints(state, &route, background, sprint).await,
         MoveResult::Error
     ) {
         return false;
@@ -722,6 +750,19 @@ mod tests {
             Some("bed")
         );
         assert!(s.refuses_play_command("/play_music"));
+    }
+
+    /// Mispaced steps leave from a stale position and get snapped back.
+    #[test]
+    fn a_sprinting_step_is_paced_by_the_sprint_speed() {
+        let walk = travel_ms(MAX_STEP_DIST, false);
+        let sprint = travel_ms(MAX_STEP_DIST, true);
+        assert_eq!(walk, ((MAX_STEP_DIST / MOVE_SPEED) * 1000.0) as u64);
+        assert_eq!(
+            sprint,
+            (walk as f32 / onlinerpg_shared::hunger::SPRINT_MOVE_MULT) as u64
+        );
+        assert!(sprint < walk);
     }
 
     #[test]

--- a/agent-client/src/main.rs
+++ b/agent-client/src/main.rs
@@ -553,6 +553,25 @@ always_active = true
         assert!(config.npcs[2].always_active(), "explicit override wins");
     }
 
+    /// A config that never mentions the key still yields a sprinting agent.
+    #[test]
+    fn agents_sprint_unless_the_config_says_otherwise() {
+        let config = parse(
+            r#"
+server = "ws://127.0.0.1:10006"
+
+[[npcs]]
+account = "npc_runner"
+
+[[npcs]]
+account = "npc_walker"
+always_sprint = false
+"#,
+        );
+        assert!(config.npcs[0].always_sprint, "default");
+        assert!(!config.npcs[1].always_sprint, "explicit override wins");
+    }
+
     /// Every registry NPC must find the prompt files the directory convention
     /// promises. A missing one is a startup crash on the server, in the dark.
     #[test]

--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -71,6 +71,10 @@ pub struct NpcConfig {
     /// default to off: they run on the operator's budget, and an NPC nobody
     /// can see has no one to act for. See `always_active()`.
     pub always_active: Option<bool>,
+    /// Sprint on every walk while well fed. Off makes the agent walk
+    /// everywhere, which costs it far less satiation.
+    #[serde(default = "default_always_sprint")]
+    pub always_sprint: bool,
     #[serde(default)]
     pub claude: ClaudeConfig,
     #[serde(default)]
@@ -100,6 +104,10 @@ pub struct NpcConfig {
     pub favor_file: Option<String>,
     /// Path to schedule file (time-based positioning).
     pub schedule_file: Option<String>,
+}
+
+fn default_always_sprint() -> bool {
+    true
 }
 
 impl NpcConfig {
@@ -456,6 +464,7 @@ async fn run_npc_session(
     )));
     {
         let mut s = state.lock().await;
+        s.always_sprint = npc.always_sprint;
         s.plays_music = npc.plays_music();
         s.keepsake_ids = npc
             .id

--- a/agent-client/src/state/mod.rs
+++ b/agent-client/src/state/mod.rs
@@ -214,6 +214,9 @@ pub struct SharedState {
     /// Items lying on the ground, keyed by instance id (from the join
     /// snapshot plus GroundItemSpawned/Appeared/Removed).
     ground_items: HashMap<u64, GroundItem>,
+    /// From `NpcConfig::always_sprint`; the hunger gate still applies —
+    /// see [`Self::sprint_allowed`].
+    pub always_sprint: bool,
     /// Whether this agent busks, from `NpcConfig::plays_music` — the same
     /// gate that put the songbook and tip rules into its prompt, so it is
     /// never instructed about tips it will not receive.
@@ -355,6 +358,7 @@ impl SharedState {
             merchant_buyback: HashMap::new(),
             nearby_monsters: HashMap::new(),
             ground_items: HashMap::new(),
+            always_sprint: true,
             plays_music: false,
             keepsake_ids: Vec::new(),
             events: Vec::new(),

--- a/agent-client/src/state/movement.rs
+++ b/agent-client/src/state/movement.rs
@@ -278,12 +278,23 @@ impl SharedState {
         }
     }
 
+    /// The action's opt-out over `always_sprint`, then the server's own hunger
+    /// gate (`satiation > NORMAL_MIN`) so both sims agree on our speed. With no
+    /// hunger data yet, let the server judge.
+    pub fn sprint_allowed(&self, requested: Option<bool>) -> bool {
+        requested.unwrap_or(self.always_sprint)
+            && self
+                .self_hunger
+                .is_none_or(|(satiation, _)| satiation > onlinerpg_shared::hunger::NORMAL_MIN)
+    }
+
     /// Send one movement step toward (x, z) on passability floor `floor`,
     /// posed and floor-stamped by `step_pose`. The single way a mover puts a
     /// step on the wire, so none of them can forget to update the floor we
     /// declare — which the server checks our height against. `background` is
     /// for steps no current action asked for (the follow task), which must
-    /// stay out of the action-progress count.
+    /// stay out of the action-progress count. Returns whether the step
+    /// actually sprints, which is what the caller paces the walk by.
     pub async fn send_step(
         &mut self,
         x: f32,
@@ -291,7 +302,8 @@ impl SharedState {
         floor: u8,
         rotation: f32,
         background: bool,
-    ) -> anyhow::Result<()> {
+        sprint: Option<bool>,
+    ) -> anyhow::Result<bool> {
         let current_y = self
             .self_player
             .as_ref()
@@ -299,8 +311,16 @@ impl SharedState {
             .unwrap_or(0.0);
         let (position, floor_level) = self.step_pose(x, z, floor, current_y);
         self.adopt_floor_level(floor_level);
-        let cmd = ClientMessage::player_move(position, rotation, floor_level);
-        self.send_flagged_command(cmd, background).await
+        let sprinting = self.sprint_allowed(sprint);
+        let cmd = ClientMessage::PlayerMove {
+            position,
+            rotation,
+            floor_level,
+            append: false,
+            sprinting,
+        };
+        self.send_flagged_command(cmd, background).await?;
+        Ok(sprinting)
     }
 
     /// Put an entity on the ground of dungeon floor `floor`, leaving it where

--- a/agent-client/src/state/tests/movement_tests.rs
+++ b/agent-client/src/state/tests/movement_tests.rs
@@ -219,3 +219,32 @@ async fn packing_up_before_leaving_folds_our_stall_and_tip_hat() {
         Ok(ClientMessage::UseItem { instance_id: 41 })
     ));
 }
+
+/// Our gate must mirror the server's exactly, boundary included.
+#[tokio::test]
+async fn a_step_sprints_only_while_the_server_would_allow_it() {
+    use onlinerpg_shared::hunger::{hunger_state, NORMAL_MIN};
+
+    let sprinting_at = |satiation: Option<u32>, always: bool, asked: Option<bool>| async move {
+        let (mut s, mut rx) = test_state();
+        s.self_player = Some(test_player(0.0, 0.0));
+        s.always_sprint = always;
+        s.self_hunger = satiation.map(|sat| (sat, hunger_state(sat)));
+        s.send_step(1.0, 0.0, 0, 0.0, false, asked).await.unwrap();
+        match rx.try_recv() {
+            Ok(ClientMessage::PlayerMove { sprinting, .. }) => sprinting,
+            other => panic!("expected a PlayerMove, got {other:?}"),
+        }
+    };
+
+    // Unset takes the agent's default; an override outranks it both ways.
+    assert!(sprinting_at(Some(NORMAL_MIN + 1), true, None).await);
+    assert!(!sprinting_at(Some(NORMAL_MIN + 1), false, None).await);
+    assert!(!sprinting_at(Some(NORMAL_MIN + 1), true, Some(false)).await);
+    assert!(sprinting_at(Some(NORMAL_MIN + 1), false, Some(true)).await);
+    // The server's gate is strict (`> NORMAL_MIN`), so ours is too.
+    assert!(!sprinting_at(Some(NORMAL_MIN), true, Some(true)).await);
+    assert!(!sprinting_at(Some(0), true, Some(true)).await);
+    // Nothing known yet: let the request stand and the server judge it.
+    assert!(sprinting_at(None, true, None).await);
+}


### PR DESCRIPTION
Agent NPCs now sprint by default. Every walking action — move, attack, pickup,
follow — carries an optional "sprint" flag the LLM can set to false to walk
instead, and a per-NPC always_sprint config key sets the default (on unless
turned off). The client mirrors the server's hunger gate exactly, so a step
only sprints while satiation stays above NORMAL_MIN, and step pacing now uses
the sprint speed multiplier — otherwise each step would be sent from a
position the server had already left behind, which the server snaps back.