### PR TITLE
Shield players behind an entry grace until their client reports WorldReady

### DIFF
--- a/agent-client/src/orchestrator.rs
+++ b/agent-client/src/orchestrator.rs
@@ -661,6 +661,8 @@ async fn enter_game(
         let msg = ws::recv(ws_rx).await?;
         match msg {
             ServerMessage::JoinSuccess { .. } => {
+                // No scene to compile here, so the entry grace ends at once.
+                ws::send(ws_tx, &ClientMessage::WorldReady).await?;
                 buffered.push(msg);
                 return Ok(buffered);
             }

--- a/agent-client/src/state/tests/mod.rs
+++ b/agent-client/src/state/tests/mod.rs
@@ -104,6 +104,7 @@ pub(crate) fn test_player(x: f32, z: f32) -> Player {
         object_id: None,
         last_combat_at: 0,
         client_kind: Default::default(),
+        ready_at: 0,
         back_color: None,
         back_texture: None,
         wet: false,

--- a/client/src/lib/components/GameScene.svelte
+++ b/client/src/lib/components/GameScene.svelte
@@ -765,14 +765,16 @@
       if (isSceneCompiling && initialDataReadyAt > 0) {
         if (rawDeltaTime < SMOOTH_FRAME_TIME_MS) {
           smoothFrameCount++
-          if (smoothFrameCount >= SMOOTH_FRAME_THRESHOLD) {
-            isSceneCompiling = false
-          }
         } else {
           smoothFrameCount = 0
         }
-        if (currentTime - initialDataReadyAt > SMOOTH_FRAME_TIMEOUT_MS) {
+        if (
+          smoothFrameCount >= SMOOTH_FRAME_THRESHOLD ||
+          currentTime - initialDataReadyAt > SMOOTH_FRAME_TIMEOUT_MS
+        ) {
           isSceneCompiling = false
+          // Ends the server's entry grace: monsters can land hits again.
+          networkManager.sendWorldReady()
         }
       }
 

--- a/client/src/lib/network/networkTypes.ts
+++ b/client/src/lib/network/networkTypes.ts
@@ -136,6 +136,7 @@ export type ClientMessage =
   | { RenameCharacter: { character_id: number; new_name: string } }
   | { RollCharacterStats: { character_class: CharacterClass; gender: Gender } }
   | { EnterGame: { character_id: number } }
+  | 'WorldReady'
   | {
       PlayerMove: {
         position: Position

--- a/client/src/lib/network/socket.ts
+++ b/client/src/lib/network/socket.ts
@@ -441,6 +441,12 @@ class NetworkManager {
 
   // --- Public send methods ---
 
+  // Lifts the server's entry grace, which keeps the player undamageable
+  // until the scene is drawn.
+  sendWorldReady() {
+    this.sendMessage('WorldReady')
+  }
+
   sendPlayerAttack(monsterId: string) {
     this.sendMessage({ PlayerAttack: { monster_id: monsterId } })
   }

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1123,6 +1123,9 @@ async fn handle_client_message(
                 state.client_kind.unwrap_or_default(),
             );
 
+            player.ready_at =
+                GameState::now_ms() + onlinerpg_shared::entity::WORLD_LOADING_GRACE_MS;
+
             // Restore saved health (if available) and floor_level from DB
             if let Some(saved_health) = selected_character.health {
                 player.health = saved_health.min(max_hp);
@@ -1339,6 +1342,14 @@ async fn handle_client_message(
                 game_state.update_player_floor(id, floor_level).await;
             } else {
                 warn!("Received floor change from client that is not in game");
+            }
+        }
+
+        ClientMessage::WorldReady => {
+            if let Some(id) = &state.player_id {
+                game_state.mark_world_ready(id).await;
+            } else {
+                warn!("Received world ready from client that is not in game");
             }
         }
 

--- a/server/src/game_state/combat.rs
+++ b/server/src/game_state/combat.rs
@@ -279,16 +279,35 @@ impl super::GameState {
         };
         let player_snapshot = {
             let players = self.players.read().await;
-            players
-                .get(player_id)
-                .map(|p| (p.name.clone(), p.level, p.floor_level, p.position, p.health))
+            players.get(player_id).map(|p| {
+                (
+                    p.name.clone(),
+                    p.level,
+                    p.floor_level,
+                    p.position,
+                    p.health,
+                    p.is_ready(Self::now_ms()),
+                )
+            })
         };
-        let Some((player_name, player_level, player_floor, player_position, player_health)) =
-            player_snapshot
+        let Some((
+            player_name,
+            player_level,
+            player_floor,
+            player_position,
+            player_health,
+            player_ready,
+        )) = player_snapshot
         else {
             warn!("Attack from non-existent player: {}", player_id);
             return Err(AttackRejectReason::NotInGame);
         };
+
+        // Untouchable during the entry grace, so untouching too: a client that
+        // withholds `WorldReady` gets no free swings out of it.
+        if !player_ready {
+            return Err(AttackRejectReason::NotInGame);
+        }
 
         // A dead attacker deals no damage. The monster-attack path already
         // gates on the target's HP; mirror it here so a 0-HP player can't
@@ -831,12 +850,14 @@ impl super::GameState {
             return;
         };
 
-        // 2. Check if target player exists and is alive
+        // 2. Check if target player exists, is alive, and is done loading.
+        // Every damage path — owning client or the server's own brain — runs
+        // through here, so the entry grace only needs gating once.
         let (target_player_name, target_position, target_floor_level);
         {
             let players = self.players.read().await;
             match players.get(target_player_id) {
-                Some(player) if player.health > 0 => {
+                Some(player) if player.health > 0 && player.is_ready(now) => {
                     target_player_name = player.name.clone();
                     target_position = player.position;
                     target_floor_level = player.floor_level;

--- a/server/src/game_state/monster_ai.rs
+++ b/server/src/game_state/monster_ai.rs
@@ -196,9 +196,15 @@ impl super::GameState {
         }
         let started = Instant::now();
         let roster: Roster = {
+            let now = Self::now_ms();
             let players = self.players.read().await;
             let mut roster = Roster::default();
             for (id, p) in players.iter() {
+                // Still drawing the world: invisible to the brains, so nothing
+                // is already mid-swing the moment the loading screen lifts.
+                if !p.is_ready(now) {
+                    continue;
+                }
                 roster
                     .entry(super::SpatialCell::from_position(&p.position))
                     .or_default()

--- a/server/src/game_state/player.rs
+++ b/server/src/game_state/player.rs
@@ -1028,6 +1028,15 @@ impl super::GameState {
         }
     }
 
+    /// End the entry grace early: the client says its scene is drawn, so it is
+    /// a damageable target again.
+    pub async fn mark_world_ready(&self, player_id: &PlayerId) {
+        let mut players = self.players.write().await;
+        if let Some(player) = players.get_mut(player_id) {
+            player.ready_at = 0;
+        }
+    }
+
     /// Handle a client PlayerMove. The client sends destinations (waypoints),
     /// so the position becomes a MoveIntent that `tick_player_movement` walks
     /// toward.

--- a/server/src/game_state/tests/mod.rs
+++ b/server/src/game_state/tests/mod.rs
@@ -39,6 +39,7 @@ mod stall_tests;
 mod tip_hat_tests;
 mod trading_tests;
 mod wet_tests;
+mod world_ready_tests;
 
 /// Stable numeric id derived from a fixture's name, so tests keep naming
 /// players ("owner", "buyer") instead of carrying opaque integers. Only needs
@@ -75,6 +76,7 @@ fn make_player(id: &str, x: f32, z: f32) -> Player {
         client_kind: Default::default(),
         back_color: None,
         back_texture: None,
+        ready_at: 0,
     }
 }
 

--- a/server/src/game_state/tests/player_tests.rs
+++ b/server/src/game_state/tests/player_tests.rs
@@ -193,6 +193,7 @@ async fn respawn_player_revives_dead_player_only() {
         object_id: None,
         last_combat_at: 0,
         client_kind: Default::default(),
+        ready_at: 0,
         back_color: None,
         back_texture: None,
     };
@@ -265,6 +266,7 @@ async fn respawn_player_ignores_alive_player() {
         object_id: None,
         last_combat_at: 0,
         client_kind: Default::default(),
+        ready_at: 0,
         back_color: None,
         back_texture: None,
     };

--- a/server/src/game_state/tests/world_ready_tests.rs
+++ b/server/src/game_state/tests/world_ready_tests.rs
@@ -1,0 +1,142 @@
+//! The entry grace: a client still compiling its scene cannot be damaged, so
+//! logging back in beside an aggroed monster is survivable.
+
+use super::*;
+use onlinerpg_shared::entity::WORLD_LOADING_GRACE_MS;
+
+/// A player who just entered: the full grace still ahead, so not yet hittable.
+fn loading_player(id: &str, x: f32) -> Player {
+    let mut player = make_player(id, x, 0.0);
+    player.ready_at = GameState::now_ms() + WORLD_LOADING_GRACE_MS;
+    player
+}
+
+/// Give `owner` a monster standing on top of `target`, so only the grace can
+/// stop the attack.
+async fn adjacent_monster(game_state: &GameState, id: &str, owner: &PlayerId) {
+    let mut monsters = game_state.monsters.write().await;
+    let mut monster = make_monster(id, pos(0.0), 0);
+    monster.owner_id = Some(*owner);
+    monsters.insert(id.to_string(), monster);
+}
+
+/// Two players in the same spot, told apart only by `ready_at`: the ready one
+/// (`make_player`, ready_at 0) is hit, the loading one is not, and after
+/// `WorldReady` the same attack lands on them too. The ready player doubles as
+/// the control — if the attack setup were broken, their half would fail.
+#[tokio::test]
+async fn only_the_loading_player_is_shielded() {
+    let game_state = make_test_game_state("loading_no_damage");
+    let owner_id = pid("owner");
+    let newcomer_id = pid("newcomer");
+    let normal_player_id = pid("normal_player");
+
+    game_state.add_player(make_player("owner", 0.0, 0.0)).await;
+    game_state.add_player(loading_player("newcomer", 0.0)).await;
+    game_state
+        .add_player(make_player("normal_player", 0.0, 0.0))
+        .await;
+
+    // Every swing burns its monster's cooldown, rejected or not, so each of
+    // the three attacks gets its own monster.
+    for id in ["loading_monster", "normal_player_monster", "ready_monster"] {
+        adjacent_monster(&game_state, id, &owner_id).await;
+    }
+
+    game_state
+        .broadcast_monster_attack(&owner_id, "loading_monster", &newcomer_id)
+        .await;
+    game_state
+        .broadcast_monster_attack(&owner_id, "normal_player_monster", &normal_player_id)
+        .await;
+
+    // `last_combat_at` is stamped for any attack that lands, hit or miss, so it
+    // records that the swing was processed without depending on a damage roll.
+    assert_eq!(
+        game_state.players.read().await[&newcomer_id].last_combat_at,
+        0,
+        "a monster must not reach a player who is still loading the world"
+    );
+    assert_eq!(
+        game_state.players.read().await[&newcomer_id].health,
+        10,
+        "a loading player must take no damage"
+    );
+    assert_ne!(
+        game_state.players.read().await[&normal_player_id].last_combat_at,
+        0,
+        "the identical attack must be processed against the ready player"
+    );
+
+    game_state.mark_world_ready(&newcomer_id).await;
+    game_state
+        .broadcast_monster_attack(&owner_id, "ready_monster", &newcomer_id)
+        .await;
+
+    assert_ne!(
+        game_state.players.read().await[&newcomer_id].last_combat_at,
+        0,
+        "the same attack must land once the client reports the world is ready"
+    );
+}
+
+/// The grace is a deadline, not a switch a client can hold down: a client that
+/// never sends `WorldReady` becomes damageable on its own.
+#[tokio::test]
+async fn loading_grace_expires_without_world_ready() {
+    let game_state = make_test_game_state("loading_grace_expiry");
+    let owner_id = pid("owner");
+    let auto_ready_id = pid("auto_ready_player");
+
+    game_state.add_player(make_player("owner", 0.0, 0.0)).await;
+    // Never sent WorldReady, but the entry deadline passed a second ago.
+    let mut auto_ready_player = make_player("auto_ready_player", 0.0, 0.0);
+    auto_ready_player.ready_at = GameState::now_ms() - 1_000;
+    game_state.add_player(auto_ready_player).await;
+
+    adjacent_monster(&game_state, "patient_monster", &owner_id).await;
+    game_state
+        .broadcast_monster_attack(&owner_id, "patient_monster", &auto_ready_id)
+        .await;
+
+    assert_ne!(
+        game_state.players.read().await[&auto_ready_id].last_combat_at,
+        0,
+        "the grace must expire on its own for a client that never reports ready"
+    );
+}
+
+/// Untouchable means untouching: a client that withholds `WorldReady` must not
+/// get free swings out of the grace.
+#[tokio::test]
+async fn loading_player_cannot_attack() {
+    let game_state = make_test_game_state("loading_cannot_attack");
+    let attacker_id = pid("attacker");
+    game_state.add_player(loading_player("attacker", 0.0)).await;
+    let mut attacker_rx = game_state.register_direct_channel(&attacker_id).await;
+
+    {
+        let mut monsters = game_state.monsters.write().await;
+        monsters.insert(
+            "victim_monster".to_string(),
+            make_monster("victim_monster", pos(1.0), 0),
+        );
+    }
+
+    game_state
+        .broadcast_player_attack(&attacker_id, "victim_monster".to_string())
+        .await;
+
+    match attacker_rx.try_recv() {
+        Ok(ServerMessage::PlayerAttackRejected { monster_id, reason }) => {
+            assert_eq!(monster_id, "victim_monster");
+            assert_eq!(reason, AttackRejectReason::NotInGame);
+        }
+        other => panic!("Expected a rejection ack while loading, got {other:?}"),
+    }
+    assert_eq!(
+        game_state.monsters.read().await["victim_monster"].health,
+        10,
+        "a loading player's swing must not damage the monster"
+    );
+}

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -53,5 +53,6 @@ pub fn new_player(
         last_combat_at: 0,
         client_kind,
         back_color: None,
+        ready_at: 0,
     }
 }

--- a/shared/src/entity.rs
+++ b/shared/src/entity.rs
@@ -99,6 +99,22 @@ pub struct Player {
     /// broadcasting it would let clients label individual players.
     #[serde(skip)]
     pub client_kind: ClientKind,
+    /// Wall-clock ms (unix time) at which the player becomes damageable.
+    /// While the client is still building the world, this sits in the future;
+    /// `WorldReady` zeroes it early, and the deadline is the backstop for a
+    /// client that never reports ready. 0 = ready.
+    #[serde(skip)]
+    pub ready_at: u64,
+}
+
+/// Longest a client may claim to still be loading the world. Entering next to
+/// an aggroed monster otherwise kills the player before the scene is drawn.
+pub const WORLD_LOADING_GRACE_MS: u64 = 30_000;
+
+impl Player {
+    pub fn is_ready(&self, now_ms: u64) -> bool {
+        now_ms >= self.ready_at
+    }
 }
 
 /// Client program on the other end of a connection. Self-reported, so it may
@@ -316,6 +332,7 @@ mod tests {
             object_id: None,
             last_combat_at: 0,
             client_kind: ClientKind::default(),
+            ready_at: 0,
             back_color: None,
             back_texture: None,
             wet: false,
@@ -358,6 +375,7 @@ mod tests {
             object_id: None,
             last_combat_at: 0,
             client_kind: ClientKind::default(),
+            ready_at: 0,
             back_color: None,
             back_texture: None,
             wet: false,

--- a/shared/src/housing.rs
+++ b/shared/src/housing.rs
@@ -91,7 +91,11 @@ pub fn double_door_partner(segs: &[WallConfig], i: usize) -> Option<usize> {
     while r > 0 && segs[r - 1].variant == WallVariant::WithDoubleDoor {
         r -= 1;
     }
-    let partner = if (i - r) % 2 == 0 { i + 1 } else { i - 1 };
+    let partner = if (i - r).is_multiple_of(2) {
+        i + 1
+    } else {
+        i - 1
+    };
     (segs.get(partner)?.variant == WallVariant::WithDoubleDoor).then_some(partner)
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -256,6 +256,7 @@ mod tests {
             object_id: None,
             last_combat_at: 0,
             client_kind: Default::default(),
+            ready_at: 0,
             back_color: None,
             back_texture: None,
             wet: false,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,7 +107,9 @@ pub const NPC_TOKEN_FILENAME: &str = "npc_token";
 /// v43: `FriendEntry.class`, so the friend panel can draw class icons.
 /// v44: `WallVariant::WithDoubleDoor` ("double-door"); stale clients cannot
 ///      decode houses that use it.
-pub const PROTOCOL_VERSION: u32 = 44;
+/// v45: `ClientMessage::WorldReady` ends the entry grace that shields a
+///      player until their scene is drawn; an older server cannot decode it.
+pub const PROTOCOL_VERSION: u32 = 45;
 
 /// Fingerprint of the dungeon layout generator this build compiled, stamped by
 /// `build.rs`. Layouts never travel the wire — both sides generate them from

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -337,6 +337,9 @@ pub enum ClientMessage {
     EnterGame {
         character_id: i64,
     },
+    /// The scene has finished compiling, so the player can be hit again. See
+    /// `entity::WORLD_LOADING_GRACE_MS`.
+    WorldReady,
     PlayerMove {
         position: Position,
         rotation: f32,

--- a/tools/terrain-gen/src/world_map.rs
+++ b/tools/terrain-gen/src/world_map.rs
@@ -693,7 +693,7 @@ impl Semantic {
         let shallow_water = proximity(pixel, [100, 160, 220], 28.0);
         let river_blue = ((pixel[2] as f32 - pixel[0] as f32 - 35.0) / 75.0).clamp(0.0, 1.0)
             * ((pixel[2] as f32 - pixel[1] as f32 - 12.0) / 55.0).clamp(0.0, 1.0);
-        let land = deep_water < 0.58 && !(shallow_water > 0.65 && !sample.land);
+        let land = deep_water < 0.58 && (shallow_water <= 0.65 || sample.land);
         let spread = *pixel.iter().max().unwrap() as f32 - *pixel.iter().min().unwrap() as f32;
         let neutral = (1.0 - smoothstep(18.0, 42.0, spread)).clamp(0.0, 1.0);
         let road = proximity(pixel, [140, 135, 125], 38.0).max(


### PR DESCRIPTION
## Problem

Spawning (or logging back in) inside a dungeon could be a death sentence: while the client sits on the "Preparing world..." screen compiling the scene, the player is fully hittable on the server but cannot see or do anything. An aggroed monster next to the spawn point kills them before the world is even drawn.

## Fix

The server now grants every entering player an **entry grace** during which monsters cannot damage them:

- New `ready_at` unix-ms field on `Player` (`#[serde(skip)]`, `0` = ready) with `is_ready(now)`; armed to `now + 30s` at `EnterGame`.
- New `ClientMessage::WorldReady`: the web client sends it when scene compilation finishes (the moment the loading overlay lifts), ending the grace immediately. The agent-client sends it right after `JoinSuccess` since it has no scene to build.
- Damage gate in `monster_attack`: every damage path — owning client or the server's own brain — already funnels through this one target check, so the grace is enforced in one place.
- The server-AI roster skips loading players, so brains never aggro onto someone who can't see the world yet.

## Abuse resistance

A tampered client withholding `WorldReady` gains nothing:

- The grace is a deadline, not a switch — it expires on its own after 30s (`WORLD_LOADING_GRACE_MS`).
- Untouchable means untouching: `validate_player_attack` rejects swings from a loading player (`NotInGame` ack), so there is no invulnerable damage window.

## Tests

`server/src/game_state/tests/world_ready_tests.rs`:

- `only_the_loading_player_is_shielded` — two players on the same spot, told apart only by `ready_at`: the loading one takes no damage, the ready control is hit, and after `WorldReady` the same attack lands.
- `loading_grace_expires_without_world_ready` — a client that never reports ready becomes damageable once the deadline passes.
- `loading_player_cannot_attack` — a loading player's swing is rejected and deals no damage.

Verified the tests catch the bug: with the gate neutered (`is_ready` forced `true`), the two shield tests fail exactly as expected.

Full workspace suite passes (1276 tests), clippy clean, client `svelte-check` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)