### PR TITLE
Add fishing-earned title for landing the golden sturgeon

### DIFF
--- a/data-src/titles.csv
+++ b/data-src/titles.csv
@@ -1,7 +1,8 @@
-id,name,nameKo,source,bossId,solo,order,supersedes
-goblin_slayer,Slayer of the Goblin Chief,고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,false,10,
-goblin_slayer_solo,Who Slew the Goblin Chief Alone,홀로 고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,true,11,goblin_slayer
-orc_slayer,Slayer of the Orc Warlord,오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,false,20,
-orc_slayer_solo,Who Slew the Orc Warlord Alone,홀로 오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,true,21,orc_slayer
-ogre_slayer,Slayer of the Ogre Warlord,오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,false,30,
-ogre_slayer_solo,Who Slew the Ogre Warlord Alone,홀로 오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,true,31,ogre_slayer
+id,name,nameKo,source,bossId,itemId,solo,order,supersedes
+goblin_slayer,Slayer of the Goblin Chief,고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,,false,10,
+goblin_slayer_solo,Who Slew the Goblin Chief Alone,홀로 고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,,true,11,goblin_slayer
+orc_slayer,Slayer of the Orc Warlord,오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,,false,20,
+orc_slayer_solo,Who Slew the Orc Warlord Alone,홀로 오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,,true,21,orc_slayer
+ogre_slayer,Slayer of the Ogre Warlord,오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,,false,30,
+ogre_slayer_solo,Who Slew the Ogre Warlord Alone,홀로 오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,,true,31,ogre_slayer
+sturgeon_angler,Who Landed the Golden Sturgeon,황금 철갑상어를 낚은 자,fishing,,golden_sturgeon,false,40,

--- a/doc/TITLES.md
+++ b/doc/TITLES.md
@@ -44,27 +44,29 @@
 ## 정의 — `data-src/titles.csv`
 
 ```
-id,name,nameKo,source,bossId,solo,order,supersedes
-goblin_slayer,Slayer of the Goblin Chief,고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,false,10,
-goblin_slayer_solo,Who Slew the Goblin Chief Alone,홀로 고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,true,11,goblin_slayer
-orc_slayer,Slayer of the Orc Warlord,오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,false,20,
-orc_slayer_solo,Who Slew the Orc Warlord Alone,홀로 오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,true,21,orc_slayer
-ogre_slayer,Slayer of the Ogre Warlord,오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,false,30,
-ogre_slayer_solo,Who Slew the Ogre Warlord Alone,홀로 오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,true,31,ogre_slayer
+id,name,nameKo,source,bossId,itemId,solo,order,supersedes
+goblin_slayer,Slayer of the Goblin Chief,고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,,false,10,
+goblin_slayer_solo,Who Slew the Goblin Chief Alone,홀로 고블린 족장을 쓰러뜨린 자,boss_kill,goblin_boss,,true,11,goblin_slayer
+orc_slayer,Slayer of the Orc Warlord,오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,,false,20,
+orc_slayer_solo,Who Slew the Orc Warlord Alone,홀로 오크 군주를 쓰러뜨린 자,boss_kill,orc_boss,,true,21,orc_slayer
+ogre_slayer,Slayer of the Ogre Warlord,오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,,false,30,
+ogre_slayer_solo,Who Slew the Ogre Warlord Alone,홀로 오거 군주를 쓰러뜨린 자,boss_kill,ogre_boss,,true,31,ogre_slayer
+sturgeon_angler,Who Landed the Golden Sturgeon,황금 철갑상어를 낚은 자,fishing,,golden_sturgeon,false,40,
 ```
 
 칭호는 등급 이름이 아니라 **한 줄짜리 이야기**다("홀로 오거 군주를 쓰러뜨린 자"). 몬스터
 이름을 그대로 써서 어느 보스인지 바로 읽히고, "홀로"가 위 90% 조건에 대응한다.
 
-- `source`는 부여 경로. 지금은 `boss_kill` 하나고 `bossId`·`solo`가 그 조건이다. 나중에
-  낚시 기록·누적 처치 같은 경로가 생기면 열이 늘지 행이 바뀌지 않는다.
+- `source`는 부여 경로. `boss_kill`은 `bossId`·`solo`가, `fishing`(2026-08-31)은
+  `itemId` — 그 물고기를 낚아 올리면 부여 — 가 그 조건이다. 경로가 더 생기면 열이 늘지
+  행이 바뀌지 않는다.
 - `supersedes`는 이 칭호가 대신하는 칭호. 그 칭호를 보이고 있던 사람이 이걸 얻으면 자동으로
   바뀐다. 코드가 "같은 보스의 홀로"를 추론하지 않고 데이터가 말한다.
 - `order`는 목록 정렬용. 가치의 서열은 아니다.
 - 다른 데이터와 같이 `node tools/convert.mjs`로 `data/titles.json`을 만들고 서버·클라이언트가
   같은 파일을 읽는다. 필드에 쉼표 금지.
-- 서버는 시작할 때 `bossId`를 `MonsterDefs`와 대조해 없는 보스면 패닉한다
-  (`dungeon_defs.rs`가 `chestDrops`를 검증하는 것과 같은 자세).
+- 서버는 시작할 때 `bossId`를 `MonsterDefs`와, `itemId`를 `ItemDefs`와 대조해 없으면
+  패닉한다(`dungeon_defs.rs`가 `chestDrops`를 검증하는 것과 같은 자세).
 
 첫 세트는 보스당 둘(쓰러뜨린 자·홀로)로 시작한다. **누적 처치**(10회·100회)와 **서버 최초 처치**는 후보로만
 둔다. 서버 최초는 "이미 누가 잡았는가"를 재시작 너머로 기억해야 하므로 영속 마커가 하나 더

--- a/server/src/game_state/fishing.rs
+++ b/server/src/game_state/fishing.rs
@@ -632,7 +632,7 @@ impl GameState {
 
     /// The 250 ms fishing tick: advances casts to waits, waits to bites, and
     /// expires bites the angler slept through.
-    pub async fn tick_fishing(&self) {
+    pub async fn tick_fishing(&self, auth: Option<&crate::auth::AuthService>) {
         if self.no_fishing_anywhere() {
             return;
         }
@@ -814,7 +814,7 @@ impl GameState {
         for (player_id, sid, after) in results {
             match after {
                 After::Beat(bobber, msg) => self.broadcast_fishing(&bobber, *msg).await,
-                After::Landed => self.finish_fishing_caught(&player_id, sid).await,
+                After::Landed => self.finish_fishing_caught(&player_id, sid, auth).await,
                 After::Escaped => {
                     self.end_fishing_if(&player_id, Some(sid), FishingOutcome::Escaped, ESCAPE_XP)
                         .await;
@@ -920,7 +920,12 @@ impl GameState {
     /// overweight), grant skill XP, end the session with the full catch
     /// details. `sid` guards against a session cancelled and re-cast between
     /// the tick's scan and this call.
-    async fn finish_fishing_caught(&self, player_id: &PlayerId, sid: u64) {
+    async fn finish_fishing_caught(
+        &self,
+        player_id: &PlayerId,
+        sid: u64,
+        auth: Option<&crate::auth::AuthService>,
+    ) {
         let Some(fish) = ({
             let mut sessions = self.fishing_sessions.write().await;
             sessions
@@ -938,6 +943,18 @@ impl GameState {
         // (`use_item`) for its copper. Junk is rarityTier 0, so the XP
         // formula below grants nothing for it naturally.
         self.award_item(player_id, &fish.item_def_id).await;
+        // Off the tick path: the catch doesn't wait on the title writes.
+        if crate::title_defs::fishing_catch_title(&fish.item_def_id).is_some() {
+            let game_state = self.clone();
+            let player_id = *player_id;
+            let item = fish.item_def_id.clone();
+            let auth = auth.cloned();
+            tokio::spawn(async move {
+                game_state
+                    .grant_fishing_catch_title(&player_id, &item, auth.as_ref())
+                    .await;
+            });
+        }
         let xp = CATCH_XP_PER_RARITY_SQ * u64::from(fish.rarity) * u64::from(fish.rarity);
         self.add_skill_xp(player_id, SkillId::Fishing, xp).await;
         self.end_fishing(

--- a/server/src/game_state/tests/fishing_tests/flow_tests.rs
+++ b/server/src/game_state/tests/fishing_tests/flow_tests.rs
@@ -33,7 +33,7 @@ async fn fight_to_the_end(
             }
         }
         advance(Duration::from_millis(250)).await;
-        game_state.tick_fishing().await;
+        game_state.tick_fishing(None).await;
     }
     panic!("the fight never ended");
 }
@@ -181,6 +181,47 @@ async fn fishing_works_in_a_river_above_sea_level() {
         matches!(outcome, FishingOutcome::Caught { .. }),
         "perfect play should land a river fish, got {outcome:?}"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn landing_a_golden_sturgeon_earns_the_angler_title() {
+    let game_state = make_test_game_state("fishing_title_flow");
+    let (id, mut rx) = make_angler(&game_state, "angler_title").await;
+    game_state.set_player_titles(&id, Vec::new()).await;
+
+    game_state.start_fishing(&id, water_target()).await;
+    advance_until_bite(&game_state, &mut rx).await;
+    // Which species bites is random; the title is not. Force the roll.
+    game_state
+        .fishing_sessions
+        .write()
+        .await
+        .get_mut(&id)
+        .unwrap()
+        .rolled_fish
+        .as_mut()
+        .unwrap()
+        .item_def_id = "golden_sturgeon".to_string();
+
+    game_state.respond_fishing(&id, FishingAction::Hook).await;
+    let (outcome, _) = fight_to_the_end(&game_state, &id, &mut rx, auto_stance).await;
+    assert!(matches!(outcome, FishingOutcome::Caught { .. }));
+
+    // The grant runs off the tick; let the spawned task finish.
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+    let titles = game_state
+        .player_titles
+        .read()
+        .await
+        .get(&id)
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(titles, ["sturgeon_angler"]);
+    assert!(drain(&mut rx)
+        .iter()
+        .any(|m| matches!(m, ServerMessage::TitleEarned { title } if title == "sturgeon_angler")));
 }
 
 #[tokio::test(start_paused = true)]
@@ -446,7 +487,7 @@ async fn ignoring_the_fight_escapes_the_fish() {
             msgs.push(msg);
         }
         advance(Duration::from_millis(250)).await;
-        game_state.tick_fishing().await;
+        game_state.tick_fishing(None).await;
     }
     assert_eq!(outcome, Some(FishingOutcome::Escaped));
     assert!(msgs.iter().any(|m| matches!(
@@ -509,7 +550,7 @@ async fn two_anglers_fish_independently() {
             }
         }
         advance(Duration::from_millis(250)).await;
-        game_state.tick_fishing().await;
+        game_state.tick_fishing(None).await;
     }
 
     assert_eq!(ended.len(), 2, "both anglers must finish their sessions");

--- a/server/src/game_state/tests/fishing_tests/mod.rs
+++ b/server/src/game_state/tests/fishing_tests/mod.rs
@@ -1,6 +1,6 @@
 // ---- Fishing (doc/FISHING.md) ----------------------------------------------
 // Paused-time tests: tokio's clock is frozen, `time::advance` moves it, and
-// `tick_fishing()` is driven by hand — the state machine runs deterministically.
+// `tick_fishing` is driven by hand — the state machine runs deterministically.
 
 use super::*;
 use onlinerpg_shared::fishing::{
@@ -96,7 +96,7 @@ async fn advance_with_ticks(game_state: &GameState, total_ms: u64) {
     while remaining > 0 {
         let step = remaining.min(250);
         advance(Duration::from_millis(step)).await;
-        game_state.tick_fishing().await;
+        game_state.tick_fishing(None).await;
         remaining -= step;
     }
 }
@@ -110,7 +110,7 @@ async fn advance_until_bite(game_state: &GameState, rx: &mut DirectRx) {
     let mut elapsed = 0;
     while elapsed < budget_ms {
         advance(Duration::from_millis(250)).await;
-        game_state.tick_fishing().await;
+        game_state.tick_fishing(None).await;
         elapsed += 250;
         if drain(rx)
             .iter()

--- a/server/src/game_state/tests/title_tests.rs
+++ b/server/src/game_state/tests/title_tests.rs
@@ -108,6 +108,36 @@ async fn an_even_split_earns_nobody_a_title_and_a_regular_monster_logs_nothing()
 }
 
 #[tokio::test]
+async fn landing_the_golden_sturgeon_earns_the_angler_title_once() {
+    let game_state = make_test_game_state("titles_fishing");
+    let mut ann = enter(&game_state, "Ann", 1).await;
+    drain(&mut ann);
+
+    game_state
+        .grant_fishing_catch_title(&pid("Ann"), "golden_sturgeon", None)
+        .await;
+    let (titles, active) = titles_of(&game_state, "Ann").await;
+    assert_eq!(titles, ["sturgeon_angler"]);
+    // A first-ever title auto-shows.
+    assert_eq!(active.as_deref(), Some("sturgeon_angler"));
+    assert!(drain(&mut ann)
+        .iter()
+        .any(|m| matches!(m, ServerMessage::TitleEarned { title } if title == "sturgeon_angler")));
+
+    // A repeat catch and an untitled fish grant nothing.
+    game_state
+        .grant_fishing_catch_title(&pid("Ann"), "golden_sturgeon", None)
+        .await;
+    game_state
+        .grant_fishing_catch_title(&pid("Ann"), "raw_minnow", None)
+        .await;
+    assert_eq!(titles_of(&game_state, "Ann").await.0, ["sturgeon_angler"]);
+    assert!(drain(&mut ann)
+        .iter()
+        .all(|m| !matches!(m, ServerMessage::TitleEarned { .. })));
+}
+
+#[tokio::test]
 async fn a_player_picks_among_earned_titles_and_cannot_show_an_unearned_one() {
     let game_state = make_test_game_state("titles_pick");
     let mut ann = enter(&game_state, "Ann", 1).await;

--- a/server/src/game_state/titles.rs
+++ b/server/src/game_state/titles.rs
@@ -1,5 +1,6 @@
-//! Boss-kill titles (doc/TITLES.md): a per-boss damage log, the grant on
-//! death, and which earned title a player shows (`Player.title`).
+//! Titles (doc/TITLES.md): the per-boss damage log and its grant on death,
+//! the fishing-catch grant, and which earned title a player shows
+//! (`Player.title`).
 
 use std::collections::HashMap;
 
@@ -99,6 +100,32 @@ impl GameState {
                 self.grant_title(character_id, &def.id, auth).await;
             }
         }
+    }
+
+    /// A landed catch of a title-worthy fish. Official NPCs are scenery,
+    /// not contenders, here as on the boss log.
+    pub(super) async fn grant_fishing_catch_title(
+        &self,
+        player_id: &PlayerId,
+        item_def_id: &str,
+        auth: Option<&AuthService>,
+    ) {
+        let Some(def) = title_defs::fishing_catch_title(item_def_id) else {
+            return;
+        };
+        let official = self
+            .players
+            .read()
+            .await
+            .get(player_id)
+            .is_none_or(|p| p.is_official_npc);
+        if official {
+            return;
+        }
+        let Some(character_id) = self.character_id_of(player_id).await else {
+            return;
+        };
+        self.grant_title(character_id, &def.id, auth).await;
     }
 
     async fn grant_title(&self, character_id: i64, title: &str, auth: Option<&AuthService>) {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -337,8 +337,8 @@ async fn main() -> ExitCode {
     let args = Args::parse();
     world_config::log_world_config();
     let monster_defs = monster_defs::MonsterDefs::load();
-    title_defs::validate(&monster_defs);
     let item_defs = item_defs::item_defs().clone();
+    title_defs::validate(&monster_defs, &item_defs);
     let dungeon_defs = dungeon_defs::DungeonDefs::load(&item_defs, &monster_defs);
     let world_drop_defs = world_drop_defs::WorldDropDefs::load(&item_defs);
     let paths = state_paths(&args.state_dir);
@@ -608,13 +608,15 @@ async fn main() -> ExitCode {
     // Fishing session timers (cast → wait → bite → expiry). 250 ms is far
     // inside every player-facing window; deadlines carry their own grace.
     let game_state_for_fishing = Arc::clone(&game_state);
+    let auth_for_fishing = Arc::clone(&auth_service);
     background.spawn(run_ticks(
         "fishing",
         Duration::from_millis(250),
         drain_shutdown.clone(),
         move || {
             let game_state = Arc::clone(&game_state_for_fishing);
-            async move { game_state.tick_fishing().await }
+            let auth = Arc::clone(&auth_for_fishing);
+            async move { game_state.tick_fishing(Some(&auth)).await }
         },
     ));
 

--- a/server/src/title_defs.rs
+++ b/server/src/title_defs.rs
@@ -11,6 +11,8 @@ pub struct TitleDef {
     pub source: String,
     #[serde(rename = "bossId", default)]
     pub boss_id: Option<String>,
+    #[serde(rename = "itemId", default)]
+    pub item_id: Option<String>,
     #[serde(default)]
     pub solo: bool,
     #[serde(default)]
@@ -45,13 +47,23 @@ pub fn boss_kill_titles(boss_type: &str) -> (Option<&'static TitleDef>, Option<&
     (shared, solo)
 }
 
+/// The title for catching `item_id`, if any.
+pub fn fishing_catch_title(item_id: &str) -> Option<&'static TitleDef> {
+    DEFS.values()
+        .find(|def| def.source == "fishing" && def.item_id.as_deref() == Some(item_id))
+}
+
 /// Order earned title ids as the definitions list them.
 pub fn sort_ids(ids: &mut [String]) {
     ids.sort_by_key(|id| (title_def(id).map_or(u32::MAX, |d| d.order), id.clone()));
 }
 
-/// Boot-time check: every boss_kill title names a real monster.
-pub fn validate(monster_defs: &crate::monster_defs::MonsterDefs) {
+/// Boot-time check: every boss_kill title names a real monster, every
+/// fishing title a real item.
+pub fn validate(
+    monster_defs: &crate::monster_defs::MonsterDefs,
+    item_defs: &crate::item_defs::ItemDefs,
+) {
     for def in DEFS.values() {
         if let Some(over) = &def.supersedes {
             assert!(
@@ -72,6 +84,18 @@ pub fn validate(monster_defs: &crate::monster_defs::MonsterDefs) {
                     "title '{}' names unknown boss '{}'",
                     def.id,
                     boss
+                );
+            }
+            "fishing" => {
+                let item = def
+                    .item_id
+                    .as_deref()
+                    .unwrap_or_else(|| panic!("title '{}' has no itemId", def.id));
+                assert!(
+                    item_defs.get(item).is_some(),
+                    "title '{}' names unknown item '{}'",
+                    def.id,
+                    item
                 );
             }
             other => panic!("title '{}' has unknown source '{}'", def.id, other),
@@ -98,7 +122,17 @@ mod tests {
     }
 
     #[test]
-    fn titles_validate_against_the_monster_table() {
-        validate(&crate::monster_defs::MonsterDefs::load());
+    fn the_golden_sturgeon_has_a_catch_title() {
+        let def = fishing_catch_title("golden_sturgeon").expect("sturgeon title");
+        assert!(!def.solo);
+        assert!(fishing_catch_title("raw_minnow").is_none());
+    }
+
+    #[test]
+    fn titles_validate_against_the_monster_and_item_tables() {
+        validate(
+            &crate::monster_defs::MonsterDefs::load(),
+            crate::item_defs::item_defs(),
+        );
     }
 }


### PR DESCRIPTION
A new title source: `fishing`. Landing a **golden sturgeon** grants `sturgeon_angler` — "Who Landed the Golden Sturgeon / 황금 철갑상어를 낚은 자".
