### PR TITLE
Match the equip panel background art to the character's gender

### DIFF
--- a/client/src/lib/components/CharacterPanel.svelte
+++ b/client/src/lib/components/CharacterPanel.svelte
@@ -10,6 +10,8 @@
   } from '../network/networkTypes'
   import { skill_xp_for_level, skill_level_cap } from '../wasm/onlinerpg_shared'
   import { levelProgress } from '../utils/xpProgress'
+  import { equipBgCandidates } from '../utils/equipBackground'
+  import { SvelteSet } from 'svelte/reactivity'
   import { skillsStore, SKILL_DISPLAY_NAMES } from '../stores/skillsStore'
   import type { SkillId, SkillProgress } from '../network/networkTypes'
   import {
@@ -54,14 +56,10 @@
     onClose,
   }: Props = $props()
 
-  const FEMALE_EQUIP_BG: Partial<Record<CharacterClass, string>> = {
-    caveman: '/character_concepts/cavewoman.png',
-    rogue: '/character_concepts/female_rogue.png',
-    bard: '/character_concepts/female_bard.png',
-  }
+  const equipBgList = $derived(equipBgCandidates(characterClass, gender))
+  const failedEquipBgs = new SvelteSet<string>()
   const equipBg = $derived(
-    (gender === 'female' && FEMALE_EQUIP_BG[characterClass]) ||
-      '/character_concepts/female_priest.png'
+    equipBgList.find((path) => !failedEquipBgs.has(path)) ?? equipBgList.at(-1)
   )
 
   // Effective guard is computed server-side (base attribute + equipped-gear
@@ -280,7 +278,15 @@
             </div>
           </div>
           <div class="equip-section">
-            <img class="equip-bg" src={equipBg} alt="" draggable="false" />
+            <img
+              class="equip-bg"
+              src={equipBg}
+              alt=""
+              draggable="false"
+              onerror={() => {
+                if (equipBg) failedEquipBgs.add(equipBg)
+              }}
+            />
             {#each VISIBLE_SLOTS as { slot, top, left } (slot)}
               {@const item = $inventoryStore.equipped[slot]}
               {@const def = item ? getItemDef(item.item_def_id) : null}

--- a/client/src/lib/utils/equipBackground.test.ts
+++ b/client/src/lib/utils/equipBackground.test.ts
@@ -1,0 +1,92 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { equipBgCandidates } from './equipBackground'
+
+const PUBLIC_DIR = join(__dirname, '..', '..', '..', 'public')
+
+const REACHABLE_COMBOS = [
+  ['knight', 'male'],
+  ['knight', 'female'],
+  ['barbarian', 'male'],
+  ['barbarian', 'female'],
+  ['rogue', 'male'],
+  ['rogue', 'female'],
+  ['caveman', 'male'],
+  ['caveman', 'female'],
+  ['valkyrie', 'female'],
+  ['ranger', 'male'],
+  ['priest', 'male'],
+  ['priest', 'female'],
+  ['bard', 'female'],
+] as const
+
+describe('equipBgCandidates', () => {
+  it('prefers own-gender art, then opposite gender, then the default', () => {
+    expect(equipBgCandidates('knight', 'male')).toEqual([
+      '/character_concepts/knight.png',
+      '/character_concepts/female_knight.png',
+      '/character_concepts/female_priest.png',
+    ])
+    expect(equipBgCandidates('bard', 'male')).toEqual([
+      '/character_concepts/bard.png',
+      '/character_concepts/female_bard.png',
+      '/character_concepts/female_priest.png',
+    ])
+    expect(equipBgCandidates('ranger', 'female')).toEqual([
+      '/character_concepts/female_ranger.png',
+      '/character_concepts/ranger.png',
+      '/character_concepts/female_priest.png',
+    ])
+  })
+
+  it('uses irregular filenames for cavewoman and valkyrie', () => {
+    expect(equipBgCandidates('caveman', 'female')[0]).toBe(
+      '/character_concepts/cavewoman.png'
+    )
+    expect(equipBgCandidates('caveman', 'male')[0]).toBe(
+      '/character_concepts/caveman.png'
+    )
+    expect(equipBgCandidates('valkyrie', 'female')).toEqual([
+      '/character_concepts/valkyrie.jpg',
+      '/character_concepts/female_priest.png',
+    ])
+  })
+
+  it('always includes the default and never repeats a candidate', () => {
+    const classes = [
+      'knight',
+      'barbarian',
+      'rogue',
+      'caveman',
+      'valkyrie',
+      'ranger',
+      'priest',
+      'bard',
+      'merchant',
+      'guard',
+      'samurai',
+    ]
+    for (const characterClass of classes) {
+      for (const gender of ['male', 'female'] as const) {
+        const candidates = equipBgCandidates(characterClass, gender)
+        expect(candidates).toContain('/character_concepts/female_priest.png')
+        expect(new Set(candidates).size).toBe(candidates.length)
+      }
+    }
+  })
+
+  it('falls back to own art before the male art for the female priest', () => {
+    expect(equipBgCandidates('priest', 'female')).toEqual([
+      '/character_concepts/female_priest.png',
+      '/character_concepts/priest.png',
+    ])
+  })
+
+  it('resolves every creatable class/gender combo to a real file first try', () => {
+    for (const [characterClass, gender] of REACHABLE_COMBOS) {
+      const [first] = equipBgCandidates(characterClass, gender)
+      expect(existsSync(join(PUBLIC_DIR, first)), first).toBe(true)
+    }
+  })
+})

--- a/client/src/lib/utils/equipBackground.ts
+++ b/client/src/lib/utils/equipBackground.ts
@@ -1,0 +1,41 @@
+import type { Gender } from '../network/networkTypes'
+
+const CONCEPT_DIR = '/character_concepts'
+const FINAL_FALLBACK = `${CONCEPT_DIR}/female_priest.png`
+
+// Files that don't follow the {class}.png / female_{class}.png convention.
+const IRREGULAR: Record<Gender, Record<string, string>> = {
+  female: {
+    caveman: `${CONCEPT_DIR}/cavewoman.png`,
+    valkyrie: `${CONCEPT_DIR}/valkyrie.jpg`,
+  },
+  male: {
+    valkyrie: `${CONCEPT_DIR}/valkyrie.jpg`,
+  },
+}
+
+function conceptPath(characterClass: string, gender: Gender): string {
+  const irregular = IRREGULAR[gender][characterClass]
+  if (irregular) return irregular
+  const prefix = gender === 'female' ? 'female_' : ''
+  return `${CONCEPT_DIR}/${prefix}${characterClass}.png`
+}
+
+// Ordered image candidates for the equip-panel background: own gender first,
+// then the opposite gender's art, then the historical default. The component
+// advances to the next entry on load error, so dropping a conventionally
+// named file into character_concepts/ takes effect without code changes.
+// characterClass is a plain string because agent-created characters can carry
+// classes outside the web client's union (same reality as classIconPath).
+export function equipBgCandidates(
+  characterClass: string,
+  gender: Gender
+): string[] {
+  const opposite: Gender = gender === 'female' ? 'male' : 'female'
+  const candidates = [
+    conceptPath(characterClass, gender),
+    conceptPath(characterClass, opposite),
+    FINAL_FALLBACK,
+  ]
+  return candidates.filter((path, i) => candidates.indexOf(path) === i)
+}


### PR DESCRIPTION
## Summary

The equipment panel's background art fell back to `female_priest.png` for every combination outside three mapped female classes — so every male character (and even the female knight, whose art exists) displayed the female priest.

The background is now derived from the `{class}.png` / `female_{class}.png` naming convention under `character_concepts/`: own gender first, then the opposite gender's art for the same class, then the old default. The `<img>` advances past missing files on load error, so dropping a conventionally named concept image into `character_concepts/` takes effect with no code change.

## Behavior today

- All 13 creatable class/gender combos with existing art resolve to their own-gender image on the first try (matching the 3D model picker's choices).
- Only two creatable combos lack own-gender art: **female ranger** and **male bard** show their class's opposite-gender art instead of the priest.
- NPC-only and agent-created classes keep the old default via the fallback chain.

## Tests

- Unit tests cover candidate order, the irregular filenames (`cavewoman.png`, `valkyrie.jpg`), and dedupe behavior.
- A filesystem-backed test asserts every creatable combo resolves to a real file on the first candidate, so a renamed or deleted asset fails CI instead of silently degrading to fallback art.

## Screenshots

**Before** — male knight showing the female priest:

<img width="960" alt="equip panel before, male knight with female priest art" src="https://github.com/user-attachments/assets/37c6c084-3d81-46b1-ae6d-d1a5af6e5f0e" />

**After** — the same character showing the knight art:

<img width="960" alt="equip panel after, male knight with knight art" src="https://github.com/user-attachments/assets/cc067b84-4393-421c-afb2-b6e41761041c" />

## Follow-up

Only 3 of the 15 concept images have transparent backgrounds (the ones the old code happened to use) — the rest carry an opaque studio backdrop, which is why the knight art shows a bright box. Cutting out the remaining backgrounds is planned as a separate PR so this one stays code-only.
