### PR TITLE
Bold fishing bonus: hold tension past 80 for a chance at a second fish / 대담한 파이트 보너스

### DIFF
--- a/agent-client/src/driver/prompt.rs
+++ b/agent-client/src/driver/prompt.rs
@@ -569,7 +569,8 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
                     item_def_id,
                     size_cm,
                     trophy,
-                } => caught_line(item_def_id, *size_cm, *trophy),
+                    bonus_fish,
+                } => caught_line(item_def_id, *size_cm, *trophy, *bonus_fish),
                 FishingOutcome::Escaped => {
                     "[Fishing] The fish got away. You can cast again with the fish action."
                         .to_string()
@@ -632,14 +633,15 @@ pub(crate) fn format_event(state: &SharedState, msg: &ServerMessage) -> Option<S
 /// The `[Fishing]` line for a landed catch, with category-aware next steps.
 /// Keep the phrasing in sync with the browser client's `catchMessage`
 /// (client/src/lib/network/fishingMessages.ts).
-fn caught_line(item_def_id: &str, size_cm: u16, trophy: bool) -> String {
+fn caught_line(item_def_id: &str, size_cm: u16, trophy: bool, bonus_fish: bool) -> String {
     match crate::item_defs::get(item_def_id).and_then(|d| d.category.as_deref()) {
         Some("coin_catch") => format!(
             "[Fishing] You hauled up a {item_def_id}. It is in your bag — use it to open it and collect the coins, or fish again."
         ),
         Some("fish") => format!(
-            "[Fishing] You caught a {item_def_id} ({size_cm} cm){}. It is in your bag — you can eat it, sell it, or fish again.",
-            if trophy { " — a TROPHY catch!" } else { "" }
+            "[Fishing] You caught a {item_def_id} ({size_cm} cm){}{}. It is in your bag — you can eat it, sell it, or fish again.",
+            if trophy { " — a TROPHY catch!" } else { "" },
+            if bonus_fish { " A second one took the trailing hook — two in the bag." } else { "" }
         ),
         _ => format!(
             "[Fishing] You fished up a {item_def_id}. It is in your bag — junk like this can be sold if a merchant pays for it, or dropped."
@@ -959,7 +961,7 @@ mod tests {
 
     #[test]
     fn a_fish_is_edible_and_sellable() {
-        let line = caught_line("raw_trout", 34, false);
+        let line = caught_line("raw_trout", 34, false, false);
         assert!(line.contains("caught a raw_trout (34 cm)"), "{line}");
         assert!(line.contains("eat it, sell it"), "{line}");
         assert!(!line.contains("TROPHY"), "{line}");
@@ -967,14 +969,14 @@ mod tests {
 
     #[test]
     fn a_trophy_fish_celebrates() {
-        let line = caught_line("golden_sturgeon", 120, true);
+        let line = caught_line("golden_sturgeon", 120, true, false);
         assert!(line.contains("TROPHY"), "{line}");
         assert!(line.contains("eat it, sell it"), "{line}");
     }
 
     #[test]
     fn junk_is_not_presented_as_edible() {
-        let line = caught_line("old_boot", 40, false);
+        let line = caught_line("old_boot", 40, false, false);
         assert!(line.contains("fished up a old_boot"), "{line}");
         assert!(
             !line.contains("eat"),
@@ -984,7 +986,7 @@ mod tests {
 
     #[test]
     fn a_coin_catch_points_at_the_bag_and_the_use_action() {
-        let line = caught_line("sunken_coin_pouch", 12, false);
+        let line = caught_line("sunken_coin_pouch", 12, false, false);
         assert!(
             line.contains("bag"),
             "the pouch lands in the bag sealed: {line}"

--- a/agent-client/src/state/tests/events_tests.rs
+++ b/agent-client/src/state/tests/events_tests.rs
@@ -218,6 +218,7 @@ async fn a_beat_during_the_reaction_is_missed() {
         fish_state: FishState::Resting,
         tension_pct,
         stamina_pct: 50,
+        bonus_chance_pct: 0,
     };
 
     s.push_event(beat(20));

--- a/client/src/lib/components/FishingPrompt.svelte
+++ b/client/src/lib/components/FishingPrompt.svelte
@@ -10,10 +10,12 @@
   import { networkManager } from '../network/socket'
   import { playFishingSound } from '../managers/sfxManager'
   import { isTypingTarget } from '../utils/dom'
+  import { fishing_tension_bold } from '../wasm/onlinerpg_shared'
 
   type FightStance = Exclude<FishingAction, 'hook'>
 
   const WHEEL_BURST_MS = 350
+  const TENSION_BOLD = fishing_tension_bold()
 
   const STANCE_BUTTONS = [
     { stance: 'reel', label: 'REEL IN', hint: 'hold · SPACE · wheel ↓' },
@@ -140,8 +142,12 @@
   </button>
 {:else if $myFishing.phase === 'fight'}
   {@const f = $myFishing.fight}
+  {@const bold =
+    f.fishState === 'running' && f.tension >= TENSION_BOLD && f.tension < 85}
   <div class="fight-panel">
-    {#if f.fishState === 'running'}
+    {#if bold}
+      <div class="fish-state bold">Bold! Hold it here — it tires fastest.</div>
+    {:else if f.fishState === 'running'}
       <div class="fish-state running">The fish runs — watch the tension!</div>
     {:else if f.fishState === 'resting'}
       <div class="fish-state resting">The fish holds steady.</div>
@@ -159,9 +165,16 @@
     >
       <span
         class="tension-fill"
-        class:tension-warn={f.tension >= 60 && f.tension < 85}
+        class:tension-warn={f.tension >= 60 && f.tension < 85 && !bold}
+        class:tension-bold={bold}
         class:tension-high={f.tension >= 85}
         style={`width: ${Math.min(100, f.tension)}%`}
+      ></span>
+      <span
+        class="bold-mark"
+        class:lit={bold}
+        style={`left: ${TENSION_BOLD}%`}
+        title="Bold line: a running fish held past here earns a bonus-fish chance"
       ></span>
     </div>
     <div class="stance-row">
@@ -242,6 +255,12 @@
     animation: state-pulse 0.4s ease-in-out infinite alternate;
   }
 
+  .fish-state.bold {
+    color: #ffd766;
+    text-shadow: 0 0 8px rgba(255, 215, 102, 0.6);
+    animation: state-pulse 0.4s ease-in-out infinite alternate;
+  }
+
   .fish-state.exhausted {
     color: #6fd598;
     animation: state-pulse 0.6s ease-in-out infinite alternate;
@@ -274,8 +293,38 @@
       background 0.2s;
   }
 
+  .bold-mark {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(255, 255, 255, 0.7);
+    transform: translateX(-1px);
+    transition: background 0.2s;
+  }
+
+  .bold-mark.lit {
+    background: #fff3b0;
+    box-shadow: 0 0 6px 2px rgba(255, 220, 120, 0.9);
+  }
+
   .tension-fill.tension-warn {
     background: #e8c34f;
+  }
+
+  .tension-fill.tension-bold {
+    background: linear-gradient(90deg, #e8c34f, #ffd766);
+    box-shadow: 0 0 10px 2px rgba(255, 215, 102, 0.75);
+    animation: fishing-bold-shimmer 0.5s ease-in-out infinite alternate;
+  }
+
+  @keyframes fishing-bold-shimmer {
+    from {
+      filter: brightness(1);
+    }
+    to {
+      filter: brightness(1.3);
+    }
   }
 
   .tension-fill.tension-high {

--- a/client/src/lib/network/fishingMessages.test.ts
+++ b/client/src/lib/network/fishingMessages.test.ts
@@ -50,6 +50,31 @@ describe('catchMessage', () => {
     )
   })
 
+  it('tells a bold fight its fish came doubled', () => {
+    expect(
+      catchMessage(
+        { name: 'Raw Trout', category: 'fish' },
+        'raw_trout',
+        34,
+        false,
+        true
+      )
+    ).toBe(
+      'You caught a Raw Trout (34 cm). Bold fight — a second one took the trailing hook!'
+    )
+    expect(
+      catchMessage(
+        { name: 'Golden Sturgeon', category: 'fish' },
+        'golden_sturgeon',
+        120,
+        true,
+        true
+      )
+    ).toBe(
+      'Trophy catch! Golden Sturgeon, 120 cm! Bold fight — a second one took the trailing hook!'
+    )
+  })
+
   it('picks the article by the leading vowel', () => {
     expect(
       catchMessage(

--- a/client/src/lib/network/fishingMessages.ts
+++ b/client/src/lib/network/fishingMessages.ts
@@ -10,14 +10,18 @@ export function catchMessage(
   def: CatchDefLike | undefined,
   fallbackId: string,
   sizeCm: number,
-  trophy: boolean
+  trophy: boolean,
+  bonusFish = false
 ): string {
   const name = def?.name ?? fallbackId
   const an = /^[aeiou]/i.test(name) ? 'an' : 'a'
-  if (trophy) return `Trophy catch! ${name}, ${sizeCm} cm!`
+  const bonus = bonusFish
+    ? ' Bold fight — a second one took the trailing hook!'
+    : ''
+  if (trophy) return `Trophy catch! ${name}, ${sizeCm} cm!${bonus}`
   if (def?.category === 'coin_catch')
     return `You haul up ${an} ${name}! Double-click it in your bag to open it.`
   if (def?.category === 'fish')
-    return `You caught ${an} ${name} (${sizeCm} cm).`
+    return `You caught ${an} ${name} (${sizeCm} cm).${bonus}`
   return `You fished up ${an} ${name}.`
 }

--- a/client/src/lib/network/messageHandlers.ts
+++ b/client/src/lib/network/messageHandlers.ts
@@ -2002,13 +2002,14 @@ export function handleServerMessage(
           addCombatMessage({ text: 'You reel in your line.', sender: 'local' })
         } else if (outcome?.Caught) {
           playFishingSound('catch')
-          const { item_def_id, size_cm, trophy } = outcome.Caught
+          const { item_def_id, size_cm, trophy, bonus_fish } = outcome.Caught
           addCombatMessage({
             text: catchMessage(
               getItemDef(item_def_id),
               item_def_id,
               size_cm,
-              trophy
+              trophy,
+              bonus_fish
             ),
             sender: 'local',
           })

--- a/client/src/lib/network/networkTypes.ts
+++ b/client/src/lib/network/networkTypes.ts
@@ -391,7 +391,12 @@ export type FishState = 'running' | 'resting' | 'exhausted'
  *  externally-tagged serde shape. */
 export type FishingOutcome =
   | {
-      Caught: { item_def_id: string; size_cm: number; trophy: boolean }
+      Caught: {
+        item_def_id: string
+        size_cm: number
+        trophy: boolean
+        bonus_fish: boolean
+      }
     }
   | 'Escaped'
   | 'Aborted'

--- a/doc/FISHING.md
+++ b/doc/FISHING.md
@@ -222,6 +222,27 @@ the angler holds one of three stances, changed any time via
   that outlives 60 s throws the hook (`Escaped`): slack-line stalling is not
   a strategy, and neither is walking away (unmanaged tension snaps within
   seconds).
+- **Bold play → bonus fish**: the server counts how long the fish has Run
+  and how much of that the line was held at or above `TENSION_BOLD` (80,
+  just under the red band). That *bold share*, squared and scaled by
+  `BONUS_FISH_MAX_CHANCE` (25%), is the chance — broadcast live as
+  `FishingFight.bonus_chance_pct` — that a second fish of the same species
+  took the trailing hook at landing (`Caught.bonus_fish`). Risk pays twice
+  on purpose: bold play already tires the fish fastest, and now it also pays
+  out, so a cautious angler and a bold one play different games rather than
+  different clocks. Continuous, so there is no threshold to camp on. Junk and
+  coin pouches (rarity 0) never double, and the bonus grants no extra XP.
+
+  | bold share of running time | bonus chance |
+  |---|---|
+  | 25% | 1.6% |
+  | 50% | 6.3% |
+  | 75% | 14.1% |
+  | 100% | 25% |
+
+  The hook-set opens at tension 30 and every rest lets it decay, so the
+  climb back past 80 never counts: a superb human fight lands around a
+  70–85% share (12–18%); the 25% cap is theoretical.
 
 Every beat is broadcast as `FishingFight { bobber, fish_state, tension_pct,
 stamina_pct }` — public information by design, which is what keeps humans

--- a/server/src/game_state/estate_storage.rs
+++ b/server/src/game_state/estate_storage.rs
@@ -106,46 +106,6 @@ impl EstateChestIndex {
     }
 }
 
-#[cfg(test)]
-mod index_tests {
-    use super::*;
-    use onlinerpg_shared::{WORLD_MAX_X, WORLD_MIN_X};
-
-    fn chest(id: i64, x: f32, z: f32, floor_level: i8) -> EstateChest {
-        EstateChest {
-            id,
-            estate_id: 1,
-            owner_id: 1,
-            item_def_id: "storage_chest".to_string(),
-            position: Position { x, y: 0.0, z },
-            rotation_deg: 0.0,
-            floor_level,
-            overdue: false,
-            revision: 0,
-        }
-    }
-
-    #[test]
-    fn nearby_uses_spatial_buckets_across_the_world_seam() {
-        let mut index = EstateChestIndex::default();
-        index.insert(chest(1, WORLD_MAX_X - 2.0, 0.0, 0));
-        index.insert(chest(2, 100.0, 100.0, 0));
-        index.insert(chest(3, WORLD_MAX_X - 2.0, 0.0, 1));
-
-        let found = index.nearby(
-            &Position {
-                x: WORLD_MIN_X + 2.0,
-                y: 0.0,
-                z: 0.0,
-            },
-            0,
-        );
-
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].id, 1);
-    }
-}
-
 fn cache_key(key: (i32, i32)) -> String {
     format!("furniture:estate-storage:{},{}", key.0, key.1)
 }
@@ -938,5 +898,45 @@ impl GameState {
             self.send_inventory_snapshot(player_id, updated).await;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod index_tests {
+    use super::*;
+    use onlinerpg_shared::{WORLD_MAX_X, WORLD_MIN_X};
+
+    fn chest(id: i64, x: f32, z: f32, floor_level: i8) -> EstateChest {
+        EstateChest {
+            id,
+            estate_id: 1,
+            owner_id: 1,
+            item_def_id: "storage_chest".to_string(),
+            position: Position { x, y: 0.0, z },
+            rotation_deg: 0.0,
+            floor_level,
+            overdue: false,
+            revision: 0,
+        }
+    }
+
+    #[test]
+    fn nearby_uses_spatial_buckets_across_the_world_seam() {
+        let mut index = EstateChestIndex::default();
+        index.insert(chest(1, WORLD_MAX_X - 2.0, 0.0, 0));
+        index.insert(chest(2, 100.0, 100.0, 0));
+        index.insert(chest(3, WORLD_MAX_X - 2.0, 0.0, 1));
+
+        let found = index.nearby(
+            &Position {
+                x: WORLD_MIN_X + 2.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            0,
+        );
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, 1);
     }
 }

--- a/server/src/game_state/fishing.rs
+++ b/server/src/game_state/fishing.rs
@@ -5,15 +5,15 @@
 //! `LATENCY_GRACE_MS` of slack.
 
 use onlinerpg_shared::fishing::{
-    fish_pull_ps, reel_speed_mps, stamina_drain_ps, stamina_max, FishState, FishingAction,
-    FishingOutcome, BITE_WINDOW_MS, CAST_MS, CATCH_SLACK_M, CATCH_XP_PER_RARITY_SQ, ESCAPE_XP,
-    EXHAUSTED_STEER_PER_TICK, FIGHT_TIMEOUT_MS, FISH_WANDER_RADIUS_M, FLOTSAM_SHARE_PCT,
+    bonus_fish_chance, fish_pull_ps, reel_speed_mps, stamina_drain_ps, stamina_max, FishState,
+    FishingAction, FishingOutcome, BITE_WINDOW_MS, CAST_MS, CATCH_SLACK_M, CATCH_XP_PER_RARITY_SQ,
+    ESCAPE_XP, EXHAUSTED_STEER_PER_TICK, FIGHT_TIMEOUT_MS, FISH_WANDER_RADIUS_M, FLOTSAM_SHARE_PCT,
     GIVE_LINE_EXTRA_MPS, LATENCY_GRACE_MS, MAX_CAST_DISTANCE_METERS, MIN_FISHABLE_DEPTH_M,
     MIN_FISH_DISTANCE_M, PANIC_BAND_M, RARITY_SKILL_BONUS_PCT, REST_MAX_MS, REST_MIN_MS,
     RUN_MAX_MS, RUN_MAX_PER_RARITY_MS, RUN_MIN_MS, RUN_SPEED_BASE_MPS, RUN_SPEED_PER_RARITY_MPS,
-    SHORE_SAMPLE_STEP_M, STAMINA_DRAIN_MIN_TENSION, STAMINA_RECOVER_PS, TENSION_GIVE_RELIEF_PS,
-    TENSION_INITIAL, TENSION_MAX, TENSION_REEL_PS, TENSION_REST_DECAY_PS, WAIT_MAX_MS, WAIT_MIN_MS,
-    WATERLINE_MARGIN_M,
+    SHORE_SAMPLE_STEP_M, STAMINA_DRAIN_MIN_TENSION, STAMINA_RECOVER_PS, TENSION_BOLD,
+    TENSION_GIVE_RELIEF_PS, TENSION_INITIAL, TENSION_MAX, TENSION_REEL_PS, TENSION_REST_DECAY_PS,
+    WAIT_MAX_MS, WAIT_MIN_MS, WATERLINE_MARGIN_M,
 };
 use onlinerpg_shared::inventory::EquipSlot;
 use onlinerpg_shared::skills::SkillId;
@@ -55,6 +55,10 @@ pub(crate) struct FightState {
     /// Time left in the current Running/Resting burst.
     pub state_ms_left: f32,
     pub tension: f32,
+    /// Time the fish has spent Running, and how much of it at or above
+    /// `TENSION_BOLD`; their ratio is the bonus-fish chance.
+    pub run_ms: f32,
+    pub bold_run_ms: f32,
     /// Remaining stamina; the pool size is `stamina_max(rarity)`.
     pub stamina: f32,
     /// Angler-to-fish line length (XZ meters).
@@ -66,6 +70,21 @@ pub(crate) struct FightState {
     pub dir_x: f32,
     pub dir_z: f32,
     pub elapsed_ms: f32,
+}
+
+impl FightState {
+    #[cfg(test)]
+    pub fn bold_share(&self) -> f32 {
+        onlinerpg_shared::fishing::bold_share(self.bold_run_ms, self.run_ms)
+    }
+
+    pub fn bonus_chance(&self) -> f32 {
+        bonus_fish_chance(self.bold_run_ms, self.run_ms)
+    }
+
+    pub fn bonus_chance_pct(&self) -> u32 {
+        (self.bonus_chance() * 100.0).round() as u32
+    }
 }
 
 /// Randomness for one behavior flip, drawn lazily (most ticks don't flip)
@@ -146,6 +165,12 @@ pub(crate) fn step_fight(
         _ => {}
     }
     f.tension = (f.tension + tension_ps * dt).max(0.0);
+    if f.fish_state == FishState::Running {
+        f.run_ms += dt * 1000.0;
+        if f.tension >= TENSION_BOLD {
+            f.bold_run_ms += dt * 1000.0;
+        }
+    }
     if f.tension >= TENSION_MAX {
         return Some(FightOutcome::Snapped);
     }
@@ -757,7 +782,7 @@ impl GameState {
             // Boxed: the message dwarfs the other two variants, and this
             // vector holds one entry per fight in flight.
             Beat(Position, Box<ServerMessage>),
-            Landed,
+            Landed { bonus: bool },
             Escaped,
         }
         let mut results: Vec<(PlayerId, u64, After)> = Vec::with_capacity(fights.len());
@@ -803,9 +828,12 @@ impl GameState {
                             tension_pct: state.tension.round() as u32,
                             stamina_pct: (state.stamina / stamina_max(rarity) * 100.0).round()
                                 as u32,
+                            bonus_chance_pct: state.bonus_chance_pct(),
                         }),
                     ),
-                    Some(FightOutcome::Landed) => After::Landed,
+                    Some(FightOutcome::Landed) => After::Landed {
+                        bonus: self.bonus_roll(&mut rng) < state.bonus_chance(),
+                    },
                     Some(FightOutcome::Snapped | FightOutcome::ThrewHook) => After::Escaped,
                 };
                 results.push((player_id, sid, after));
@@ -814,13 +842,25 @@ impl GameState {
         for (player_id, sid, after) in results {
             match after {
                 After::Beat(bobber, msg) => self.broadcast_fishing(&bobber, *msg).await,
-                After::Landed => self.finish_fishing_caught(&player_id, sid, auth).await,
+                After::Landed { bonus } => {
+                    self.finish_fishing_caught(&player_id, sid, bonus, auth)
+                        .await
+                }
                 After::Escaped => {
                     self.end_fishing_if(&player_id, Some(sid), FishingOutcome::Escaped, ESCAPE_XP)
                         .await;
                 }
             }
         }
+    }
+
+    /// The bonus-fish roll, pinned by tests via `fishing_bonus_roll`.
+    fn bonus_roll(&self, rng: &mut impl Rng) -> f32 {
+        #[cfg(test)]
+        if let Some(forced) = *self.fishing_bonus_roll.lock().unwrap() {
+            return forced;
+        }
+        rng.gen::<f32>()
     }
 
     /// Roll species + size + trophy for a bite, from the item-def catch
@@ -892,6 +932,8 @@ impl GameState {
                     fish_state: FishState::Running,
                     state_ms_left: rolls.next_run_ms,
                     tension: TENSION_INITIAL,
+                    run_ms: 0.0,
+                    bold_run_ms: 0.0,
                     stamina: stamina_max(rarity),
                     distance: len.max(session.reel_floor_m),
                     min_distance: session.reel_floor_m,
@@ -911,6 +953,7 @@ impl GameState {
                 fish_state: FishState::Running,
                 tension_pct: TENSION_INITIAL.round() as u32,
                 stamina_pct: 100,
+                bonus_chance_pct: 0,
             },
         )
         .await;
@@ -919,11 +962,13 @@ impl GameState {
     /// The fish was reeled in exhausted: award it (bag, or ground when
     /// overweight), grant skill XP, end the session with the full catch
     /// details. `sid` guards against a session cancelled and re-cast between
-    /// the tick's scan and this call.
-    async fn finish_fishing_caught(
+    /// the tick's scan and this call. `bonus` is the bonus-chance roll's verdict;
+    /// it only ever doubles a fish — junk and coin pouches (rarity 0) never.
+    pub(super) async fn finish_fishing_caught(
         &self,
         player_id: &PlayerId,
         sid: u64,
+        bonus: bool,
         auth: Option<&crate::auth::AuthService>,
     ) {
         let Some(fish) = ({
@@ -943,6 +988,10 @@ impl GameState {
         // (`use_item`) for its copper. Junk is rarityTier 0, so the XP
         // formula below grants nothing for it naturally.
         self.award_item(player_id, &fish.item_def_id).await;
+        let bonus_fish = bonus && fish.rarity > 0;
+        if bonus_fish {
+            self.award_item(player_id, &fish.item_def_id).await;
+        }
         self.grant_fishing_catch_title(player_id, &fish.item_def_id, auth)
             .await;
         let xp = CATCH_XP_PER_RARITY_SQ * u64::from(fish.rarity) * u64::from(fish.rarity);
@@ -953,6 +1002,7 @@ impl GameState {
                 item_def_id: fish.item_def_id,
                 size_cm: fish.size_cm,
                 trophy: fish.trophy,
+                bonus_fish,
             },
             0,
         )
@@ -1043,6 +1093,7 @@ fn rarity_of(rolled: &Option<RolledFish>) -> u32 {
 mod tests {
     use super::*;
     use onlinerpg_shared::fishing::auto_stance;
+    use onlinerpg_shared::fishing::BONUS_FISH_MAX_CHANCE;
     use onlinerpg_shared::skills::SKILL_LEVEL_CAP;
 
     /// Fixed rolls make the pure fight step fully deterministic.
@@ -1058,6 +1109,8 @@ mod tests {
             fish_state: FishState::Running,
             state_ms_left: 2_000.0,
             tension: TENSION_INITIAL,
+            run_ms: 0.0,
+            bold_run_ms: 0.0,
             stamina: stamina_max(rarity),
             distance: 6.0,
             min_distance: MIN_FISH_DISTANCE_M,
@@ -1111,6 +1164,99 @@ mod tests {
             matches!(outcome, FightOutcome::Snapped | FightOutcome::ThrewHook),
             "hands-off play must never land a fish, got {outcome:?}"
         );
+    }
+
+    /// Bold time counts only while the fish runs, and only at or above the
+    /// bold line — a slack run and a resting fish add nothing.
+    #[test]
+    fn bold_share_is_the_bold_fraction_of_running_time() {
+        let mut f = fresh_fight(5);
+        assert_eq!(f.bold_share(), 0.0, "nothing before the first tick");
+        // Hold against a legend's run from 30: the first ticks are below the
+        // bold line, the last ones above it.
+        let mut ticks = 0;
+        while f.fish_state == FishState::Running {
+            step_fight(&mut f, 0.25, 5, 0, &mut || ROLLS);
+            ticks += 1;
+        }
+        // The flip tick is counted as the state it flipped into.
+        assert_eq!(f.run_ms, (ticks - 1) as f32 * 250.0);
+        assert!(
+            f.bold_run_ms > 0.0 && f.bold_run_ms < f.run_ms,
+            "bold {} of run {}",
+            f.bold_run_ms,
+            f.run_ms
+        );
+        let share = f.bold_share();
+        // Resting under any tension changes neither counter.
+        let (run, bold) = (f.run_ms, f.bold_run_ms);
+        step_fight(&mut f, 0.25, 5, 0, &mut || ROLLS);
+        assert_eq!(f.fish_state, FishState::Resting);
+        assert_eq!((f.run_ms, f.bold_run_ms), (run, bold));
+        assert_eq!(f.bold_share(), share);
+    }
+
+    /// The cautious policy sheds line the moment a run starts, so it never
+    /// builds bold time: safe play lands the fish and nothing more.
+    #[test]
+    fn the_cautious_policy_earns_no_bonus() {
+        for rarity in 1..=5 {
+            let mut f = fresh_fight(rarity);
+            let (outcome, _) = run_fight(&mut f, rarity, 0, |f| {
+                auto_stance(f.fish_state, f.tension.round() as u32)
+            });
+            assert_eq!(outcome, FightOutcome::Landed);
+            assert!(
+                f.bold_share() < 0.1,
+                "rarity {rarity}: cautious play must stay cold, got {}",
+                f.bold_share()
+            );
+        }
+    }
+
+    /// Riding the gauge just under the snap lands faster *and* earns the
+    /// bonus — risk pays twice, which is the point.
+    #[test]
+    fn a_bold_policy_lands_faster_and_earns_the_bonus() {
+        let bold = |f: &FightState| match f.fish_state {
+            FishState::Exhausted => FishingAction::Reel,
+            FishState::Running if f.tension >= 92.0 => FishingAction::GiveLine,
+            FishState::Running if f.tension < TENSION_BOLD + 4.0 => FishingAction::Reel,
+            FishState::Running => FishingAction::Hold,
+            _ => auto_stance(f.fish_state, f.tension.round() as u32),
+        };
+        let mut hot = fresh_fight(3);
+        let (outcome, hot_ticks) = run_fight(&mut hot, 3, 0, bold);
+        assert_eq!(outcome, FightOutcome::Landed);
+        assert!(
+            hot.bold_share() > 0.6,
+            "bold play must hold most of the run: {}",
+            hot.bold_share()
+        );
+        assert!(
+            hot.bonus_chance() > 0.36 * BONUS_FISH_MAX_CHANCE,
+            "and the chance follows the square of that share"
+        );
+
+        let mut safe = fresh_fight(3);
+        let (_, safe_ticks) = run_fight(&mut safe, 3, 0, |f| {
+            auto_stance(f.fish_state, f.tension.round() as u32)
+        });
+        assert!(
+            hot_ticks < safe_ticks,
+            "bold {hot_ticks} ticks must beat cautious {safe_ticks}"
+        );
+    }
+
+    /// Bold time is a fight statistic, not an outcome: a snapped line still
+    /// reports what was held, and the caller decides that a lost fish pays
+    /// nothing.
+    #[test]
+    fn a_snapped_line_keeps_its_bold_record() {
+        let mut f = fresh_fight(1);
+        let (outcome, _) = run_fight(&mut f, 1, 0, |_| FishingAction::Reel);
+        assert_eq!(outcome, FightOutcome::Snapped);
+        assert!(f.bold_share() > 0.0);
     }
 
     #[test]

--- a/server/src/game_state/mod.rs
+++ b/server/src/game_state/mod.rs
@@ -406,6 +406,9 @@ pub struct GameState {
     /// arriving at random.
     #[cfg(test)]
     ambient_spawns_enabled: Arc<std::sync::atomic::AtomicBool>,
+    /// Test-only: pins the bonus-fish roll so landing tests are deterministic.
+    #[cfg(test)]
+    fishing_bonus_roll: Arc<std::sync::Mutex<Option<f32>>>,
     housing_io: Arc<HousingIO>,
     terrain_io: Arc<onlinerpg_terrain::io::TerrainIO>,
     /// Uploaded cape textures: what a worn `cape_texture` is checked against
@@ -701,6 +704,8 @@ impl GameState {
             splat_sampler,
             #[cfg(test)]
             ambient_spawns_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            #[cfg(test)]
+            fishing_bonus_roll: Arc::new(std::sync::Mutex::new(None)),
             monster_brains: Arc::new(Mutex::new(monster_ai::ServerBrains::new())),
             server_monster_ai: Arc::new(std::sync::atomic::AtomicBool::new(
                 !cfg!(test) && crate::world_config::world_config().server_monster_ai,

--- a/server/src/game_state/tests/fishing_tests/bold_fight_tests.rs
+++ b/server/src/game_state/tests/fishing_tests/bold_fight_tests.rs
@@ -1,0 +1,289 @@
+use super::*;
+use crate::game_state::fishing::{FightState, FishingPhase};
+use onlinerpg_shared::fishing::CATCH_XP_PER_RARITY_SQ;
+
+/// Put a hooked session one tick from landing: fish exhausted, reeled to the
+/// line floor, the angler cranking. `bold_run_ms` sets the bonus chance and
+/// `roll` pins the die, so the outcome is deterministic.
+async fn hook_and_exhaust(
+    game_state: &GameState,
+    id: &PlayerId,
+    rx: &mut DirectRx,
+    species: &str,
+    bold_run_ms: f32,
+    roll: f32,
+) {
+    *game_state.fishing_bonus_roll.lock().unwrap() = Some(roll);
+    game_state.start_fishing(id, water_target()).await;
+    advance_until_bite(game_state, rx).await;
+    let mut sessions = game_state.fishing_sessions.write().await;
+    let session = sessions.get_mut(id).unwrap();
+    let rolled = session.rolled_fish.as_mut().unwrap();
+    rolled.item_def_id = species.to_string();
+    rolled.rarity = game_state
+        .item_defs
+        .get(species)
+        .unwrap()
+        .rarity_tier
+        .unwrap_or(0);
+    let floor = session.reel_floor_m;
+    session.phase = FishingPhase::Fight {
+        state: FightState {
+            stance: FishingAction::Reel,
+            fish_state: FishState::Exhausted,
+            state_ms_left: 0.0,
+            tension: 10.0,
+            run_ms: 8_000.0,
+            bold_run_ms,
+            stamina: 0.0,
+            distance: floor,
+            min_distance: floor,
+            dir_x: -1.0,
+            dir_z: 0.0,
+            elapsed_ms: 12_000.0,
+        },
+        last_tick: tokio::time::Instant::now(),
+    };
+}
+
+const ALL_BOLD_MS: f32 = 8_000.0;
+const ALL_COLD_MS: f32 = 0.0;
+/// A die that succeeds against any non-zero chance, and one that fails
+/// against anything under the cap.
+const LUCKY_ROLL: f32 = 0.0;
+const UNLUCKY_ROLL: f32 = 0.99;
+
+async fn land_with_messages(
+    game_state: &GameState,
+    rx: &mut DirectRx,
+) -> (FishingOutcome, Vec<ServerMessage>) {
+    advance(Duration::from_millis(250)).await;
+    game_state.tick_fishing(None).await;
+    let msgs = drain(rx);
+    let outcome = msgs
+        .iter()
+        .find_map(|m| match m {
+            ServerMessage::FishingEnded { outcome, .. } => Some(outcome.clone()),
+            _ => None,
+        })
+        .expect("the exhausted fish at the floor lands this tick");
+    (outcome, msgs)
+}
+
+async fn land(game_state: &GameState, rx: &mut DirectRx) -> FishingOutcome {
+    land_with_messages(game_state, rx).await.0
+}
+
+async fn bag_count(game_state: &GameState, id: &PlayerId, species: &str) -> u32 {
+    game_state
+        .get_player_inventory(id)
+        .await
+        .unwrap()
+        .bag
+        .iter()
+        .filter(|i| i.item_def_id == species)
+        .map(|i| i.quantity)
+        .sum()
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_fight_held_bold_throughout_can_land_two_fish() {
+    let game_state = make_test_game_state("fishing_bold_two");
+    let (id, mut rx) = make_angler(&game_state, "angler_bold").await;
+    hook_and_exhaust(
+        &game_state,
+        &id,
+        &mut rx,
+        "raw_trout",
+        ALL_BOLD_MS,
+        LUCKY_ROLL,
+    )
+    .await;
+
+    let outcome = land(&game_state, &mut rx).await;
+
+    assert!(
+        matches!(
+            outcome,
+            FishingOutcome::Caught {
+                bonus_fish: true,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert_eq!(bag_count(&game_state, &id, "raw_trout").await, 2);
+}
+
+/// With no bold time the chance is exactly zero, so even a lucky die pays
+/// nothing.
+#[tokio::test(start_paused = true)]
+async fn a_fight_never_held_bold_lands_one_fish() {
+    let game_state = make_test_game_state("fishing_bold_none");
+    let (id, mut rx) = make_angler(&game_state, "angler_cold").await;
+    hook_and_exhaust(
+        &game_state,
+        &id,
+        &mut rx,
+        "raw_trout",
+        ALL_COLD_MS,
+        LUCKY_ROLL,
+    )
+    .await;
+
+    let outcome = land(&game_state, &mut rx).await;
+
+    assert!(
+        matches!(
+            outcome,
+            FishingOutcome::Caught {
+                bonus_fish: false,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert_eq!(bag_count(&game_state, &id, "raw_trout").await, 1);
+}
+
+/// The bonus is a roll, not a guarantee: a perfect fight with an unlucky die
+/// lands one fish, and the beat before it advertised no more than the cap.
+#[tokio::test(start_paused = true)]
+async fn a_bold_fight_with_an_unlucky_roll_lands_one_fish() {
+    let game_state = make_test_game_state("fishing_bold_unlucky");
+    let (id, mut rx) = make_angler(&game_state, "angler_unlucky").await;
+    hook_and_exhaust(
+        &game_state,
+        &id,
+        &mut rx,
+        "raw_trout",
+        ALL_BOLD_MS,
+        UNLUCKY_ROLL,
+    )
+    .await;
+
+    let outcome = land(&game_state, &mut rx).await;
+
+    assert!(
+        matches!(
+            outcome,
+            FishingOutcome::Caught {
+                bonus_fish: false,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert_eq!(bag_count(&game_state, &id, "raw_trout").await, 1);
+}
+
+/// A second boot does not take the trailing hook: junk and coin pouches
+/// never double, and the outcome says no bonus so the client stays honest.
+#[tokio::test(start_paused = true)]
+async fn junk_never_doubles_however_bold_the_fight() {
+    let game_state = make_test_game_state("fishing_bold_junk");
+    let (id, mut rx) = make_angler(&game_state, "angler_booted").await;
+    hook_and_exhaust(
+        &game_state,
+        &id,
+        &mut rx,
+        "old_boot",
+        ALL_BOLD_MS,
+        LUCKY_ROLL,
+    )
+    .await;
+
+    let outcome = land(&game_state, &mut rx).await;
+
+    assert!(
+        matches!(
+            outcome,
+            FishingOutcome::Caught {
+                bonus_fish: false,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert_eq!(bag_count(&game_state, &id, "old_boot").await, 1);
+}
+
+/// The bonus fish is a gift, not a second catch: skill XP is granted once.
+#[tokio::test(start_paused = true)]
+async fn the_bonus_fish_grants_no_extra_xp() {
+    let game_state = make_test_game_state("fishing_bold_xp");
+    let (id, mut rx) = make_angler(&game_state, "angler_xp").await;
+    hook_and_exhaust(
+        &game_state,
+        &id,
+        &mut rx,
+        "raw_trout",
+        ALL_BOLD_MS,
+        LUCKY_ROLL,
+    )
+    .await;
+
+    let (outcome, msgs) = land_with_messages(&game_state, &mut rx).await;
+    assert!(matches!(
+        outcome,
+        FishingOutcome::Caught {
+            bonus_fish: true,
+            ..
+        }
+    ));
+
+    let xp_gains: Vec<u64> = msgs
+        .iter()
+        .filter_map(|m| match m {
+            ServerMessage::SkillXpGained { total_xp, .. } => Some(*total_xp),
+            _ => None,
+        })
+        .collect();
+    let trout_rarity: u64 = 3;
+    assert_eq!(
+        xp_gains,
+        vec![CATCH_XP_PER_RARITY_SQ * trout_rarity * trout_rarity]
+    );
+}
+
+/// Through the real tick loop, the cautious policy (line out the moment a
+/// run starts) never builds bold time: every beat reports a zero bonus chance
+/// and even a lucky die lands one fish.
+#[tokio::test(start_paused = true)]
+async fn the_cautious_policy_reports_no_bonus_chance_and_lands_one() {
+    let game_state = make_test_game_state("fishing_bold_cautious");
+    let (id, mut rx) = make_angler(&game_state, "angler_book").await;
+    *game_state.fishing_bonus_roll.lock().unwrap() = Some(LUCKY_ROLL);
+    game_state.start_fishing(&id, water_target()).await;
+    advance_until_bite(&game_state, &mut rx).await;
+    game_state
+        .fishing_sessions
+        .write()
+        .await
+        .get_mut(&id)
+        .unwrap()
+        .rolled_fish
+        .as_mut()
+        .unwrap()
+        .item_def_id = "raw_perch".to_string();
+    game_state.respond_fishing(&id, FishingAction::Hook).await;
+
+    let (outcome, msgs) =
+        flow_tests::fight_to_the_end(&game_state, &id, &mut rx, auto_stance).await;
+
+    assert!(
+        matches!(
+            outcome,
+            FishingOutcome::Caught {
+                bonus_fish: false,
+                ..
+            }
+        ),
+        "{outcome:?}"
+    );
+    assert!(msgs.iter().all(|m| !matches!(
+        m,
+        ServerMessage::FishingFight { bonus_chance_pct, .. } if *bonus_chance_pct > 0
+    )));
+    assert_eq!(bag_count(&game_state, &id, "raw_perch").await, 1);
+}

--- a/server/src/game_state/tests/fishing_tests/flow_tests.rs
+++ b/server/src/game_state/tests/fishing_tests/flow_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 /// returning the outcome (plus every message seen on the way). The
 /// policy sees each `FishingFight` beat's state and tension — exactly
 /// what a real client (human gauge or agent reflex) gets.
-async fn fight_to_the_end(
+pub(super) async fn fight_to_the_end(
     game_state: &GameState,
     id: &PlayerId,
     rx: &mut DirectRx,
@@ -276,6 +276,7 @@ async fn full_catch_flow_awards_fish_and_skill_xp() {
     let FishingOutcome::Caught {
         item_def_id: fish_id,
         size_cm,
+        bonus_fish,
         ..
     } = outcome
     else {
@@ -298,15 +299,19 @@ async fn full_catch_flow_awards_fish_and_skill_xp() {
     // the bag; only rarity ≥ 1 (fish) grants XP.
     let defs = ItemDefs::load();
     let def = defs.get(&fish_id).expect("caught def");
+    let rarity = def.rarity_tier.unwrap_or(1);
+    let expected_units = if bonus_fish { 2 } else { 1 };
     let inv = game_state.get_player_inventory(&id).await.unwrap();
-    assert!(inv
+    let units: u32 = inv
         .bag
         .iter()
-        .any(|item| item.item_def_id == fish_id && item.quantity == 1));
+        .filter(|item| item.item_def_id == fish_id)
+        .map(|item| item.quantity)
+        .sum();
+    assert_eq!(units, expected_units);
     assert!(msgs
         .iter()
         .any(|m| matches!(m, ServerMessage::InventoryUpdated { .. })));
-    let rarity = def.rarity_tier.unwrap_or(1);
     let got_xp = msgs.iter().any(|m| {
         matches!(
             m,
@@ -441,33 +446,35 @@ async fn duplicate_hook_during_the_fight_is_ignored() {
     assert!(matches!(outcome, FishingOutcome::Caught { .. }));
 }
 
-/// Neither fish nor junk stack, so every bagged catch is its own slot even
-/// when two of them are the same species — the bag reads as a catch log.
+/// Neither fish nor junk stack, so every bagged catch — bonus fish included —
+/// is its own slot even when two are the same species: the bag reads as a
+/// catch log.
 #[tokio::test(start_paused = true)]
 async fn caught_fish_take_one_bag_slot_each() {
     let game_state = make_test_game_state("fishing_stacks");
     let (id, mut rx) = make_angler(&game_state, "angler_stacker").await;
 
-    let mut bagged_catches = 0u32;
+    let mut bagged_fish = 0u32;
     for _ in 0..3 {
         game_state.start_fishing(&id, water_target()).await;
         advance_until_bite(&game_state, &mut rx).await;
         game_state.respond_fishing(&id, FishingAction::Hook).await;
         let (outcome, _) = fight_to_the_end(&game_state, &id, &mut rx, auto_stance).await;
-        let FishingOutcome::Caught { .. } = outcome else {
-            panic!("perfect play must catch");
+        let FishingOutcome::Caught { bonus_fish, .. } = outcome else {
+            panic!("perfect play must catch, got {outcome:?}");
         };
-        // Every species takes a slot — even a coin pouch arrives sealed.
-        bagged_catches += 1;
+        // Every species takes a slot — even a coin pouch arrives sealed —
+        // and a bonus fish is one more unit in the bag.
+        bagged_fish += if bonus_fish { 2 } else { 1 };
     }
     let inv = game_state.get_player_inventory(&id).await.unwrap();
     let total_fish: u32 = inv.bag.iter().map(|item| item.quantity).sum();
-    assert_eq!(total_fish, bagged_catches);
+    assert_eq!(total_fish, bagged_fish);
     // Fish and junk are both non-stackable, so this holds no matter which
     // species the rolls produced.
     assert_eq!(
         inv.bag.len() as u32,
-        bagged_catches,
+        bagged_fish,
         "each fish should occupy its own bag slot"
     );
     assert!(

--- a/server/src/game_state/tests/fishing_tests/mod.rs
+++ b/server/src/game_state/tests/fishing_tests/mod.rs
@@ -9,6 +9,7 @@ use onlinerpg_shared::fishing::{
 };
 use tokio::time::{advance, Duration};
 
+mod bold_fight_tests;
 mod economy_tests;
 mod flow_tests;
 mod interruption_tests;

--- a/server/src/terrain/routes.rs
+++ b/server/src/terrain/routes.rs
@@ -1,7 +1,7 @@
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path, Query, State},
-    http::{header, StatusCode},
+    http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
@@ -614,9 +614,10 @@ async fn serve_vegetation(
     } else {
         serve_revalidated(path, headers).await?
     };
-    response
-        .headers_mut()
-        .insert(header::CACHE_CONTROL, "public, no-cache".parse().unwrap());
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, no-cache"),
+    );
     Ok(response)
 }
 

--- a/shared/src/fishing.rs
+++ b/shared/src/fishing.rs
@@ -49,6 +49,9 @@ pub enum FishingOutcome {
         size_cm: u16,
         /// Natural 20 on the quality roll, or at/over the species' trophyCm.
         trophy: bool,
+        /// A second fish of the same kind took the trailing hook — rolled
+        /// with `bonus_fish_chance` at landing. Never junk.
+        bonus_fish: bool,
     },
     /// Hooked too early, too late, or not at all.
     Escaped,
@@ -117,6 +120,36 @@ pub const ESCAPE_XP: u64 = 2;
 pub const TENSION_MAX: f32 = 100.0;
 /// Tension the hook-set itself puts on the line — the fight opens live.
 pub const TENSION_INITIAL: f32 = 30.0;
+
+/// A running fish held at or above this tension counts as *bold* time.
+/// Sits just under the gauge's red band (85): under a human reaction delay
+/// the line can only be kept here by someone reading the fight, and a slip
+/// snaps it. Risk is rewarded twice — it tires the fish fastest *and* feeds
+/// the bonus-fish chance.
+pub const TENSION_BOLD: f32 = 80.0;
+
+/// Bonus-fish chance for a fight held bold from first run to landing. A
+/// second fish is a treat, not the supply: even perfect play doubles one
+/// catch in four.
+pub const BONUS_FISH_MAX_CHANCE: f32 = 0.25;
+
+/// Share (0–1) of the fish's running time the line was held at or above
+/// `TENSION_BOLD`.
+pub fn bold_share(bold_run_ms: f32, run_ms: f32) -> f32 {
+    if run_ms <= 0.0 {
+        return 0.0;
+    }
+    (bold_run_ms / run_ms).clamp(0.0, 1.0)
+}
+
+/// Chance (0–1) of a second fish: `bold_share² · BONUS_FISH_MAX_CHANCE`.
+/// Squared so half-hearted pressure earns almost nothing while a fight held
+/// bold throughout earns the cap; continuous so there is no threshold to
+/// camp on.
+pub fn bonus_fish_chance(bold_run_ms: f32, run_ms: f32) -> f32 {
+    let share = bold_share(bold_run_ms, run_ms);
+    share * share * BONUS_FISH_MAX_CHANCE
+}
 /// Fish pull while Running: `(BASE + PER_RARITY·rarity) · distance factor`,
 /// reduced by skill (`SKILL_PULL_RELIEF_PCT`). Deliberately hot: an
 /// unmanaged run leaves the safe range in about a second and snaps the line
@@ -304,6 +337,33 @@ mod tests {
         // exhausted fish, while a lively one panics before it gets there.
         assert!(CATCH_SLACK_M < PANIC_BAND_M);
         assert!(WATERLINE_MARGIN_M < MIN_FISH_DISTANCE_M);
+    }
+
+    #[test]
+    fn bold_share_is_the_bold_fraction_of_the_run() {
+        assert_eq!(bold_share(0.0, 0.0), 0.0, "no run, no share");
+        assert_eq!(bold_share(0.0, 4_000.0), 0.0);
+        assert_eq!(bold_share(1_000.0, 4_000.0), 0.25);
+        assert_eq!(bold_share(4_000.0, 4_000.0), 1.0);
+        assert_eq!(bold_share(5_000.0, 4_000.0), 1.0, "clamped");
+    }
+
+    // Constant on purpose: this test locks the tuning invariant.
+    #[allow(clippy::assertions_on_constants)]
+    #[test]
+    fn bonus_chance_is_squared_and_capped() {
+        assert_eq!(bonus_fish_chance(0.0, 4_000.0), 0.0);
+        assert_eq!(bonus_fish_chance(4_000.0, 4_000.0), BONUS_FISH_MAX_CHANCE);
+        // Half the run held bold earns a quarter of the cap, not half.
+        assert_eq!(
+            bonus_fish_chance(2_000.0, 4_000.0),
+            0.25 * BONUS_FISH_MAX_CHANCE
+        );
+        assert!(bonus_fish_chance(3_200.0, 4_000.0) < 0.7 * BONUS_FISH_MAX_CHANCE);
+        assert!(
+            BONUS_FISH_MAX_CHANCE <= 0.3,
+            "a bonus, not a second supply line"
+        );
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -140,7 +140,9 @@ pub const NPC_TOKEN_FILENAME: &str = "npc_token";
 /// v60: player house-scroll placement preview and authoritative placement.
 /// v61: persistent estate storage chests with atomic, weight-limited transfers.
 /// v62: estate editor tabs can request an authenticated landscaping mode.
-pub const PROTOCOL_VERSION: u32 = 62;
+/// v63: `FishingFight.bonus_chance_pct` and `FishingOutcome::Caught.bonus_fish`
+///      — tension held bold during the fight rolls a second fish.
+pub const PROTOCOL_VERSION: u32 = 63;
 
 /// Fingerprint of the dungeon layout generator this build compiled, stamped by
 /// `build.rs`. Layouts never travel the wire — both sides generate them from

--- a/shared/src/messages.rs
+++ b/shared/src/messages.rs
@@ -1196,6 +1196,9 @@ pub enum ServerMessage {
         fish_state: fishing::FishState,
         tension_pct: u32,
         stamina_pct: u32,
+        /// Live bonus-fish chance (0–100): the share of the run so far held
+        /// at `TENSION_BOLD`, so the angler sees what bold play is earning.
+        bonus_chance_pct: u32,
     },
     /// The session is over: despawn the bobber and, for the angler, show the
     /// outcome. A caught fish also arrives via the normal `InventoryUpdated`

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -104,6 +104,12 @@ pub fn fishing_cast_ms() -> u32 {
     crate::fishing::CAST_MS
 }
 
+/// Tension from which a running fish counts as held bold (bonus-fish time).
+#[wasm_bindgen]
+pub fn fishing_tension_bold() -> f32 {
+    crate::fishing::TENSION_BOLD
+}
+
 /// Live instrument batch window, so the client flushes on the server's clock.
 #[wasm_bindgen]
 pub fn instrument_batch_ms() -> u32 {

--- a/terrain/src/height.rs
+++ b/terrain/src/height.rs
@@ -140,6 +140,9 @@ fn restore_heightmap_tile(
     changed
 }
 
+// The tile load between the check and the insert is awaited, so an `Entry`
+// cannot span it.
+#[allow(clippy::map_entry)]
 pub async fn flatten_heightmap_rects(
     terrain: &TerrainIO,
     rects: &[HeightRect],
@@ -187,6 +190,9 @@ pub async fn flatten_heightmap_rects(
         .collect())
 }
 
+// The tile load between the check and the insert is awaited, so an `Entry`
+// cannot span it.
+#[allow(clippy::map_entry)]
 pub async fn restore_heightmap_rects(
     terrain: &TerrainIO,
     rects: &[HeightRect],


### PR DESCRIPTION
## 목적

낚시 파이트에 재미 요소를 하나 더합니다. 물고기가 달리는 동안 텐션을 한계 근처(80 이상)에 오래 머물게 할수록 물고기 한 마리를 더 얻을 확률이 올라갑니다. 안전하게 하면 예전과 똑같이 한 마리, 게이지를 읽으며 대담하게 버티면 더 빨리 잡고 두 마리 확률까지 붙습니다.

## 변경

**서버 (`shared`, `server`)**
- 파이트 동안 물고기가 Running인 시간(`run_ms`)과 그중 텐션이 `TENSION_BOLD`(80) 이상이었던 시간(`bold_run_ms`)을 250ms 틱마다 누적합니다.
- 물고기를 잡는 순간 `bold_share = bold_run_ms / run_ms`, 확률 `= bold_share² × BONUS_FISH_MAX_CHANCE(25%)`로 굴려 같은 종 한 마리를 추가로 줍니다. 잡동사니·동전 주머니(rarity 0)는 두 배가 되지 않고, 보너스 물고기는 XP를 주지 않습니다.
- 프로토콜 v63: `FishingFight.bonus_chance_pct`(실시간 확률), `FishingOutcome::Caught.bonus_fish`.

| 달린 시간 중 80 이상 비율 | 확률 |
|---|---|
| 25% | 1.6% |
| 50% | 6.3% |
| 75% | 14.1% |
| 100% | 25% |

바늘이 걸리면 텐션 30에서 시작하고 쉴 때마다 내려가서 80까지 다시 올리는 시간은 셀 수 없으므로, 사람이 아주 잘해도 비율 70~85%, 확률 12~18%가 현실적 상한입니다. 결정적 시뮬레이션에서 최적 정책은 0.71(12.7%)이 나왔습니다. 25%는 이론상 상한입니다.
