### PR TITLE
Fix the Docker image builds: copy the deck catalog and hash-assets script

### DIFF
--- a/docker/agent-client.Dockerfile
+++ b/docker/agent-client.Dockerfile
@@ -10,8 +10,11 @@ FROM rust:1-bookworm AS builder
 WORKDIR /build
 
 COPY Cargo.toml Cargo.lock clippy.toml ./
-# shared/ embeds three tracked JSON files from data/ with include_str!.
+# shared/ embeds tracked JSON from data/ and the object catalog with
+# include_str!. The catalog is a small tracked file, so it is copied alone
+# rather than dragging all of client/public into the image.
 COPY data/ data/
+COPY client/public/models/objects/catalog.json client/public/models/objects/
 COPY shared/ shared/
 COPY terrain/ terrain/
 COPY agent-client/ agent-client/

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -58,6 +58,7 @@ RUN npm ci
 COPY client/index.html client/vite.config.ts client/svelte.config.js \
      client/tsconfig.json client/tsconfig.app.json client/tsconfig.node.json ./
 COPY client/src/ src/
+COPY client/scripts/ scripts/
 
 ARG CLIENT_ID_PLACEHOLDER
 ENV VITE_GOOGLE_CLIENT_ID=${CLIENT_ID_PLACEHOLDER}


### PR DESCRIPTION
## Problem

The Docker publish workflow has been failing on every master push since 2026-08-29 (6 consecutive runs on upstream). The regular CI workflow is unaffected — only the image builds break, in two independent ways:

- **agent-client (slim/codex, both arches)**: `shared/src/bridge.rs` now embeds `client/public/models/objects/catalog.json` via `include_str!` (introduced in c648c4e4), but `docker/agent-client.Dockerfile` never copies anything from `client/public`, so `cargo build` fails with `couldn't read ... catalog.json: No such file or directory`.
- **client (both arches)**: `npm run build` now ends with `hash:assets` → `node scripts/hash-assets.mjs` (introduced in c18b724c), but `docker/client.Dockerfile` enumerates its client-root build inputs and `client/scripts/` was not added, so the build fails with `Cannot find module '/build/client/scripts/hash-assets.mjs'`.

## Fix

- `docker/agent-client.Dockerfile`: copy the single tracked `catalog.json` file, the same way `docker/server.Dockerfile` already does for terrain-gen, instead of pulling all of `client/public` (~750 MB) into the build context.
- `docker/client.Dockerfile`: add `COPY client/scripts/ scripts/` next to the other enumerated client-root inputs.

## Verification

Ran the full Docker publish matrix on my fork with only these changes on top of current master (the fork branch adds a temporary workflow trigger, not included here). All 8 build jobs and all 4 manifest jobs passed:

https://github.com/darkdarkcocoa/OpenMMO/actions/runs/33260973470