### PR TITLE
Show a live character preview beside the emote panel on hover

### DIFF
--- a/client/src/lib/components/EmotePanel.svelte
+++ b/client/src/lib/components/EmotePanel.svelte
@@ -7,10 +7,82 @@
   import { EMOTE_LIST, type EmoteMeta } from '../emote-meta'
   import { gameStore } from '../stores/gameStore'
   import { networkManager } from '../network/socket'
+  import { innerWidth } from 'svelte/reactivity/window'
   import { draggablePanel } from '../actions/draggablePanel'
+  import { panelPositions } from '../stores/panelLayout'
+  import { EMOTE_PANEL_W, previewPlacement } from '../emote-preview-layout'
+  import EmotePreview from './EmotePreview.svelte'
 
   const visible = $derived($emotePanelVisible)
   const active = $derived($localEmoteAnim)
+  const previewPlayer = $derived($gameStore.currentPlayer)
+
+  // Last pointed-at emote; kept playing after the pointer leaves so the
+  // preview never snaps back to an empty box. Cleared on close — the
+  // component itself stays mounted for the whole session.
+  let previewed = $state<EmoteMeta | null>(null)
+  $effect(() => {
+    // Also cleared on death/disconnect, so the box doesn't pop back open
+    // by itself on respawn or reconnect.
+    if (!visible || !usable) previewed = null
+    // Re-evaluate the mount latch per open; deaths keep the device warm.
+    if (!visible) everFit = false
+  })
+
+  // The box hangs off the panel's side. Work out which side has room from
+  // the panel's position and the viewport; with room on neither (narrow
+  // phone viewports), don't mount the preview canvas at all.
+  const placement = $derived(
+    previewPlacement(
+      $panelPositions.emotes?.x ??
+        (innerWidth.current ?? 0) - EMOTE_PANEL_W - 16,
+      innerWidth.current ?? 0
+    )
+  )
+
+  // The store position updates on drag release, so hide the box while the
+  // panel is mid-drag instead of letting it ride off-screen on a stale side.
+  // Mirrors draggablePanel's gesture test (left button, not a header button,
+  // 4px slop) so a plain click never blinks the preview.
+  let draggingPanel = $state(false)
+  let dragPointerId: number | null = null
+  function trackDragStart(node: HTMLElement) {
+    const down = (e: PointerEvent) => {
+      if (e.button !== 0 || dragPointerId !== null) return
+      if ((e.target as HTMLElement).closest('button')) return
+      dragPointerId = e.pointerId
+      const { clientX, clientY } = e
+      const move = (m: PointerEvent) => {
+        if (m.pointerId !== dragPointerId) return
+        const dx = m.clientX - clientX
+        const dy = m.clientY - clientY
+        if (dx * dx + dy * dy >= 16) draggingPanel = true
+      }
+      const up = (u: PointerEvent) => {
+        if (u.pointerId !== dragPointerId) return
+        dragPointerId = null
+        window.removeEventListener('pointermove', move)
+        window.removeEventListener('pointerup', up)
+        window.removeEventListener('pointercancel', up)
+        draggingPanel = false
+      }
+      window.addEventListener('pointermove', move)
+      window.addEventListener('pointerup', up)
+      window.addEventListener('pointercancel', up)
+    }
+    node.addEventListener('pointerdown', down)
+    return { destroy: () => node.removeEventListener('pointerdown', down) }
+  }
+
+  // Mount the preview stack once a fitting position has existed, then keep
+  // it warm; visibility churn (resize, zoom, drags across the fit boundary)
+  // only nulls the anim instead of rebuilding the WebGPU canvas.
+  let everFit = $state(false)
+  $effect(() => {
+    // Reads `visible` so the latch re-evaluates on every reopen, not only
+    // when the placement inputs change.
+    if (visible && placement.fits) everFit = true
+  })
   // sendChatMessage is a silent no-op while disconnected; grey out like the
   // chat input does instead of eating clicks. Dead players are greyed out
   // too — the server accepts a corpse's /emote, so the client must not
@@ -33,7 +105,7 @@
 
 {#if visible}
   <div class="emote-panel" aria-label="Emotes" use:draggablePanel={'emotes'}>
-    <div class="panel-header" data-drag-handle>
+    <div class="panel-header" data-drag-handle use:trackDragStart>
       <span class="panel-title">Emotes</span>
       <button
         class="close-btn"
@@ -52,6 +124,8 @@
             ? 'Stop'
             : `/emote ${emote.anim}`}
           onclick={() => play(emote)}
+          onpointerenter={() => (previewed = emote)}
+          onfocus={() => (previewed = emote)}
         >
           <span class="emote-label">{emote.label}</span>
           {#if emote.loops}
@@ -62,6 +136,18 @@
     </div>
 
     <div class="panel-hint">/emote &lt;name&gt; · dances stop on move</div>
+
+    {#if previewPlayer && everFit}
+      <EmotePreview
+        anim={usable && placement.fits && !draggingPanel
+          ? (previewed?.anim ?? null)
+          : null}
+        label={previewed?.label ?? null}
+        characterClass={previewPlayer.characterClass}
+        gender={previewPlayer.gender}
+        side={placement.side}
+      />
+    {/if}
   </div>
 {/if}
 

--- a/client/src/lib/components/EmotePanel.svelte
+++ b/client/src/lib/components/EmotePanel.svelte
@@ -4,7 +4,12 @@
     emoteStopRequest,
     localEmoteAnim,
   } from '../stores/emoteStore'
-  import { EMOTE_LIST, type EmoteMeta } from '../emote-meta'
+  import {
+    EMOTE_LIST,
+    emoteClickCommand,
+    type EmoteIntent,
+    type EmoteMeta,
+  } from '../emote-meta'
   import { gameStore } from '../stores/gameStore'
   import { networkManager } from '../network/socket'
   import { innerWidth } from 'svelte/reactivity/window'
@@ -91,15 +96,26 @@
     $gameStore.isConnected && ($gameStore.currentPlayer?.health ?? 0) > 0
   )
 
+  // Last commanded emote, kept until the server echo confirms it (or a TTL
+  // assumes rejection). See emoteClickCommand.
+  let intent = $state<EmoteIntent | null>(null)
+  $effect(() => {
+    if (intent && active === intent.anim) intent = null
+  })
+
   function play(emote: EmoteMeta) {
     // Clicking the running looping emote stops it, like Escape does.
-    if (emote.loops && active === emote.anim) {
+    if (
+      emoteClickCommand(emote, active, intent, performance.now()) === 'stop'
+    ) {
       emoteStopRequest.set(true)
+      intent = { anim: null, at: performance.now() }
       return
     }
     // Same path as typing the command: the server validates and its
     // broadcast starts our animation (see chat-commands `/emote`).
     networkManager.sendChatMessage(`/emote ${emote.anim}`)
+    intent = { anim: emote.anim, at: performance.now() }
   }
 </script>
 

--- a/client/src/lib/components/EmotePanel.svelte
+++ b/client/src/lib/components/EmotePanel.svelte
@@ -155,7 +155,9 @@
   .emote-panel {
     position: fixed;
     right: 16px;
-    top: 16%;
+    /* Above the HUD corner buttons, so it opens next to the social flyout
+       that summoned it. */
+    bottom: 64px;
     z-index: 40;
     width: 180px;
     display: flex;

--- a/client/src/lib/components/EmotePreview.svelte
+++ b/client/src/lib/components/EmotePreview.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import { devicePixelRatio } from 'svelte/reactivity/window'
+  import EmotePreviewScene from './EmotePreviewScene.svelte'
+  import { createPreviewWebGPURenderer } from '../utils/renderer'
+  import {
+    getEffectivePreset,
+    graphicsQuality,
+  } from '../stores/graphicsSettings'
+  import type { CharacterClass, Gender } from '../network/networkTypes'
+
+  interface Props {
+    anim: string | null
+    label: string | null
+    characterClass: CharacterClass
+    gender: Gender
+    /** Which side of the panel the box hangs off. */
+    side?: 'left' | 'right'
+  }
+
+  let { anim, label, characterClass, gender, side = 'left' }: Props = $props()
+
+  let playing = $state(false)
+
+  // Reactive so browser zoom / DPI moves and quality changes reach the
+  // renderer; Threlte re-applies its dpr prop on every change.
+  const dpr = $derived(
+    Math.min(
+      devicePixelRatio.current ?? window.devicePixelRatio,
+      getEffectivePreset($graphicsQuality).pixelRatioCap
+    )
+  )
+</script>
+
+<!-- Mounted (hidden) as soon as the panel opens so the WebGPU device, GLBs
+     and pipelines are warm before the box first shows. -->
+<div
+  class="emote-preview"
+  class:shown={anim !== null && playing}
+  class:right-side={side === 'right'}
+  aria-hidden="true"
+>
+  <div class="preview-canvas">
+    <Canvas createRenderer={createPreviewWebGPURenderer} {dpr}>
+      <EmotePreviewScene {anim} {characterClass} {gender} bind:playing />
+    </Canvas>
+  </div>
+  {#if label}
+    <div class="preview-label">{label}</div>
+  {/if}
+</div>
+
+<style>
+  .emote-preview {
+    position: absolute;
+    right: calc(100% + 10px);
+    top: 0;
+    width: 170px;
+    display: flex;
+    flex-direction: column;
+    visibility: hidden;
+    backdrop-filter: blur(4px);
+    padding: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    background: rgba(6, 10, 14, 0.88);
+  }
+
+  /* !important: GameHud's `.game-hud :global(*) { pointer-events: auto }`
+   * would otherwise win and turn the (mostly invisible) box into a
+   * click-swallowing dead zone over the world. */
+  .emote-preview,
+  .emote-preview :global(*) {
+    pointer-events: none !important;
+  }
+
+  .emote-preview.right-side {
+    right: auto;
+    left: calc(100% + 10px);
+  }
+
+  .emote-preview.shown {
+    visibility: visible;
+  }
+
+  .preview-canvas {
+    width: 100%;
+    height: 210px;
+  }
+
+  .preview-label {
+    margin-top: 6px;
+    color: #8fe08f;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    font-weight: 700;
+    text-align: center;
+  }
+</style>

--- a/client/src/lib/components/EmotePreviewScene.svelte
+++ b/client/src/lib/components/EmotePreviewScene.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { T, useTask, useThrelte } from '@threlte/core'
+  import * as THREE from 'three'
+  import { PMREMGenerator, type WebGPURenderer } from 'three/webgpu'
+  import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js'
+  import { untrack } from 'svelte'
+  import { SvelteMap } from 'svelte/reactivity'
+  import {
+    computeSoleGroundOffset,
+    createCharacterModelRoot,
+    getGltfAnimations,
+  } from '../utils/characterAnimationUtils'
+  import {
+    CHARACTER_ANIMATION_PACK_PATHS,
+    getCharacterModelPath,
+  } from '../utils/modelPaths'
+  import { getCurrentPreset } from '../stores/graphicsSettings'
+  import { createRenderCadence } from '../utils/renderCadence'
+  import { loadGLB } from '../utils/gltfCache'
+  import type { CharacterClass, Gender } from '../network/networkTypes'
+
+  interface Props {
+    /** Social-pack clip to loop, or null to show nothing. */
+    anim: string | null
+    characterClass: CharacterClass
+    gender: Gender
+    /** True once a clip is actually posing the model, so the wrapper can
+     *  stay hidden through the load window instead of framing an empty box. */
+    playing?: boolean
+  }
+
+  let {
+    anim,
+    characterClass,
+    gender,
+    playing = $bindable(false),
+  }: Props = $props()
+
+  const { renderer: _renderer, scene, invalidate } = useThrelte()
+  const renderer = _renderer as unknown as WebGPURenderer
+
+  const CAMERA_FOV = 32
+  const CAMERA_POSITION: [number, number, number] = [0, 1.05, 3.4]
+  const CAMERA_LOOK_AT_Y = 0.9
+
+  $effect(() => {
+    let envRt: THREE.RenderTarget | null = null
+    let disposed = false
+    renderer.init().then(() => {
+      if (disposed) return
+      const pmremGenerator = new PMREMGenerator(renderer)
+      envRt = pmremGenerator.fromScene(new RoomEnvironment())
+      scene.environment = envRt.texture
+      scene.environmentIntensity = 0.55
+      pmremGenerator.dispose()
+      invalidate()
+    })
+    return () => {
+      disposed = true
+      scene.environment = null
+      envRt?.dispose()
+    }
+  })
+
+  let modelRoot = $state<THREE.Group | null>(null)
+  let mixer = $state<THREE.AnimationMixer | null>(null)
+  let currentAction = $state<THREE.AnimationAction | null>(null)
+  const clipsByName = new SvelteMap<string, THREE.AnimationClip>()
+
+  const modelPath = $derived(getCharacterModelPath(characterClass, gender))
+
+  $effect(() => {
+    const path = modelPath
+    let cancelled = false
+    Promise.all([
+      loadGLB(path),
+      loadGLB(CHARACTER_ANIMATION_PACK_PATHS.social),
+    ]).then(([charGltf, socialGltf]) => {
+      if (cancelled) return
+      for (const clip of getGltfAnimations(socialGltf)) {
+        clipsByName.set(clip.name, clip)
+      }
+      const { modelRoot: root } = createCharacterModelRoot(charGltf.scene)
+      root.position.y = computeSoleGroundOffset(root)
+      mixer = new THREE.AnimationMixer(root)
+      modelRoot = root
+      // One hidden bind-pose frame so the character's pipelines compile
+      // before the wrapper ever becomes visible.
+      invalidate()
+    })
+    return () => {
+      cancelled = true
+      mixer?.stopAllAction()
+      mixer = null
+      currentAction = null
+      modelRoot = null
+      playing = false
+    }
+  })
+
+  $effect(() => {
+    const name = anim
+    if (!name || !mixer || !modelRoot) return
+    const clip = clipsByName.get(name)
+    if (!clip) return
+
+    const action = mixer.clipAction(clip)
+    const previous = untrack(() => currentAction)
+    // A null-anim spell (drag, death) followed by the same clip resumes
+    // where it left off — only a genuinely new clip restarts. Hard switch,
+    // no crossfade: interrupted fades snap to stale weights (three.js
+    // fadeIn/fadeOut hardcode their endpoints), and a preview should show
+    // the hovered emote instantly anyway.
+    if (previous !== action) {
+      previous?.stop()
+      action.reset()
+      action.loop = THREE.LoopRepeat
+      action.play()
+    }
+    // Pose immediately so the first visible frame is mid-clip, not bind pose.
+    mixer.update(0)
+    currentAction = action
+    playing = true
+    invalidate()
+  })
+
+  // Manual invalidation: no anim playing (panel open, nothing hovered yet)
+  // means no renders at all. Steps at the graphics preset's frame cap so
+  // the preview can't out-render the main scene.
+  const cadence = createRenderCadence(getCurrentPreset().maxRenderFps)
+  let pendingDelta = 0
+  useTask(
+    (delta) => {
+      if (!mixer || !currentAction || !anim) return
+      pendingDelta += delta
+      if (!cadence.shouldRender(delta * 1000)) return
+      mixer.update(Math.min(pendingDelta, 0.1))
+      pendingDelta = 0
+      invalidate()
+    },
+    { autoInvalidate: false }
+  )
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  fov={CAMERA_FOV}
+  position={CAMERA_POSITION}
+  oncreate={(cam) => cam.lookAt(0, CAMERA_LOOK_AT_Y, 0)}
+/>
+
+<T.AmbientLight intensity={0.35} />
+<T.DirectionalLight position={[1.5, 3, 2.5]} intensity={1.4} />
+
+{#if modelRoot}
+  <T is={modelRoot} />
+{/if}

--- a/client/src/lib/emote-meta.test.ts
+++ b/client/src/lib/emote-meta.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import { EMOTE_LIST } from './emote-meta'
+import {
+  EMOTE_INTENT_TTL_MS,
+  EMOTE_LIST,
+  emoteClickCommand,
+} from './emote-meta'
 import { LOOPING_EMOTE_ANIMS, ONE_SHOT_EMOTE_ANIMS } from './stores/emoteStore'
 
 // The wire contract lives in shared/src/messages.rs; emoteStore mirrors it by
@@ -41,5 +45,43 @@ describe('emote panel metadata', () => {
       expect(emote.label.length).toBeGreaterThan(0)
       expect(emote.loops).toBe(LOOPING_EMOTE_ANIMS.has(emote.anim))
     }
+  })
+})
+
+describe('emoteClickCommand', () => {
+  const dance = { anim: 'twist', label: 'Twist', loops: true }
+  const other = { anim: 'macarena', label: 'Macarena', loops: true }
+  const oneShot = { anim: 'clap', label: 'Clap', loops: false }
+
+  it('toggles a settled looping emote to stop', () => {
+    expect(emoteClickCommand(dance, 'twist', null, 1000)).toBe('stop')
+    expect(emoteClickCommand(dance, null, null, 1000)).toBe('play')
+  })
+
+  it('plays, not stops, when a different emote was just commanded', () => {
+    // Server echo still says twist, but the player already clicked macarena.
+    const intent = { anim: other.anim, at: 900 }
+    expect(emoteClickCommand(dance, 'twist', intent, 1000)).toBe('play')
+  })
+
+  it('replays an emote the player just stopped despite the stale echo', () => {
+    const intent = { anim: null, at: 900 }
+    expect(emoteClickCommand(dance, 'twist', intent, 1000)).toBe('play')
+  })
+
+  it('stops a re-click of the emote just commanded', () => {
+    const intent = { anim: dance.anim, at: 900 }
+    expect(emoteClickCommand(dance, null, intent, 1000)).toBe('stop')
+  })
+
+  it('falls back to the server echo once the intent expires', () => {
+    const intent = { anim: other.anim, at: 0 }
+    expect(
+      emoteClickCommand(dance, 'twist', intent, EMOTE_INTENT_TTL_MS + 1)
+    ).toBe('stop')
+  })
+
+  it('never stops a one-shot emote', () => {
+    expect(emoteClickCommand(oneShot, 'clap', null, 1000)).toBe('play')
   })
 })

--- a/client/src/lib/emote-meta.ts
+++ b/client/src/lib/emote-meta.ts
@@ -22,3 +22,27 @@ export const EMOTE_LIST: EmoteMeta[] = [...SLASH_EMOTE_ANIMS].map((anim) => ({
   label: labelFor(anim),
   loops: LOOPING_EMOTE_ANIMS.has(anim),
 }))
+
+/** The player's last click — anim they commanded (null = stop) and when. */
+export interface EmoteIntent {
+  anim: string | null
+  at: number
+}
+
+/** After this long an unconfirmed intent is assumed rejected by the server. */
+export const EMOTE_INTENT_TTL_MS = 2000
+
+/** Whether clicking `emote` should stop or play, judged against the last
+ *  commanded intent rather than the server echo — the echo lags a round
+ *  trip, and deciding on stale state turns fast clicks into wrong stops
+ *  (or dead re-stops) while an earlier command is still in flight. */
+export function emoteClickCommand(
+  emote: EmoteMeta,
+  active: string | null,
+  intent: EmoteIntent | null,
+  now: number
+): 'stop' | 'play' {
+  const current =
+    intent && now - intent.at <= EMOTE_INTENT_TTL_MS ? intent.anim : active
+  return emote.loops && current === emote.anim ? 'stop' : 'play'
+}

--- a/client/src/lib/emote-preview-layout.test.ts
+++ b/client/src/lib/emote-preview-layout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { EMOTE_PANEL_W, previewPlacement } from './emote-preview-layout'
+
+/** The panel's default CSS position is `right: 16px`. */
+function defaultPanelLeft(viewportWidth: number): number {
+  return viewportWidth - EMOTE_PANEL_W - 16
+}
+
+describe('previewPlacement', () => {
+  it('hangs left of the default-placed panel on a desktop viewport', () => {
+    expect(previewPlacement(defaultPanelLeft(1920), 1920)).toEqual({
+      side: 'left',
+      fits: true,
+    })
+  })
+
+  it('does not render at all on a phone-width viewport', () => {
+    // 375px iPhone portrait: neither side of the default panel has room.
+    expect(previewPlacement(defaultPanelLeft(375), 375).fits).toBe(false)
+    // The default panel's left side gains room at exactly 415px.
+    expect(previewPlacement(defaultPanelLeft(414), 414).fits).toBe(false)
+    expect(previewPlacement(defaultPanelLeft(415), 415).fits).toBe(true)
+  })
+
+  it('flips right when the panel is dragged against the left edge', () => {
+    expect(previewPlacement(50, 1000)).toEqual({ side: 'right', fits: true })
+  })
+
+  it('refuses the dead band where neither side fits a dragged panel', () => {
+    // 500px window, panel dragged to x=150: left needs 197, right needs 399.
+    expect(previewPlacement(150, 500).fits).toBe(false)
+  })
+
+  it('keeps the left side the moment it has room', () => {
+    expect(previewPlacement(197, 500)).toEqual({ side: 'left', fits: true })
+  })
+})

--- a/client/src/lib/emote-preview-layout.ts
+++ b/client/src/lib/emote-preview-layout.ts
@@ -1,0 +1,21 @@
+/** Border-box width of the emote panel (180 content + 20 padding + 2 border). */
+export const EMOTE_PANEL_W = 202
+/** Width the preview box needs beside the panel (188 border box + 9 offset). */
+export const EMOTE_PREVIEW_W = 197
+
+export interface PreviewPlacement {
+  side: 'left' | 'right'
+  /** False when neither side has room — the preview must not render at all. */
+  fits: boolean
+}
+
+/** Which side of the emote panel the preview box fits on, if any.
+ *  `panelLeft` is the panel's border-box left edge in viewport px. */
+export function previewPlacement(
+  panelLeft: number,
+  viewportWidth: number
+): PreviewPlacement {
+  const fitsLeft = panelLeft >= EMOTE_PREVIEW_W
+  const fitsRight = panelLeft + EMOTE_PANEL_W + EMOTE_PREVIEW_W <= viewportWidth
+  return { side: fitsLeft ? 'left' : 'right', fits: fitsLeft || fitsRight }
+}

--- a/client/src/lib/utils/renderer.ts
+++ b/client/src/lib/utils/renderer.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import { WebGPURenderer } from 'three/webgpu'
 import {
   applyInitialAntialias,
+  getAppliedAntialias,
   getCurrentPreset,
 } from '../stores/graphicsSettings'
 
@@ -36,6 +37,29 @@ export function createWebGPURenderer(canvas: HTMLCanvasElement) {
     } catch {
       // backend not yet initialized — safe to ignore
     }
+  }
+
+  return renderer
+}
+
+/** Renderer for the small secondary preview canvases. Reuses the main
+ *  renderer's applied antialias without re-recording it (that record is
+ *  the main canvas's restart-notice source), and defers a dispose that
+ *  races init() so the GPU device is actually released. The pixel-ratio
+ *  cap must come from the Canvas `dpr` prop — Threlte overwrites anything
+ *  set here. */
+export function createPreviewWebGPURenderer(canvas: HTMLCanvasElement) {
+  const renderer = new WebGPURenderer({
+    canvas,
+    antialias: getAppliedAntialias(),
+  })
+
+  const _origDispose = renderer.dispose.bind(renderer)
+  renderer.dispose = () => {
+    renderer
+      .init()
+      .then(() => _origDispose())
+      .catch(() => {})
   }
 
   return renderer


### PR DESCRIPTION
## Summary

Hovering an emote row now shows the player's own character performing that emote in a small box beside the panel — inspired by the emote previews in Once Human and other MMORPGs. The preview renders the live character model with its equipped look, so what you see is exactly what everyone else will see.

Clicking a row performs the emote for real — the server broadcasts it to everyone nearby. Hovering costs nothing, so a player can check what a dance actually looks like, at portrait scale, before deciding to perform it in public; the top-down camera keeps the in-world character small, so the preview also doubles as a close-up of what everyone else is seeing.

Like the panel itself, the preview is fully derived from the server's emote list: it plays clips from `social.glb` by name, so a new server emote gets a working preview with zero extra client work — no per-emote images to produce or record.

<img width="1553" height="765" alt="Preview box beside the emote panel, playing the Twist dance on the player's own character" src="https://github.com/user-attachments/assets/0d82cdad-2f2c-4b1a-b865-7624eac28586" />

<img width="1553" height="765" alt="Chicken emote clicked: the active row is highlighted and both the preview and the in-world character dance" src="https://github.com/user-attachments/assets/b68584ba-009a-4870-ae5e-be2c788a538c" />

## How it works

- `EmotePreview.svelte` mounts a second small Threlte `<Canvas>` (own WebGPU renderer) inside the panel — the shared main canvas is busy rendering the world, so a self-contained canvas keeps its render pipeline untouched, the same approach `CharacterPreview` takes on the select screen. `EmotePreviewScene.svelte` loads the character model and the social animation pack through the shared GLB cache — everything is already in memory in-game, so there is no extra download.
- Clips play by name on an `AnimationMixer`, same as `PlayerModel` does in-world; one-shots loop in the preview so the motion stays readable.
- The box follows the hovered row, keeps the last emote playing when the pointer leaves, and hides while dead/disconnected or while the panel is being dragged.
- `emote-preview-layout.ts` decides which side of the panel has room (flipping right when the panel is dragged against the left edge) and hides the preview entirely on viewports where neither side fits (< 415 px), where it also skips mounting the canvas at all.

## Performance notes

- The preview renders only while an emote is actually playing (manual invalidation), steps at the graphics preset's frame cap via the shared `createRenderCadence`, and takes its pixel ratio from the preset cap through the Canvas `dpr` prop.
- A dedicated `createPreviewWebGPURenderer` reuses the main renderer's applied antialias without touching the stored applied-AA record (which drives the settings panel's restart notice), and defers a dispose that races `init()` so the GPU device is actually released.

## Testing

- `npm test` (client): 513 passing, including new placement tests covering the side flip and the narrow-viewport cutoff.
- `npm run check` / `npm run lint`: clean.
- Verified live: hover/switch/click-to-play, panel close/reopen, click-through over the hidden box, no console errors.
