### PR TITLE
Bind quickslots to enchant level so the right copy of an item is equipped

### DIFF
--- a/client/src/lib/actions/itemTooltip.ts
+++ b/client/src/lib/actions/itemTooltip.ts
@@ -11,6 +11,9 @@ export interface ItemTooltipParams {
   /** The hovered instance, when one exists — supplies per-instance display
    * data such as the +N enchant. Omit for def-only surfaces (shop catalog). */
   item?: ItemInstance
+  /** Enchant to show when no instance backs the surface (e.g. a quickslot
+   * whose bound item is depleted). Ignored when `item` is present. */
+  enchant?: number
   side?: 'left' | 'right'
 }
 
@@ -38,7 +41,7 @@ export function itemTooltip(
       target: document.body,
       props: {
         def: params.def,
-        enchant: params.item?.enchant,
+        enchant: params.item?.enchant ?? params.enchant,
         compare: displacedDef
           ? { def: displacedDef, enchant: displaced.enchant }
           : undefined,

--- a/client/src/lib/components/CharacterPanel.svelte
+++ b/client/src/lib/components/CharacterPanel.svelte
@@ -163,7 +163,7 @@
   function onEquipPointerDown(
     e: PointerEvent,
     slot: EquipSlot,
-    item: { instance_id: number; item_def_id: string }
+    item: { instance_id: number; item_def_id: string; enchant: number }
   ) {
     if (e.button !== 0) return
     e.preventDefault()
@@ -174,6 +174,7 @@
       {
         instanceId: item.instance_id,
         defId: item.item_def_id,
+        enchant: item.enchant,
         equipSlot: def?.equipSlot ?? null,
         source: { type: 'equipped', slot },
         icon: def?.icon ?? FALLBACK_ICON,

--- a/client/src/lib/components/InventoryPanel.svelte
+++ b/client/src/lib/components/InventoryPanel.svelte
@@ -166,6 +166,7 @@
       {
         instanceId: slot.instance_id,
         defId: slot.item_def_id,
+        enchant: slot.enchant,
         // Group drags never equip, regardless of drop position.
         equipSlot: null,
         source: { type: 'bag' },
@@ -207,6 +208,7 @@
       {
         instanceId: slot.instance_id,
         defId: slot.item_def_id,
+        enchant: slot.enchant,
         equipSlot: def?.equipSlot ?? null,
         source: { type: 'bag' },
         icon: def?.icon ?? FALLBACK_ICON,

--- a/client/src/lib/components/QuickslotBar.svelte
+++ b/client/src/lib/components/QuickslotBar.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { inventoryStore } from '../stores/inventoryStore'
-  import { getItemDef, isConsumable } from '../data/itemDefs'
+  import { getItemDef } from '../data/itemDefs'
   import { networkManager } from '../network/socket'
   import {
     quickslots,
     QUICKSLOT_COUNT,
     loadQuickslots,
     clearQuickslot,
+    resolveQuickslot,
+    quickslotAction,
   } from '../stores/quickslotStore'
   import { dragMeta, dragPos, quickslotAt } from '../stores/dragStore'
   import { itemTooltip } from '../actions/itemTooltip'
@@ -22,23 +24,16 @@
     if (characterId != null) loadQuickslots(characterId)
   })
 
-  /** Total quantity of an item def currently sitting in the bag. */
-  function bagQuantity(defId: string): number {
-    let total = 0
-    for (const item of $inventoryStore.bag) {
-      if (item.item_def_id === defId) total += item.quantity
-    }
-    return total
-  }
-
-  const slots = $derived(
-    $quickslots.map((defId) => {
-      if (!defId) return null
-      const def = getItemDef(defId)
+  const slots = $derived.by(() => {
+    const { bag, equipped } = $inventoryStore
+    return $quickslots.map((entry) => {
+      if (!entry) return null
+      const def = getItemDef(entry.defId)
       if (!def) return null
-      return { defId, def, qty: bagQuantity(defId) }
+      const worn = def.equipSlot ? equipped[def.equipSlot] : undefined
+      return { def, ...resolveQuickslot(entry, worn, bag) }
     })
-  )
+  })
 
   // While an item is dragged, the slot it would drop into (-1 otherwise).
   // Uses the same snap logic as the drop handler so highlight and drop agree.
@@ -56,17 +51,12 @@
   function useSlot(index: number) {
     const entry = slots[index]
     if (!entry) return
-    const slot = entry.def.equipSlot
-    // Already wearing this exact item in its slot → unequip (toggle off).
-    if (slot && $inventoryStore.equipped[slot]?.item_def_id === entry.defId) {
-      networkManager.sendUnequipItem(slot)
-      return
-    }
-    const inst = $inventoryStore.bag.find((b) => b.item_def_id === entry.defId)
-    if (!inst) return // none left in bag
-    if (slot) networkManager.sendEquipItem(inst.instance_id)
-    else if (isConsumable(entry.def))
-      networkManager.sendUseItem(inst.instance_id)
+    const action = quickslotAction(entry.def, entry)
+    if (!action) return
+    if (action.kind === 'unequip') networkManager.sendUnequipItem(action.slot)
+    else if (action.kind === 'equip')
+      networkManager.sendEquipItem(action.instanceId)
+    else networkManager.sendUseItem(action.instanceId)
   }
 
   // Digit1..Digit9 → slots 0..8, Digit0 → slot 9.
@@ -100,7 +90,9 @@
       class:empty={!entry}
       class:drop-target={i === dropIndex}
       data-quickslot={i}
-      use:itemTooltip={entry ? { def: entry.def, side: 'right' } : null}
+      use:itemTooltip={entry
+        ? { def: entry.def, enchant: entry.enchant ?? undefined, side: 'right' }
+        : null}
       onclick={() => useSlot(i)}
       oncontextmenu={(e) => {
         e.preventDefault()
@@ -116,6 +108,9 @@
           alt=""
           draggable="false"
         />
+        {#if entry.enchant !== null && entry.enchant > 0}
+          <span class="item-enchant">+{entry.enchant}</span>
+        {/if}
         {#if entry.qty !== 1}
           <span class="item-qty" class:zero={entry.qty === 0}>{entry.qty}</span>
         {/if}
@@ -198,6 +193,18 @@
     font-weight: 700;
     color: #fff;
     text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
+  }
+
+  /* Top-right: the key label owns the top-left corner. */
+  .item-enchant {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #7ec8ff;
+    text-shadow: 0 0 3px rgba(0, 0, 0, 0.9);
+    pointer-events: none;
   }
 
   .item-qty.zero {

--- a/client/src/lib/stores/dragStore.ts
+++ b/client/src/lib/stores/dragStore.ts
@@ -7,6 +7,7 @@ export const FALLBACK_ICON = 'icon_frame.png'
 export type DragMeta = {
   instanceId: number
   defId: string
+  enchant: number
   equipSlot: EquipSlot | null
   source: { type: 'bag' } | { type: 'equipped'; slot: EquipSlot }
   icon: string
@@ -135,7 +136,7 @@ export function startDrag(
         if (qsIndex < 0) {
           onDrop(ue.clientX, ue.clientY)
         } else if (meta.groupItems === undefined) {
-          assignQuickslot(qsIndex, meta.defId)
+          assignQuickslot(qsIndex, { defId: meta.defId, enchant: meta.enchant })
         }
       } else {
         onClick?.()

--- a/client/src/lib/stores/quickslotStore.test.ts
+++ b/client/src/lib/stores/quickslotStore.test.ts
@@ -1,0 +1,234 @@
+import { get } from 'svelte/store'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  assignQuickslot,
+  loadQuickslots,
+  quickslotAction,
+  quickslots,
+  resetQuickslots,
+  resolveQuickslot,
+  type CarriedItem,
+} from './quickslotStore'
+
+// The node test environment has no localStorage.
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => void storage.set(key, value),
+})
+
+beforeEach(() => {
+  storage.clear()
+  resetQuickslots()
+})
+
+function item(
+  instance_id: number,
+  item_def_id: string,
+  enchant = 0,
+  quantity = 1
+): CarriedItem {
+  return { instance_id, item_def_id, enchant, quantity }
+}
+
+describe('resolveQuickslot', () => {
+  it('acts on exactly the bound level when it is carried (#148)', () => {
+    const bag = [item(1, 'shield', 0), item(2, 'shield', 3)]
+    const plus3 = resolveQuickslot(
+      { defId: 'shield', enchant: 3 },
+      undefined,
+      bag
+    )
+    expect(plus3.enchant).toBe(3)
+    expect(plus3.bagItem?.instance_id).toBe(2)
+    expect(plus3.qty).toBe(1)
+    const plain = resolveQuickslot(
+      { defId: 'shield', enchant: 0 },
+      undefined,
+      bag
+    )
+    expect(plain.enchant).toBe(0)
+    expect(plain.bagItem?.instance_id).toBe(1)
+  })
+
+  it('toggles off the worn item at the bound level', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'shield', enchant: 3 },
+      item(2, 'shield', 3),
+      [item(1, 'shield', 0)]
+    )
+    expect(resolved.unequip).toBe(true)
+    expect(resolved.bagItem).toBeUndefined()
+  })
+
+  it('follows the worn copy when it was enchanted in place, even past a stronger spare', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: 2 },
+      item(9, 'iron_sword', 3),
+      [item(5, 'iron_sword', 5)]
+    )
+    expect(resolved.enchant).toBe(3)
+    expect(resolved.unequip).toBe(true)
+  })
+
+  it('still toggles off a drifted worn copy when a bag spare sits at the bound level', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: 3 },
+      item(9, 'iron_sword', 4),
+      [item(5, 'iron_sword', 3)]
+    )
+    expect(resolved.enchant).toBe(4)
+    expect(resolved.unequip).toBe(true)
+    expect(resolved.bagItem).toBeUndefined()
+  })
+
+  it('picks the bag copy closest to the bound level, not the strongest', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: 2 },
+      undefined,
+      [item(5, 'iron_sword', 5), item(9, 'iron_sword', 3)]
+    )
+    expect(resolved.enchant).toBe(3)
+    expect(resolved.bagItem?.instance_id).toBe(9)
+  })
+
+  it('keeps an any-level binding on the worn copy over a fresh plain spare', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'chain_mail', enchant: null },
+      item(9, 'chain_mail', 4),
+      [item(5, 'chain_mail', 0)]
+    )
+    expect(resolved.enchant).toBe(4)
+    expect(resolved.unequip).toBe(true)
+  })
+
+  it('sends an any-level binding to the best bag copy when nothing is worn', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: null },
+      undefined,
+      [item(5, 'iron_sword', 1), item(9, 'iron_sword', 4)]
+    )
+    expect(resolved.enchant).toBe(4)
+    expect(resolved.bagItem?.instance_id).toBe(9)
+  })
+
+  it('goes inert but keeps the bound level when the def is gone entirely', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: 2 },
+      undefined,
+      [item(1, 'shield', 2)]
+    )
+    expect(resolved).toEqual({
+      enchant: 2,
+      unequip: false,
+      bagItem: undefined,
+      qty: 0,
+    })
+  })
+
+  it('sums bag quantity only at the resolved level', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'healing_potion', enchant: 0 },
+      undefined,
+      [item(1, 'healing_potion', 0, 5), item(2, 'healing_potion', 0, 2)]
+    )
+    expect(resolved.qty).toBe(7)
+  })
+})
+
+describe('quickslotAction', () => {
+  const sword = { equipSlot: 'main_hand' as const }
+  const potion = { consumable: true }
+
+  it('unequips the worn copy even when a bag spare matches the bound level', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'iron_sword', enchant: 3 },
+      item(9, 'iron_sword', 4),
+      [item(5, 'iron_sword', 3)]
+    )
+    expect(quickslotAction(sword, resolved)).toEqual({
+      kind: 'unequip',
+      slot: 'main_hand',
+    })
+  })
+
+  it('equips exactly the bound instance (#148)', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'shield', enchant: 3 },
+      undefined,
+      [item(1, 'shield', 0), item(2, 'shield', 3)]
+    )
+    expect(quickslotAction({ equipSlot: 'off_hand' }, resolved)).toEqual({
+      kind: 'equip',
+      instanceId: 2,
+    })
+  })
+
+  it('consumes from the bag and goes inert when nothing is carried', () => {
+    const resolved = resolveQuickslot(
+      { defId: 'healing_potion', enchant: 0 },
+      undefined,
+      [item(1, 'healing_potion', 0, 5)]
+    )
+    expect(quickslotAction(potion, resolved)).toEqual({
+      kind: 'use',
+      instanceId: 1,
+    })
+    const empty = resolveQuickslot(
+      { defId: 'healing_potion', enchant: 0 },
+      undefined,
+      []
+    )
+    expect(quickslotAction(potion, empty)).toBeNull()
+  })
+})
+
+describe('assignQuickslot', () => {
+  it('keeps one binding per item type, replacing any level of the same def', () => {
+    assignQuickslot(0, { defId: 'shield', enchant: 3 })
+    assignQuickslot(4, { defId: 'shield', enchant: 0 })
+    const slots = get(quickslots)
+    expect(slots[0]).toBeNull()
+    expect(slots[4]).toEqual({ defId: 'shield', enchant: 0 })
+  })
+
+  it('leaves other defs alone', () => {
+    assignQuickslot(0, { defId: 'shield', enchant: 3 })
+    assignQuickslot(1, { defId: 'iron_sword', enchant: 3 })
+    expect(get(quickslots)[0]).toEqual({ defId: 'shield', enchant: 3 })
+  })
+})
+
+describe('loadQuickslots', () => {
+  it('round-trips assignments through storage', () => {
+    loadQuickslots(7)
+    assignQuickslot(2, { defId: 'shield', enchant: 3 })
+    quickslots.set([])
+    loadQuickslots(7)
+    expect(get(quickslots)[2]).toEqual({ defId: 'shield', enchant: 3 })
+  })
+
+  it('reads pre-enchant entries (plain def ids) as any-level bindings', () => {
+    storage.set(
+      'quickslots:7',
+      JSON.stringify(['healing_potion', null, 'shield'])
+    )
+    loadQuickslots(7)
+    const slots = get(quickslots)
+    expect(slots[0]).toEqual({ defId: 'healing_potion', enchant: null })
+    expect(slots[1]).toBeNull()
+    expect(slots[2]).toEqual({ defId: 'shield', enchant: null })
+  })
+
+  it('drops corrupt or unrecognized entries', () => {
+    storage.set(
+      'quickslots:7',
+      JSON.stringify([42, { defId: 'shield' }, { defId: 'sword', enchant: 1 }])
+    )
+    loadQuickslots(7)
+    const slots = get(quickslots)
+    expect(slots[0]).toBeNull()
+    expect(slots[1]).toBeNull()
+    expect(slots[2]).toEqual({ defId: 'sword', enchant: 1 })
+  })
+})

--- a/client/src/lib/stores/quickslotStore.ts
+++ b/client/src/lib/stores/quickslotStore.ts
@@ -1,21 +1,125 @@
 import { writable } from 'svelte/store'
+import type { EquipSlot } from '../network/networkTypes'
 
 export const QUICKSLOT_COUNT = 10
 
 /**
- * Quickslot assignments. Each slot holds an item *definition* id (not an
- * instance id) so the binding survives stacks being consumed and re-created —
- * the bar always points at "the first Healing Potion in my bag", not a specific
- * one. `null` means the slot is empty.
+ * One quickslot binding: an item *definition* id plus an enchant level. Not an
+ * instance id — those are reissued every login, so a binding must survive on
+ * def + enchant alone. `enchant: null` means "any level": bindings saved
+ * before enchant levels were stored carry no level intent.
  */
-export const quickslots = writable<(string | null)[]>(
+export type QuickslotEntry = {
+  defId: string
+  enchant: number | null
+}
+
+/** Quickslot assignments; `null` means the slot is empty. */
+export const quickslots = writable<(QuickslotEntry | null)[]>(
   new Array(QUICKSLOT_COUNT).fill(null)
 )
+
+/** The inventory fields quickslot resolution reads. */
+export type CarriedItem = {
+  instance_id: number
+  item_def_id: string
+  enchant: number
+  quantity: number
+}
+
+/**
+ * The bag copy a binding equips or consumes: the bound level while a copy at
+ * that level is in the bag — that is what keeps a "+3 shield" binding off the
+ * plain shield — then the level closest to the bound one (ties to the
+ * higher), so a binding whose level no longer exists degrades to the nearest
+ * copy instead of an unrelated spare. Any-level bindings take the best copy.
+ */
+function pickBagLevel(bound: number | null, levels: number[]): number | null {
+  if (levels.length === 0) return null
+  if (bound !== null && levels.includes(bound)) return bound
+  if (bound === null) return Math.max(...levels)
+  return levels.reduce((a, b) => {
+    const da = Math.abs(a - bound)
+    const db = Math.abs(b - bound)
+    return db < da || (db === da && b > a) ? b : a
+  })
+}
+
+export type ResolvedQuickslot = {
+  /** Level the slot displays and acts on; the stored intent (possibly null)
+   *  when nothing of the def is carried. */
+  enchant: number | null
+  /** Pressing the slot unequips the worn item (toggle off). */
+  unequip: boolean
+  /** Bag item a press equips or consumes, when not unequipping. */
+  bagItem: CarriedItem | undefined
+  /** Bag quantity at the resolved level. */
+  qty: number
+}
+
+/**
+ * What a quickslot press acts on. `worn` is the occupant of the bound def's
+ * own equip slot (undefined for consumables or an empty slot).
+ *
+ * A `worn` item of the bound def always resolves to a toggle-off at its own
+ * level, whatever level is stored: enchant scrolls raise a worn item's level
+ * in place, so the worn copy IS the bound item after it drifts — and with one
+ * binding per def, "unequip what I'm wearing" is the only consistent meaning
+ * for the key. The bound level picks which bag copy to equip, nothing more.
+ */
+export function resolveQuickslot(
+  entry: QuickslotEntry,
+  worn: CarriedItem | undefined,
+  bag: CarriedItem[]
+): ResolvedQuickslot {
+  const bagMatches = bag.filter((i) => i.item_def_id === entry.defId)
+  const wornMatch = worn?.item_def_id === entry.defId ? worn : undefined
+  const level = wornMatch
+    ? wornMatch.enchant
+    : pickBagLevel(
+        entry.enchant,
+        bagMatches.map((i) => i.enchant)
+      )
+  if (level === null)
+    return {
+      enchant: entry.enchant,
+      unequip: false,
+      bagItem: undefined,
+      qty: 0,
+    }
+  const atLevel = bagMatches.filter((i) => i.enchant === level)
+  return {
+    enchant: level,
+    unequip: wornMatch !== undefined,
+    bagItem: wornMatch ? undefined : atLevel[0],
+    qty: atLevel.reduce((total, i) => total + i.quantity, 0),
+  }
+}
+
+export type QuickslotAction =
+  | { kind: 'unequip'; slot: EquipSlot }
+  | { kind: 'equip'; instanceId: number }
+  | { kind: 'use'; instanceId: number }
+  | null
+
+/** The network action a quickslot press dispatches, if any. */
+export function quickslotAction(
+  def: { equipSlot?: EquipSlot | null; consumable?: boolean },
+  resolved: ResolvedQuickslot
+): QuickslotAction {
+  const slot = def.equipSlot
+  if (slot && resolved.unequip) return { kind: 'unequip', slot }
+  if (!resolved.bagItem) return null
+  if (slot) return { kind: 'equip', instanceId: resolved.bagItem.instance_id }
+  if (def.consumable === true)
+    return { kind: 'use', instanceId: resolved.bagItem.instance_id }
+  return null
+}
 
 /** localStorage key for the active character; null until a character loads. */
 let storageKey: string | null = null
 
-function persist(slots: (string | null)[]) {
+function persist(slots: (QuickslotEntry | null)[]) {
   if (!storageKey) return
   try {
     localStorage.setItem(storageKey, JSON.stringify(slots))
@@ -24,17 +128,29 @@ function persist(slots: (string | null)[]) {
   }
 }
 
+/** Entries saved before enchant levels were stored are plain def ids. */
+function parseEntry(raw: unknown): QuickslotEntry | null {
+  if (typeof raw === 'string') return { defId: raw, enchant: null }
+  if (typeof raw === 'object' && raw !== null) {
+    const { defId, enchant } = raw as QuickslotEntry
+    if (
+      typeof defId === 'string' &&
+      (typeof enchant === 'number' || enchant === null)
+    )
+      return { defId, enchant }
+  }
+  return null
+}
+
 /** Load this character's saved quickslots (call when a character is selected). */
 export function loadQuickslots(characterId: number) {
   storageKey = `quickslots:${characterId}`
-  const next: (string | null)[] = new Array(QUICKSLOT_COUNT).fill(null)
+  const next: (QuickslotEntry | null)[] = new Array(QUICKSLOT_COUNT).fill(null)
   try {
     const raw = localStorage.getItem(storageKey)
     const parsed = raw ? JSON.parse(raw) : null
     if (Array.isArray(parsed)) {
-      for (let i = 0; i < QUICKSLOT_COUNT; i++) {
-        if (typeof parsed[i] === 'string') next[i] = parsed[i]
-      }
+      for (let i = 0; i < QUICKSLOT_COUNT; i++) next[i] = parseEntry(parsed[i])
     }
   } catch {
     /* corrupt entry — fall back to empty */
@@ -42,15 +158,17 @@ export function loadQuickslots(characterId: number) {
   quickslots.set(next)
 }
 
-export function assignQuickslot(index: number, itemDefId: string) {
+export function assignQuickslot(index: number, entry: QuickslotEntry) {
   if (index < 0 || index >= QUICKSLOT_COUNT) return
   quickslots.update((slots) => {
     const next = [...slots]
-    // Avoid the same item occupying two slots: clear any previous binding.
+    // One binding per item type: level fallbacks make two bindings of the
+    // same def collapse into indistinguishable slots, so re-dragging a def
+    // moves its binding instead.
     for (let i = 0; i < next.length; i++) {
-      if (next[i] === itemDefId) next[i] = null
+      if (next[i]?.defId === entry.defId) next[i] = null
     }
-    next[index] = itemDefId
+    next[index] = { defId: entry.defId, enchant: entry.enchant }
     persist(next)
     return next
   })


### PR DESCRIPTION
Fixes #148 — thanks to @edgame1647 for the clear report and screenshots, which made this easy to reproduce.

## Summary

Quickslots stored only an item definition id, so every copy of an item shared one slot: a +3 shield and a plain shield displayed as a stacked count of "2", and pressing the key equipped whichever copy came first in the bag — not the one that was dragged in.

A binding is now a (definition, enchant level) pair, and a single pure resolver decides what a slot shows and does:

- The slot's count and its new +N badge track only the bound level, so distinct copies no longer merge.
- Pressing the key equips exactly the bound copy.
- Wearing the bound item still toggles it off — and since enchant scrolls raise a worn item's level in place, the binding follows the worn copy: the badge updates live and the toggle keeps working after enchanting. When the bound level is gone from the bag, the closest remaining level is chosen.
- Bindings saved before this change (plain def-id strings in localStorage) load as "any level" bindings and keep working; they are rewritten in the new format on the next assignment.
- One binding per item type is kept, as before — re-dragging the same item moves its binding.
- The quickslot tooltip now shows the bound enchant, which also removes the bogus self-comparison it used to render against the worn item.

Instance ids could not back the binding: they are reissued on every login while quickslots persist in localStorage, and the DB stores no per-item identity — (definition, enchant) is the finest stable key the game has. Two capes of the same definition and level that differ only in dye remain indistinguishable, as before.

## Tests

- 17 unit tests over the store: level resolution (exact match, worn-copy drift, closest-level fallback, any-level legacy bindings), the press action (unequip / equip / use), one-binding-per-def dedupe, and storage round-trip including legacy and corrupt entries.
- Verified live against the issue's repro: with a plain and a +2 shield in the bag, the slot showed "1" with a +2 badge and equipped the +2; enchanting it to +3 while worn moved the badge to +3 and the key still unequipped; legacy string bindings from an older save loaded correctly.

## Screenshots

**Before** — the bag holds a plain and a +3 wooden shield; dragging the +3 to slot 6 shows them merged as "2", and pressing the key equipped the plain one:

<img width="960" alt="before, both shields merged into one quickslot as 2" src="https://github.com/user-attachments/assets/e872d7c2-bf29-4399-94d1-6ab492994f81" />

<img width="750" alt="before quickslot bar closeup showing count 2" src="https://github.com/user-attachments/assets/b5f76922-0245-4289-9f83-fe2a9a920cb1" />

**After** — the same bag: the slot is bound to the +3 shield alone, shows a +3 badge with no stacked count, and the key equips exactly that shield:

<img width="960" alt="after, quickslot bound to the +3 shield only" src="https://github.com/user-attachments/assets/0d895ae3-cf99-4743-9804-069144bcfdae" />

<img width="750" alt="after quickslot bar closeup showing the +3 badge" src="https://github.com/user-attachments/assets/33e1c082-5a96-4701-83cd-bddc6f076c99" />
