### PR TITLE
Switch emote animations mid-emote instead of ignoring the new one

### DIFF
--- a/client/src/lib/components/PlayerModel.svelte
+++ b/client/src/lib/components/PlayerModel.svelte
@@ -252,6 +252,7 @@
   let socialClipsByName = new SvelteMap<string, THREE.AnimationClip>()
   let socialLoading = false
   let lastPlayerState: PlayerStateName | undefined
+  let lastInteractionAnim: string | undefined
   let lastAttackCounter: number | undefined
   let dyingFinishedNotified = $state(false)
   let interactionFinishedNotified = $state(false)
@@ -1045,10 +1046,13 @@
     if (validAnimations.length > 0) {
       if (
         lastPlayerState !== playerState ||
+        (playerState === 'interact' &&
+          lastInteractionAnim !== interactionAnim) ||
         (playerState === 'moving' && lastMovementMode !== movementMode) ||
         (playerState === 'attack' && lastAttackCounter !== attackCounter)
       ) {
         lastPlayerState = playerState
+        lastInteractionAnim = interactionAnim
         lastMovementMode = movementMode
         // Assign even when undefined, or the check stays true every frame and
         // the re-trigger pins the clip to frame 0.


### PR DESCRIPTION
## Summary

Issuing `/emote chicken` while `/emote twist` was looping did nothing on
screen: the dancer kept twisting until they moved or pressed Escape, and
only then would the next emote take. The same gap swallowed every
interact-to-interact switch — dance to dance, dance to a one-shot like
`/emote clap`, or into `/play_music`.

The whole pipeline already agreed on the switch. The server overwrites
the stored pose and broadcasts `PlayerInteractionChanged`, the client
stores the new clip name in the player state, and the FSM accepts the
same-state transition. Only the last step — the per-frame check in
`PlayerModel` that decides when to (re)play an animation — watched
nothing but the player-state name, so `interact -> interact` never
re-triggered `playAnimationForState`.

The fix watches `interactionAnim` alongside the state name, the same
pattern `moving` uses for `movementMode` and `attack` uses for
`attackCounter`. The existing 300 ms crossfade makes the switch smooth,
and remote players pick it up too, since the same component renders them.

## Testing

- Client: `vitest` 493 passed; `eslint`, `prettier --check`,
  `svelte-check` all clean
- Live on a local server, before the fix: `/emote chicken` and
  `/emote clap` during a twist were both visibly ignored
- Live after the fix: twist -> clap switches instantly to the standing
  clap; twist -> chicken crossfades straight into the squat-flap loop;
  Escape and click-to-move still end a dance as before
