### PR TITLE
Record the emote panel's two new HUD icons in the UI asset doc

### DIFF
--- a/doc/assets/ui.md
+++ b/doc/assets/ui.md
@@ -4,6 +4,8 @@
 
 - https://icon-sets.iconify.design/fa6-solid/people-group/
 - https://icon-sets.iconify.design/icon-park-solid/backpack/
+- https://icon-sets.iconify.design/fa6-solid/handshake-simple/ — social corner button in GameHud.svelte
+- https://icon-sets.iconify.design/fa6-solid/face-smile/ — Emotes entry in the social flyout, GameHud.svelte
 - GitHub mark (octicon mark-github, MIT) — inline SVG in LoginScreen.svelte
 
 ## Party UI design mockups


### PR DESCRIPTION
Follow-up to #138, answering the review question about the SVG icon sources — and adding the missing doc entries.

Both icons added in #138 come from **Font Awesome 6 Free** (solid style), the same set as the existing HUD icons already listed in `doc/assets/ui.md` (e.g. `fa6-solid/people-group` for Friends):

- `fa6-solid/handshake-simple` — the social corner button
- `fa6-solid/face-smile` — the Emotes entry in the social flyout

Font Awesome Free icons are licensed CC BY 4.0, so there is no licensing concern. I should have recorded them in `ui.md` as part of #138 — sorry for missing that; this PR adds the two entries in the existing format.