### PR TITLE
Drop the vanished prompts/ directory from the agent image

### DIFF
--- a/docker/agent-client.Dockerfile
+++ b/docker/agent-client.Dockerfile
@@ -51,7 +51,6 @@ COPY agent-client/data/animation_durations.json \
      agent-client/data/system_prompt.txt \
      /app/agent-client/data/
 COPY agent-client/data/templates/ /app/agent-client/data/templates/
-COPY agent-client/data/prompts/ /app/agent-client/data/prompts/
 COPY agent-client/data/user_prompts/ /app/agent-client/data/user_prompts/
 
 # The binary resolves data/config.toml and ../data/npc_token relative to CWD.


### PR DESCRIPTION
## Summary

Docker publish has failed for every `agent-client-slim` / `agent-client-codex` build since 3e9cb702: the slim stage still copies `agent-client/data/prompts/`, whose last file left with the Rico memory reset (59a2d97f). Git keeps no empty directories, so the `COPY` now fails with `not found`.

The runtime reads `data/templates`, `data/user_prompts` and `data/npcs` — the first two are already copied, and `npcs/` is bind-mounted from the server at run time (see `agent-entrypoint.sh`). Removing the stale line is the whole fix; server and client images were unaffected.

## Verification

Ran the full Docker publish matrix on a fork with this change: all 8 image builds and 4 manifests succeeded (`darkdarkcocoa/OpenMMO` run 33594387361).